### PR TITLE
PTI-4-2: Update epic import to create initial default flavour records.

### DIFF
--- a/api/src/integrations/epic/epic-datasource.js
+++ b/api/src/integrations/epic/epic-datasource.js
@@ -105,9 +105,19 @@ class EpicDataSource {
         // Persist NRPTI record
         const savedRecord = await this.typeUtils.saveRecord(nrptiRecord);
 
-        if (savedRecord) {
-          this.status.itemsProcessed++;
+        if (!savedRecord) {
+          defaultLog.error('processRecords - failed to save record.');
+          continue;
         }
+
+        const saveFlavourRecords = await this.typeUtils.createFlavourRecords(savedRecord);
+
+        if (!saveFlavourRecords) {
+          defaultLog.error('processRecords - failed to save flavour records.');
+          continue;
+        }
+
+        this.status.itemsProcessed++;
       } catch (error) {
         defaultLog.error(`processRecords - record failed: ${error.message}`);
         defaultLog.debug(`processRecords - record failed - error.stack: ${error.stack}`);

--- a/api/src/integrations/integration-schema-enum.js
+++ b/api/src/integrations/integration-schema-enum.js
@@ -1,0 +1,11 @@
+/**
+ * Enum for supported integration schemas.
+ *
+ * @enum {string}
+ */
+const INTEGRATION_SCHEMA = Object.freeze({
+  order: { nrptiSchema: 'Order', flavourSchemas: ['OrderNRCED', 'OrderLNG'] },
+  inspection: { nrptiSchema: 'Inspection', flavourSchemas: ['InspectionNRCED', 'InspectionLNG'] }
+});
+
+module.exports = INTEGRATION_SCHEMA;


### PR DESCRIPTION
Added a new call to the epic import that creates all of the the flavour records for that master record, if they dont already exist.