### PR TITLE
PTI-81-2: Add .toArray() call to mongodb aggregate cursor result.

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.ts
@@ -71,21 +71,26 @@ export class ImportComponent implements OnInit {
     });
 
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
-      if (res) {
-        this.tableData.items = res.records[0].data.searchResults;
-
-        if (res.records[0].data.meta.length > 0) {
-          this.tableData.totalListItems = res.records[0].data.meta[0].searchResultsTotal;
-        }
-
-        this.tableData.columns = this.tableColumns;
-        this.loading = false;
-        this._changeDetectionRef.detectChanges();
-      } else {
+      if (!res) {
         alert("Uh-oh, couldn't load valued components");
-        // project not found --> navigate back to search
-        this.router.navigate(['/search']);
+        // project not found --> navigate back to home
+        this.router.navigate(['/']);
+        return;
       }
+
+      this.tableData.items = res.records && res.records[0] && res.records[0].data && res.records[0].data.searchResults;
+
+      this.tableData.totalListItems =
+        res.records &&
+        res.records[0] &&
+        res.records[0].data &&
+        res.records[0].data.meta &&
+        res.records[0].data.meta[0] &&
+        res.records[0].data.meta[0].searchResultsTotal;
+
+      this.tableData.columns = this.tableColumns;
+      this.loading = false;
+      this._changeDetectionRef.detectChanges();
     });
   }
 

--- a/angular/projects/admin-nrpti/src/app/records/records-list/records-list.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/records-list/records-list.component.ts
@@ -89,17 +89,22 @@ export class RecordsListComponent implements OnInit, OnDestroy {
     });
 
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
-      if (!res || !res.records) {
+      if (!res) {
         alert("Uh-oh, couldn't load NRPTI records");
         // project not found --> navigate back to home
         this.router.navigate(['/']);
         return;
       }
 
-      this.tableData.items = res.records[0] && res.records[0].data && res.records[0].data.searchResults;
-      if (res.records[0] && res.records[0].data && res.records[0].data.meta && res.records[0].data.meta.length) {
-        this.tableData.totalListItems = res.records[0].data.meta[0].searchResultsTotal;
-      }
+      this.tableData.items = res.records && res.records[0] && res.records[0].data && res.records[0].data.searchResults;
+
+      this.tableData.totalListItems =
+        res.records &&
+        res.records[0] &&
+        res.records[0].data &&
+        res.records[0].data.meta &&
+        res.records[0].data.meta[0] &&
+        res.records[0].data.meta[0].searchResultsTotal;
 
       this.tableData.columns = this.tableColumns;
       this.loading = false;

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -325,7 +325,7 @@ var searchCollection = async function (roles, keywords, schemaName, pageNum, pag
         defaultLog.info("err:", err);
         resolve([]);
       } else {
-        resolve(data);
+        resolve(data.toArray());
       }
     })
   });


### PR DESCRIPTION
Add more error handling to list pages for when results are empty.

Was checking out the new mongo stuff, but noticed we were getting a circular json stringify error.  Investigated and it looks like the mongo aggregate by default returns the entire cursor.  But slapping on .toArray() gives just the results.