### PR TITLE
PTI-329: update epic import, fix unit tests, add/fix lint commands.

### DIFF
--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,9 +1,10 @@
 node_modules
 
 dist
+coverage
+
 migrations
 migrations_data
-openshift
 
 openshift
 sonar-runner

--- a/api/.prettierignore
+++ b/api/.prettierignore
@@ -1,6 +1,10 @@
 node_modules
 
 dist
+coverage
+
+migrations
+migrations_data
 
 openshift
 sonar-runner

--- a/api/package.json
+++ b/api/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "start": "node app",
     "test": "node_modules/.bin/jest --verbose",
-    "lint": "eslint . --no-fix --ignore-pattern 'node_modules' --ext .js",
-    "lint-fix:1": "eslint --fix --ignore-pattern 'node_modules' --ext .js",
-    "lint-fix:2": "prettier ./**/*.js --write --loglevel warn",
-    "lint-fix": "npm-run-all -l -s -c lint-fix:*"
+    "lint": "npm-run-all -l -s -c lint:*",
+    "lint:1": "eslint . --ignore-pattern 'node_modules' --ext .js",
+    "lint:2": "prettier --check ./**/*.js ",
+    "lint-fix": "npm-run-all -l -s -c lint-fix:*",
+    "lint-fix:1": "eslint . -fix --ignore-pattern 'node_modules' --ext .js",
+    "lint-fix:2": "prettier ./**/*.js --write --loglevel warn"
   },
   "engines": {
     "node": ">= 10.0.0",

--- a/api/src/integrations/epic/epic-datasource.test.js
+++ b/api/src/integrations/epic/epic-datasource.test.js
@@ -1,397 +1,442 @@
-// const EpicDataSource = require('./epic-datasource');
-// const EpicOrders = require('./epic-orders');
-// const EpicInspections = require('./epic-inspections');
-// const EPIC_TYPE = require('./epic-type-enum');
+const EpicDataSource = require('./epic-datasource');
+const EpicOrders = require('./epic-orders');
+const EpicInspections = require('./epic-inspections');
+const EPIC_TYPE = require('./epic-type-enum');
 
 describe('EpicDataSource', () => {
-  it('Is True', () => {
-    expect(true).toEqual(true);
+  describe('constructor', () => {
+    it('throws error if recordType not provided', () => {
+      expect(() => new EpicDataSource()).toThrow(new Error('EpicDataSource - missing required recordType parameter'));
+    });
+
+    it('throws error if recordType is not in the EPIC_TYPE enum', () => {
+      expect(() => new EpicDataSource('notAValidType')).toThrow(
+        new Error('EpicDataSource - recordType parameter is not supported')
+      );
+    });
+
+    it('sets type', () => {
+      const epicDataSource = new EpicDataSource('order');
+      expect(epicDataSource.type).toEqual(EPIC_TYPE.order);
+    });
+
+    it('sets params', () => {
+      const epicDataSource = new EpicDataSource('order', { params: 1 });
+      expect(epicDataSource.params).toEqual({ params: 1 });
+    });
+
+    it('sets default params if not provided', () => {
+      const epicDataSource = new EpicDataSource('order');
+      expect(epicDataSource.params).toEqual({});
+    });
+
+    it('sets default status fields', () => {
+      const epicDataSource = new EpicDataSource('order');
+      expect(epicDataSource.status).toEqual({ itemsProcessed: 0, itemTotal: 0 });
+    });
+  });
+
+  describe('updateRecords', () => {
+    it('catches any thrown exceptions and returns gracefully', async () => {
+      // mock utils called by updateRecords()
+      const mockResponse = [{ searchResults: [], meta: 'meta!' }];
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return Promise.resolve(mockResponse);
+      });
+
+      const epicDataSource = new EpicDataSource('order', { param1: 1 });
+
+      // mock EpicDataSource functions called by updateRecords()
+      epicDataSource.getRecordTypeId = jest.fn(() => {
+        throw Error('unexpected error!');
+      });
+      epicDataSource.getBaseParams = jest.fn();
+      epicDataSource.getIntegrationUrl = jest.fn();
+      epicDataSource.getHostname = jest.fn();
+      epicDataSource.getPathname = jest.fn();
+      epicDataSource.processRecords = jest.fn();
+
+      const status = await epicDataSource.updateRecords();
+
+      expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
+      expect(epicDataSource.getBaseParams).not.toHaveBeenCalled();
+      expect(epicDataSource.getIntegrationUrl).not.toHaveBeenCalled();
+      expect(epicDataSource.processRecords).not.toHaveBeenCalled();
+
+      expect(status).toEqual({
+        message: 'unexpected error',
+        error: JSON.stringify(new Error('unexpected error!')),
+        itemsProcessed: 0,
+        itemTotal: 0
+      });
+    });
+
+    it('returns early if no epic records are found', async () => {
+      // mock utils called by updateRecords()
+      const mockResponse = [{ searchResults: [], meta: 'meta!' }];
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return Promise.resolve(mockResponse);
+      });
+
+      const epicDataSource = new EpicDataSource('order', { param1: 1 });
+
+      // mock EpicDataSource functions called by updateRecords()
+      epicDataSource.getRecordTypeId = jest.fn(() => {
+        return Promise.resolve('321');
+      });
+      epicDataSource.getBaseParams = jest.fn(() => {
+        return { baseparams: 1 };
+      });
+      epicDataSource.getIntegrationUrl = jest.fn(() => {
+        return 'url';
+      });
+      epicDataSource.getHostname = jest.fn(() => {
+        return 'hostname';
+      });
+      epicDataSource.getEpicSearchPathname = jest.fn(() => {
+        return 'searchPathname';
+      });
+      epicDataSource.getEpicProjectPathname = jest.fn(() => {
+        return 'projectPathname';
+      });
+      epicDataSource.processRecords = jest.fn();
+
+      const status = await epicDataSource.updateRecords();
+
+      expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
+      expect(epicDataSource.getBaseParams).toHaveBeenCalledWith(
+        '321',
+        '5cf00c03a266b7e1877504ef', // TODO don't hardcode milestone
+        Number.MAX_SAFE_INTEGER,
+        0
+      );
+      expect(epicDataSource.getIntegrationUrl).toHaveBeenCalledWith('hostname', 'searchPathname', {
+        param1: 1,
+        baseparams: 1
+      });
+
+      expect(epicDataSource.processRecords).not.toHaveBeenCalled();
+
+      expect(status).toEqual({
+        message: 'no records found',
+        itemsProcessed: 0,
+        itemTotal: 0,
+        dataSource: 'url'
+      });
+    });
+
+    it('calls all functions necessary to update epic records for the given type', async () => {
+      // mock utils called by updateRecords()
+      const mockResponse = [
+        {
+          searchResults: [{ _id: '123' }, { _id: '456' }, { _id: '789' }],
+          meta: 'meta!'
+        }
+      ];
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return Promise.resolve(mockResponse);
+      });
+
+      const epicDataSource = new EpicDataSource('order', { param1: 1 });
+
+      // mock EpicDataSource functions called by updateRecords()
+      epicDataSource.getRecordTypeId = jest.fn(() => {
+        return Promise.resolve('321');
+      });
+      epicDataSource.getBaseParams = jest.fn(() => {
+        return { baseparams: 1 };
+      });
+      epicDataSource.getIntegrationUrl = jest.fn(() => {
+        return 'url';
+      });
+      epicDataSource.getHostname = jest.fn(() => {
+        return 'hostname';
+      });
+      epicDataSource.getEpicSearchPathname = jest.fn(() => {
+        return 'searchPathname';
+      });
+      epicDataSource.processRecords = jest.fn();
+
+      const status = await epicDataSource.updateRecords();
+
+      expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
+      expect(epicDataSource.getBaseParams).toHaveBeenCalledWith(
+        '321',
+        '5cf00c03a266b7e1877504ef', // TODO don't hardcode milestone
+        Number.MAX_SAFE_INTEGER,
+        0
+      );
+
+      expect(epicDataSource.getIntegrationUrl).toHaveBeenCalledWith('hostname', 'searchPathname', {
+        param1: 1,
+        baseparams: 1
+      });
+
+      expect(status).toEqual({ itemsProcessed: 0, itemTotal: 3, dataSource: 'url', epicMeta: 'meta!' });
+    });
+  });
+
+  describe('processRecords', () => {
+    it('transforms, saves, and updates the status for each epic record', async () => {
+      // mock epic inspection utils
+      const mockEpicInspections = {
+        transformRecord: jest.fn(record => {
+          return { ...record, transformed: true };
+        }),
+        saveRecord: jest.fn(record => {
+          return 'saved!';
+        })
+      };
+
+      const epicDataSource = new EpicDataSource('inspection');
+
+      epicDataSource.getRecordProject = jest.fn(record => {
+        return { name: record._id };
+      });
+
+      // return our mock utils instead of the real ones.
+      epicDataSource.getRecordTypeUtils = () => {
+        return mockEpicInspections;
+      };
+
+      const epicRecords = [{ _id: '123' }, { _id: '456' }];
+
+      await epicDataSource.processRecords(epicRecords);
+
+      expect(epicDataSource.getRecordProject).toHaveBeenNthCalledWith(1, { _id: '123' });
+      expect(epicDataSource.getRecordProject).toHaveBeenNthCalledWith(2, { _id: '456' });
+
+      expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(1, {
+        _id: '123',
+        project: { name: '123' }
+      });
+      expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(2, {
+        _id: '456',
+        project: { name: '456' }
+      });
+
+      expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(1, {
+        _id: '123',
+        project: { name: '123' },
+        transformed: true
+      });
+      expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(2, {
+        _id: '456',
+        project: { name: '456' },
+        transformed: true
+      });
+
+      // itemTotal is 0 here because it is set elsewhere in the class
+      expect(epicDataSource.status).toEqual({ itemTotal: 0, itemsProcessed: 2 });
+    });
+
+    it('continues processing records even if one record fails and throws an exception', async () => {
+      // mock epic inspection utils
+      const mockEpicInspections = {
+        transformRecord: jest.fn(record => {
+          // force an error if _id is '123'
+          if (record._id === '123') {
+            throw Error('an unexpected error!');
+          }
+
+          return { ...record, transformed: true };
+        }),
+        saveRecord: jest.fn(() => 'saved!')
+      };
+
+      const epicDataSource = new EpicDataSource('inspection');
+
+      epicDataSource.getRecordProject = jest.fn(record => {
+        return { name: record._id };
+      });
+
+      // return our mock utils instead of the real ones.
+      epicDataSource.getRecordTypeUtils = () => {
+        return mockEpicInspections;
+      };
+
+      const epicRecords = [{ _id: '123' }, { _id: '456' }];
+
+      await epicDataSource.processRecords(epicRecords);
+
+      expect(epicDataSource.getRecordProject).toHaveBeenNthCalledWith(1, { _id: '123' });
+      expect(epicDataSource.getRecordProject).toHaveBeenNthCalledWith(2, { _id: '456' });
+
+      expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(1, { _id: '123', project: { name: '123' } });
+      expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(2, { _id: '456', project: { name: '456' } });
+
+      // saveRecord is not called on _id=123 because it threw an error during the transformRecord call
+      expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(1, {
+        _id: '456',
+        project: { name: '456' },
+        transformed: true
+      });
+
+      // itemTotal is 0 here because it is set elsewhere in the class
+      expect(epicDataSource.status).toEqual({ itemTotal: 0, itemsProcessed: 1 });
+    });
+  });
+
+  describe('getHostname', () => {
+    it('returns hostname for epic urls', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const pathName = epicDataSource.getHostname();
+      expect(pathName).toEqual(process.env.EPIC_API_HOSTNAME || 'eagle-prod.pathfinder.gov.bc.ca');
+    });
+  });
+
+  describe('getEpicSearchPathname', () => {
+    it('returns epic search pathname', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const pathName = epicDataSource.getEpicSearchPathname();
+      expect(pathName).toEqual(process.env.EPIC_API_SEARCH_PATHNAME || '/api/public/search');
+    });
+  });
+
+  describe('getEpicProjectPathname', () => {
+    it('returns epic project pathname', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const pathName = epicDataSource.getEpicProjectPathname('123456');
+      expect(pathName).toEqual(`${process.env.EPIC_API_PROJECT_PATHNAME || '/api/project'}/123456`);
+    });
+  });
+
+  describe('getBaseParams', () => {
+    it('returns base params', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const baseParams = epicDataSource.getBaseParams('123', '456', 22, 7);
+      expect(baseParams).toEqual({
+        dataset: 'Document',
+        populate: false,
+        pageSize: 22,
+        pageNum: 7,
+        and: { type: '123', milestone: '456' }
+      });
+    });
+  });
+
+  describe('getIntegrationUrl', () => {
+    it('builds and returns an https url', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const url = epicDataSource.getIntegrationUrl('www.google.com', '/some/path/to/stuff', {
+        param1: 1,
+        param2: 'hello'
+      });
+      expect(url).toEqual(new URL('/some/path/to/stuff?param1=1&param2=hello', 'https://www.google.com'));
+    });
+  });
+
+  describe('getRecordTypeUtils', () => {
+    it('throws an error if the type utils cannot be found', () => {
+      const epicDataSource = new EpicDataSource('order');
+      epicDataSource.type = 'notAValidType';
+      expect(() => epicDataSource.getRecordTypeUtils()).toThrow(
+        new Error(`getTypeUtil - failed to find utils for type: ${epicDataSource.type}`)
+      );
+    });
+
+    it('returns typeUtils for type order', () => {
+      const epicDataSource = new EpicDataSource('order');
+      const typeUtils = epicDataSource.getRecordTypeUtils();
+      expect(typeUtils).toBeInstanceOf(EpicOrders);
+    });
+
+    it('returns typeUtils for type inspection', () => {
+      const epicDataSource = new EpicDataSource('inspection');
+      const typeUtils = epicDataSource.getRecordTypeUtils();
+      expect(typeUtils).toBeInstanceOf(EpicInspections);
+    });
+  });
+
+  describe('getRecordTypeId', () => {
+    it('throws an error if the response array is null', async () => {
+      // create mock response
+      const mockResponse = null;
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
+        new Error('getTypeUtil - failed to fetch List dataset.')
+      );
+    });
+
+    it('throws an error if the response array is empty', async () => {
+      // create mock response
+      const mockResponse = [];
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
+        new Error('getTypeUtil - failed to fetch List dataset.')
+      );
+    });
+
+    it('throws an error if the response array element does not contain searchResults', async () => {
+      // create mock response
+      const mockResponse = [{}];
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
+        new Error('getTypeUtil - failed to fetch List dataset.')
+      );
+    });
+
+    it('throws an error if the response does not contain a doctype element', async () => {
+      // create mock response
+      const mockResponse = [{ searchResults: [{ type: 'notDocType', name: EPIC_TYPE.inspection.epicType }] }];
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
+        new Error(`getTypeUtil - failed to find type _id for epic type: ${EPIC_TYPE.inspection.epicType}`)
+      );
+    });
+
+    it('throws an error if the response does not contain a doctype element with matching epic type', async () => {
+      // create mock response
+      const mockResponse = [{ searchResults: [{ type: 'doctype', name: 'notInspectionType' }] }];
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
+        new Error(`getTypeUtil - failed to find type _id for epic type: ${EPIC_TYPE.inspection.epicType}`)
+      );
+    });
+
+    it('returns the _id of the doctype element with matching epic type', async () => {
+      // create mock response
+      const mockResponse = [{ searchResults: [{ type: 'doctype', name: EPIC_TYPE.inspection.epicType, _id: '123' }] }];
+
+      // spy on integration-utils to return mock response
+      jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
+        return mockResponse;
+      });
+
+      const epicDataSource = new EpicDataSource('inspection');
+      const id = await epicDataSource.getRecordTypeId();
+
+      expect(id).toEqual('123');
+    });
   });
 });
-
-// describe('EpicDataSource', () => {
-//   describe('constructor', () => {
-//     it('throws error if recordType not provided', () => {
-//       expect(() => new EpicDataSource()).toThrow(new Error('EpicDataSource - missing required recordType parameter'));
-//     });
-
-//     it('throws error if recordType is not in the EPIC_TYPE enum', () => {
-//       expect(() => new EpicDataSource('notAValidType')).toThrow(
-//         new Error('EpicDataSource - recordType parameter is not supported')
-//       );
-//     });
-
-//     it('sets type', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       expect(epicDataSource.type).toEqual(EPIC_TYPE.order);
-//     });
-
-//     it('sets params', () => {
-//       const epicDataSource = new EpicDataSource('order', { params: 1 });
-//       expect(epicDataSource.params).toEqual({ params: 1 });
-//     });
-
-//     it('sets default params if not provided', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       expect(epicDataSource.params).toEqual({});
-//     });
-
-//     it('sets default status fields', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       expect(epicDataSource.status).toEqual({ itemsProcessed: 0, itemTotal: 0 });
-//     });
-//   });
-
-//   describe('updateRecords', () => {
-//     it('catches any thrown exceptions and returns gracefully', async () => {
-//       // mock utils called by updateRecords()
-//       const mockResponse = [{ searchResults: [], meta: 'meta!' }];
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return Promise.resolve(mockResponse);
-//       });
-
-//       const epicDataSource = new EpicDataSource('order', { param1: 1 });
-
-//       // mock EpicDataSource functions called by updateRecords()
-//       epicDataSource.getRecordTypeId = jest.fn(() => {
-//         throw Error('unexpected error!');
-//       });
-//       epicDataSource.getBaseParams = jest.fn();
-//       epicDataSource.getIntegrationUrl = jest.fn();
-//       epicDataSource.getHostname = jest.fn();
-//       epicDataSource.getPathname = jest.fn();
-//       epicDataSource.processRecords = jest.fn();
-
-//       const status = await epicDataSource.updateRecords();
-
-//       expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
-//       expect(epicDataSource.getBaseParams).not.toHaveBeenCalled();
-//       expect(epicDataSource.getIntegrationUrl).not.toHaveBeenCalled();
-//       expect(epicDataSource.processRecords).not.toHaveBeenCalled();
-
-//       expect(status).toEqual({
-//         message: 'unexpected error',
-//         error: JSON.stringify(new Error('unexpected error!')),
-//         itemsProcessed: 0,
-//         itemTotal: 0
-//       });
-//     });
-
-//     it('returns early if no epic records are found', async () => {
-//       // mock utils called by updateRecords()
-//       const mockResponse = [{ searchResults: [], meta: 'meta!' }];
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return Promise.resolve(mockResponse);
-//       });
-
-//       const epicDataSource = new EpicDataSource('order', { param1: 1 });
-
-//       // mock EpicDataSource functions called by updateRecords()
-//       epicDataSource.getRecordTypeId = jest.fn(() => {
-//         return Promise.resolve('321');
-//       });
-//       epicDataSource.getBaseParams = jest.fn(() => {
-//         return { baseparams: 1 };
-//       });
-//       epicDataSource.getIntegrationUrl = jest.fn(() => {
-//         return 'url';
-//       });
-//       epicDataSource.getHostname = jest.fn(() => {
-//         return 'hostname';
-//       });
-//       epicDataSource.getPathname = jest.fn(() => {
-//         return 'pathname';
-//       });
-//       epicDataSource.processRecords = jest.fn();
-
-//       const status = await epicDataSource.updateRecords();
-
-//       expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
-//       expect(epicDataSource.getBaseParams).toHaveBeenCalledWith(
-//         '321',
-//         '5cf00c03a266b7e1877504ef', // TODO don't hardcode milestone
-//         Number.MAX_SAFE_INTEGER,
-//         0
-//       );
-//       expect(epicDataSource.getIntegrationUrl).toHaveBeenCalledWith('hostname', 'pathname', {
-//         param1: 1,
-//         baseparams: 1
-//       });
-
-//       expect(epicDataSource.processRecords).not.toHaveBeenCalled();
-
-//       expect(status).toEqual({
-//         message: 'no records found',
-//         itemsProcessed: 0,
-//         itemTotal: 0,
-//         dataSource: 'url'
-//       });
-//     });
-
-//     it('calls all functions necessary to update epic records for the given type', async () => {
-//       // mock utils called by updateRecords()
-//       const mockResponse = [{ searchResults: [{ _id: '123' }, { _id: '456' }, { _id: '789' }], meta: 'meta!' }];
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return Promise.resolve(mockResponse);
-//       });
-
-//       const epicDataSource = new EpicDataSource('order', { param1: 1 });
-
-//       // mock EpicDataSource functions called by updateRecords()
-//       epicDataSource.getRecordTypeId = jest.fn(() => {
-//         return Promise.resolve('321');
-//       });
-//       epicDataSource.getBaseParams = jest.fn(() => {
-//         return { baseparams: 1 };
-//       });
-//       epicDataSource.getIntegrationUrl = jest.fn(() => {
-//         return 'url';
-//       });
-//       epicDataSource.getHostname = jest.fn(() => {
-//         return 'hostname';
-//       });
-//       epicDataSource.getPathname = jest.fn(() => {
-//         return 'pathname';
-//       });
-//       epicDataSource.processRecords = jest.fn();
-
-//       const status = await epicDataSource.updateRecords();
-
-//       expect(epicDataSource.getRecordTypeId).toHaveBeenCalledTimes(1);
-//       expect(epicDataSource.getBaseParams).toHaveBeenCalledWith(
-//         '321',
-//         '5cf00c03a266b7e1877504ef', // TODO don't hardcode milestone
-//         Number.MAX_SAFE_INTEGER,
-//         0
-//       );
-//       expect(epicDataSource.getIntegrationUrl).toHaveBeenCalledWith('hostname', 'pathname', {
-//         param1: 1,
-//         baseparams: 1
-//       });
-
-//       expect(status).toEqual({ itemsProcessed: 0, itemTotal: 3, dataSource: 'url', epicMeta: 'meta!' });
-//     });
-//   });
-
-//   describe('processRecords', () => {
-//     it('transforms, saves, and updates the status for each epic record', () => {
-//       // mock epic inspection utils
-//       const mockEpicInspections = {
-//         transformRecord: jest.fn(record => {
-//           return { ...record, transformed: true };
-//         }),
-//         saveRecord: jest.fn()
-//       };
-
-//       const epicDataSource = new EpicDataSource('inspection');
-
-//       // return our mock utils instead of the real ones.
-//       epicDataSource.getRecordTypeUtils = () => {
-//         return mockEpicInspections;
-//       };
-
-//       const epicRecords = [{ _id: '123' }, { _id: '456' }];
-
-//       epicDataSource.processRecords(epicRecords);
-
-//       expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(1, { _id: '123' });
-//       expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(2, { _id: '456' });
-
-//       expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(1, { _id: '123', transformed: true });
-//       expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(2, { _id: '456', transformed: true });
-
-//       // itemTotal is 0 here because it is set elsewhere in the class
-//       expect(epicDataSource.status).toEqual({ itemTotal: 0, itemsProcessed: 2 });
-//     });
-
-//     it('continues processing records even if one record fails and throws an exception', () => {
-//       // mock epic inspection utils
-//       const mockEpicInspections = {
-//         transformRecord: jest.fn(record => {
-//           // force an error if _id is '123'
-//           if (record._id === '123') {
-//             throw Error('an unexpected error!');
-//           }
-
-//           return { ...record, transformed: true };
-//         }),
-//         saveRecord: jest.fn()
-//       };
-
-//       const epicDataSource = new EpicDataSource('inspection');
-
-//       // return our mock utils instead of the real ones.
-//       epicDataSource.getRecordTypeUtils = () => {
-//         return mockEpicInspections;
-//       };
-
-//       const epicRecords = [{ _id: '123' }, { _id: '456' }];
-
-//       epicDataSource.processRecords(epicRecords);
-
-//       expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(1, { _id: '123' });
-//       expect(mockEpicInspections.transformRecord).toHaveBeenNthCalledWith(2, { _id: '456' });
-
-//       // saveRecord is not called on _id=123 because it threw an error during the transformRecord call
-//       expect(mockEpicInspections.saveRecord).toHaveBeenNthCalledWith(1, { _id: '456', transformed: true });
-
-//       // itemTotal is 0 here because it is set elsewhere in the class
-//       expect(epicDataSource.status).toEqual({ itemTotal: 0, itemsProcessed: 1 });
-//     });
-//   });
-
-//   describe('getHostname', () => {
-//     it('returns hostname for epic urls', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       const pathName = epicDataSource.getHostname();
-//       expect(pathName).toEqual(process.env.EPIC_API_HOSTNAME || 'eagle-prod.pathfinder.gov.bc.ca');
-//     });
-//   });
-
-//   describe('getPathname', () => {
-//     it('returns pathname for epic urls', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       const pathName = epicDataSource.getPathname();
-//       expect(pathName).toEqual(process.env.EPIC_API_INSPECTIONS_PATHNAME || '/api/public/search');
-//     });
-//   });
-
-//   describe('getBaseParams', () => {
-//     it('returns base params', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       const baseParams = epicDataSource.getBaseParams('123', '456', 22, 7);
-//       expect(baseParams).toEqual({
-//         dataset: 'Document',
-//         populate: false,
-//         pageSize: 22,
-//         pageNum: 7,
-//         and: { type: '123', milestone: '456' }
-//       });
-//     });
-//   });
-
-//   describe('getIntegrationUrl', () => {
-//     it('builds and returns an https url', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       const url = epicDataSource.getIntegrationUrl('www.google.com', '/some/path/to/stuff', {
-//         param1: 1,
-//         param2: 'hello'
-//       });
-//       expect(url).toEqual(new URL('/some/path/to/stuff', 'https://www.google.com?param1=1&param2=hello'));
-//     });
-//   });
-
-//   describe('getRecordTypeUtils', () => {
-//     it('throws an error if the type utils cannot be found', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       epicDataSource.type = 'notAValidType';
-//       expect(() => epicDataSource.getRecordTypeUtils()).toThrow(
-//         new Error(`getTypeUtil - failed to find utils for type: ${epicDataSource.type}`)
-//       );
-//     });
-
-//     it('returns typeUtils for type order', () => {
-//       const epicDataSource = new EpicDataSource('order');
-//       const typeUtils = epicDataSource.getRecordTypeUtils();
-//       expect(typeUtils).toBeInstanceOf(EpicOrders);
-//     });
-
-//     it('returns typeUtils for type inspection', () => {
-//       const epicDataSource = new EpicDataSource('inspection');
-//       const typeUtils = epicDataSource.getRecordTypeUtils();
-//       expect(typeUtils).toBeInstanceOf(EpicInspections);
-//     });
-//   });
-
-//   describe('getRecordTypeId', () => {
-//     it('throws an error if the response array is null', async () => {
-//       // create mock response
-//       const mockResponse = null;
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
-//         new Error('getTypeUtil - failed to fetch List dataset.')
-//       );
-//     });
-
-//     it('throws an error if the response array is empty', async () => {
-//       // create mock response
-//       const mockResponse = [];
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
-//         new Error(`getTypeUtil - failed to find List record for type: ${EPIC_TYPE.inspection.nrptiType}`)
-//       );
-//     });
-
-//     it('throws an error if the response array element does not contain searchResults', async () => {
-//       // create mock response
-//       const mockResponse = [{}];
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
-//         new Error(`getTypeUtil - failed to find List record for type: ${EPIC_TYPE.inspection.nrptiType}`)
-//       );
-//     });
-
-//     it('throws an error if the response does not contain a doctype element', async () => {
-//       // create mock response
-//       const mockResponse = [{ searchResults: [{ type: 'notDocType', name: EPIC_TYPE.inspection.epicType }] }];
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
-//         new Error(`getTypeUtil - failed to find type _id for epic type: ${EPIC_TYPE.inspection.epicType}`)
-//       );
-//     });
-
-//     it('throws an error if the response does not contain a doctype element with matching epic type', async () => {
-//       // create mock response
-//       const mockResponse = [{ searchResults: [{ type: 'doctype', name: 'notInspectionType' }] }];
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       await expect(epicDataSource.getRecordTypeId()).rejects.toThrow(
-//         new Error(`getTypeUtil - failed to find type _id for epic type: ${EPIC_TYPE.inspection.epicType}`)
-//       );
-//     });
-
-//     it('returns the _id of the doctype element with matching epic type', async () => {
-//       // create mock response
-//       const mockResponse = [{ searchResults: [{ type: 'doctype', name: EPIC_TYPE.inspection.epicType, _id: '123' }] }];
-
-//       // spy on integration-utils to return mock response
-//       jest.spyOn(require('../integration-utils'), 'getRecords').mockImplementation(() => {
-//         return mockResponse;
-//       });
-
-//       const epicDataSource = new EpicDataSource('inspection');
-//       const id = await epicDataSource.getRecordTypeId();
-
-//       expect(id).toEqual('123');
-//     });
-//   });
-// });

--- a/api/src/integrations/epic/epic-orders.test.js
+++ b/api/src/integrations/epic/epic-orders.test.js
@@ -1,142 +1,149 @@
-// const EpicOrders = require('./epic-orders');
+const EpicOrders = require('./epic-orders');
 
 describe('EpicOrders', () => {
-  it('Is True', () => {
-    expect(true).toEqual(true);
+  describe('transformRecord', () => {
+    it('throws error if no epicRecord provided', async () => {
+      const epicOrders = new EpicOrders();
+
+      try {
+        await epicOrders.transformRecord();
+      } catch (error) {
+        expect(error).toEqual(new Error('transformRecord - required record must be non-null.'));
+      }
+    });
+
+    it('returns a default nrpti record when empty epicRecord provided', async () => {
+      const epicOrders = new EpicOrders();
+
+      const epicRecord = {};
+
+      const actualRecord = await epicOrders.transformRecord(epicRecord);
+
+      const expectedRecord = {
+        _schemaName: 'Order',
+
+        _epicProjectId: '',
+        _sourceRefId: '',
+        _epicMilestoneId: '',
+
+        read: ['sysadmin'],
+        write: ['sysadmin'],
+
+        recordName: '',
+        recordType: '',
+        dateIssued: null,
+        issuingAgency: 'Environmental Assessment Agency',
+        author: '',
+        legislation: '',
+        projectName: '',
+        location: '',
+        centroid: '',
+
+        dateAdded: expect.any(Date),
+        dateUpdated: expect.any(Date),
+        updatedBy: '',
+        sourceDateAdded: null,
+        sourceDateUpdated: null,
+        sourceSystemRef: 'epic'
+      };
+
+      expect(actualRecord).toMatchObject(expectedRecord);
+    });
+
+    it('returns a nrpti record with all supported epicRecord fields populated', async () => {
+      const epicOrders = new EpicOrders();
+
+      const epicRecord = {
+        _id: 123,
+        displayName: 'docDisplay',
+        documentType: 'docType',
+        documentFileName: 'docFileName',
+        project: {
+          name: 'projectName',
+          legislation: 'projectLegislation'
+        },
+        milestone: 'milestone'
+      };
+
+      const actualRecord = await epicOrders.transformRecord(epicRecord);
+
+      const expectedRecord = {
+        _schemaName: 'Order',
+
+        _epicProjectId: '',
+        _sourceRefId: 123,
+        _epicMilestoneId: 'milestone',
+
+        read: ['sysadmin'],
+        write: ['sysadmin'],
+
+        recordName: 'docDisplay',
+        recordType: 'docType',
+        dateIssued: null,
+        issuingAgency: 'Environmental Assessment Agency',
+        author: '',
+        legislation: 'projectLegislation',
+        projectName: 'projectName',
+        location: '',
+        centroid: '',
+
+        dateAdded: expect.any(Date),
+        dateUpdated: expect.any(Date),
+        updatedBy: '',
+        sourceDateAdded: null,
+        sourceDateUpdated: null,
+        sourceSystemRef: 'epic'
+      };
+
+      expect(actualRecord).toMatchObject(expectedRecord);
+    });
+  });
+
+  describe('saveRecord', () => {
+    it('throws error if no order record provided', async () => {
+      const epicOrders = new EpicOrders();
+      await expect(epicOrders.saveRecord()).rejects.toThrow(
+        new Error('saveRecord - required record must be non-null.')
+      );
+    });
+
+    it('catches any errors thrown when creating/saving the order record', async () => {
+      // create mock save function
+      const mockFindOneAndUpdate = jest.fn(() => {
+        throw Error('this should not be thrown');
+      });
+
+      // mock mongoose to call mock save function
+      const mongoose = require('mongoose');
+      mongoose.model = jest.fn(() => {
+        return { findOneAndUpdate: mockFindOneAndUpdate };
+      });
+
+      const epicOrders = new EpicOrders();
+
+      const orderRecord = { _id: '321' };
+
+      await expect(epicOrders.saveRecord(orderRecord)).resolves.not.toThrow();
+    });
+
+    it('creates and saves a new order record', async () => {
+      // create mock save function
+      const mockFindOneAndUpdate = jest.fn(() => Promise.resolve('saved!'));
+
+      // mock mongoose to call mock save function
+      const mongoose = require('mongoose');
+      mongoose.model = jest.fn(() => {
+        return { findOneAndUpdate: mockFindOneAndUpdate };
+      });
+
+      const epicOrders = new EpicOrders();
+
+      const orderRecord = { _id: '123' };
+
+      const dbStatus = await epicOrders.saveRecord(orderRecord);
+
+      expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+      expect(dbStatus).toEqual('saved!');
+    });
   });
 });
-
-// describe('EpicOrders', () => {
-//   describe('transformRecord', () => {
-//     it('throws error if no epicRecord provided', () => {
-//       const epicOrders = new EpicOrders();
-//       expect(() => epicOrders.transformRecord()).toThrow(
-//         new Error('transformRecord - required record must be non-null.')
-//       );
-//     });
-
-//     it('returns a default nrpti record when empty epicRecord provided', () => {
-//       const epicOrders = new EpicOrders();
-
-//       const epicRecord = {};
-
-//       const actualRecord = epicOrders.transformRecord(epicRecord);
-
-//       const expectedRecord = {
-//         _schemaName: 'Order',
-
-//         read: ['sysadmin'],
-//         write: ['sysadmin'],
-
-//         recordName: '',
-//         issuingAgency: '',
-//         author: '',
-//         type: ' - ',
-//         description: '',
-//         sourceSystemRef: 'epic',
-//         project: '',
-
-//         documentId: '',
-//         documentType: '',
-//         documentFileName: '',
-//         documentDate: null,
-
-//         dateUpdated: expect.any(Date),
-
-//         sourceDateAdded: null,
-//         sourceDateUpdated: null
-//       };
-
-//       expect(actualRecord).toMatchObject(expectedRecord);
-//     });
-
-//     it('returns a nrpti record with all supported epicRecord fields populated', () => {
-//       const epicOrders = new EpicOrders();
-
-//       const epicRecord = {
-//         _id: 123,
-//         displayName: 'docDisplay',
-//         documentType: 'docType',
-//         documentFileName: 'docFileName',
-//         milestone: 'milestone'
-//       };
-
-//       const actualRecord = epicOrders.transformRecord(epicRecord);
-
-//       const expectedRecord = {
-//         _schemaName: 'Order',
-
-//         read: ['sysadmin'],
-//         write: ['sysadmin'],
-
-//         recordName: 'docDisplay',
-//         issuingAgency: '',
-//         author: '',
-//         type: 'docType - milestone',
-//         description: '',
-//         sourceSystemRef: 'epic',
-//         project: '',
-
-//         documentId: 123,
-//         documentType: 'docType',
-//         documentFileName: 'docFileName',
-//         documentDate: null,
-
-//         dateUpdated: expect.any(Date),
-
-//         sourceDateAdded: null,
-//         sourceDateUpdated: null
-//       };
-
-//       expect(actualRecord).toMatchObject(expectedRecord);
-//     });
-//   });
-
-//   describe('saveRecord', () => {
-//     it('throws error if no order record provided', async () => {
-//       const epicOrders = new EpicOrders();
-//       await expect(epicOrders.saveRecord()).rejects.toThrow(
-//         new Error('saveRecord - required record must be non-null.')
-//       );
-//     });
-
-//     it('catches any errors thrown when creating/saving the order record', async () => {
-//       // create mock save function
-//       const mockFindOneAndUpdate = jest.fn(() => {
-//         throw Error('this should not be thrown');
-//       });
-
-//       // mock mongoose to call mock save function
-//       const mongoose = require('mongoose');
-//       mongoose.model = jest.fn(() => {
-//         return { findOneAndUpdate: mockFindOneAndUpdate };
-//       });
-
-//       const epicOrders = new EpicOrders();
-
-//       const orderRecord = { _id: '321' };
-
-//       await expect(epicOrders.saveRecord(orderRecord)).resolves.not.toThrow();
-//     });
-
-//     it('creates and saves a new order record', async () => {
-//       // create mock save function
-//       const mockFindOneAndUpdate = jest.fn(() => Promise.resolve('saved!'));
-
-//       // mock mongoose to call mock save function
-//       const mongoose = require('mongoose');
-//       mongoose.model = jest.fn(() => {
-//         return { findOneAndUpdate: mockFindOneAndUpdate };
-//       });
-
-//       const epicOrders = new EpicOrders();
-
-//       const orderRecord = { _id: '123' };
-
-//       const dbStatus = await epicOrders.saveRecord(orderRecord);
-
-//       expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
-//       expect(dbStatus).toEqual('saved!');
-//     });
-//   });
-// });

--- a/api/src/integrations/integration-utils.test.js
+++ b/api/src/integrations/integration-utils.test.js
@@ -1,55 +1,49 @@
-// const integrationUtils = require('./integration-utils');
+const integrationUtils = require('./integration-utils');
 
 describe('IntegrationUtils', () => {
-  it('Is True', () => {
-    expect(true).toEqual(true);
+  describe('getRecords', () => {
+    it('throws error if an unexpected error occurs', async () => {
+      const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
+        throw Error('unexpected error!');
+      });
+
+      await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
+        new Error(`getRecords - error: unexpected error!.`)
+      );
+      expect(mockAxios).toHaveBeenCalledWith('url');
+    });
+
+    it('throws error if the response is null', async () => {
+      const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
+        return null;
+      });
+
+      await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
+        new Error(`getRecords - returned null response.`)
+      );
+      expect(mockAxios).toHaveBeenCalledWith('url');
+    });
+
+    it('throws error if the response status is not 200', async () => {
+      const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
+        return { status: 999 };
+      });
+
+      await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
+        new Error(`getRecords - returned non-200 status: 999.`)
+      );
+      expect(mockAxios).toHaveBeenCalledWith('url');
+    });
+
+    it('returns response.data', async () => {
+      const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
+        return { status: 200, data: [{ value: 1 }] };
+      });
+
+      const data = await integrationUtils.getRecords({ href: 'url' });
+
+      expect(data).toEqual([{ value: 1 }]);
+      expect(mockAxios).toHaveBeenCalledWith('url');
+    });
   });
 });
-
-// describe('IntegrationUtils', () => {
-//   describe('getRecords', () => {
-//     it('throws error if an unexpected error occurs', async () => {
-//       const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
-//         throw Error('unexpected error!');
-//       });
-
-//       await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
-//         new Error(`getRecords - error: unexpected error!.`)
-//       );
-//       expect(mockAxios).toHaveBeenCalledWith('url');
-//     });
-
-//     it('throws error if the response is null', async () => {
-//       const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
-//         return null;
-//       });
-
-//       await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
-//         new Error(`getRecords - returned null response.`)
-//       );
-//       expect(mockAxios).toHaveBeenCalledWith('url');
-//     });
-
-//     it('throws error if the response status is not 200', async () => {
-//       const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
-//         return { status: 999 };
-//       });
-
-//       await expect(integrationUtils.getRecords({ href: 'url' })).rejects.toThrow(
-//         new Error(`getRecords - returned non-200 status: 999.`)
-//       );
-//       expect(mockAxios).toHaveBeenCalledWith('url');
-//     });
-
-//     it('returns response.data', async () => {
-//       const mockAxios = jest.spyOn(require('axios'), 'get').mockImplementation(() => {
-//         return { status: 200, data: [{ value: 1 }] };
-//       });
-
-//       const data = await integrationUtils.getRecords({ href: 'url' });
-
-//       expect(data).toEqual([{ value: 1 }]);
-//       expect(mockAxios).toHaveBeenCalledWith('url');
-//     });
-//   });
-// });


### PR DESCRIPTION
- All api unit tests passing.
- Updated epic import to move the project fetching into epic-datasource (out of the type specific utils).
  - Partially because I think it fits better there, and partially because it makes the testing easier.
- Added better lint commands to package.json:
  - It now has both non-fix and fix versions, with updated config.
- Added the migrations, and other similar folders, to the lint ignore.