### PR TITLE
PTI-258-2: Update admin details to leverage new getItem populate.

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
@@ -26,11 +26,14 @@ export class InspectionDetailComponent extends RecordComponent implements OnInit
         return;
       }
 
-      const records = res.records[0] && res.records[0].data && res.records[0].data.searchResults;
+      const record = res.records[0] && res.records[0].data;
 
       this.data = {
-        _master: records && records[0] && new Inspection(records[0]._master),
-        flavourData: records.map(record => RecordUtils.getRecordModelInstance(record)) || []
+        _master: new Inspection(record),
+        flavourData:
+          (record.flavours &&
+            record.flavours.map(flavourRecord => RecordUtils.getRecordModelInstance(flavourRecord))) ||
+          []
       };
 
       this.changeDetectionRef.detectChanges();

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-resolver.ts
@@ -10,18 +10,6 @@ export class InspectionResolver implements Resolve<Observable<SearchResults[]>> 
 
   resolve(route: ActivatedRouteSnapshot): Observable<SearchResults[]> {
     const inspectionId = route.paramMap.get('inspectionId');
-    return this.factoryService.getRecords(
-      null,
-      ['InspectionNRCED', 'InspectionLNG'],
-      null,
-      null,
-      null,
-      null,
-      {
-        _master: inspectionId
-      },
-      null,
-      null
-    );
+    return this.factoryService.getRecordWithFlavours(inspectionId, 'Inspection');
   }
 }

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
@@ -26,11 +26,14 @@ export class OrderDetailComponent extends RecordComponent implements OnInit, OnD
         return;
       }
 
-      const records = res.records[0] && res.records[0].data && res.records[0].data.searchResults;
+      const record = res.records[0] && res.records[0].data;
 
       this.data = {
-        _master: records && records[0] && new Order(records[0]._master),
-        flavourData: records.map(record => RecordUtils.getRecordModelInstance(record)) || []
+        _master: new Order(record),
+        flavourData:
+          (record.flavours &&
+            record.flavours.map(flavourRecord => RecordUtils.getRecordModelInstance(flavourRecord))) ||
+          []
       };
 
       this.changeDetectionRef.detectChanges();

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-resolver.ts
@@ -10,18 +10,6 @@ export class OrderResolver implements Resolve<Observable<SearchResults[]>> {
 
   resolve(route: ActivatedRouteSnapshot): Observable<SearchResults[]> {
     const orderId = route.paramMap.get('orderId');
-    return this.factoryService.getRecords(
-      null,
-      ['OrderNRCED', 'OrderLNG'],
-      null,
-      null,
-      null,
-      null,
-      {
-        _master: orderId
-      },
-      null,
-      null
-    );
+    return this.factoryService.getRecordWithFlavours(orderId, 'Order');
   }
 }

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -77,22 +77,16 @@ definitions:
   SearchSortByFields:
     type: string
     description: 'Optional fields to sort by (prefixed with + or - for order)'
-    example: +score,-score
+    example: +dateAdded,-startDate
     enum: &searchSortByFields
+      - -dateAdded
+      - +dateAdded
       - +startDate
       - -startDate
-      - +headline
-      - -headline
-      - +score
-      - -score
       - +displayName
       - -displayName
-      - +datePosted
-      - -datePosted
       - +documentType
       - -documentType
-      - +documentFileSize
-      - -documentFileSize
 
   ### Task Definitions
   TaskObject:


### PR DESCRIPTION
Update to leverage the addition of populate, added here: https://github.com/bcgov/NRPTI/pull/109

I also updated the swagger search order enum. I removed some values that aren't used anywhere, and added the one being used in the admin records-list page.

But, the list page seemed to be sorting just fine before I changed it, so I'm not sure what the swagger is actually enforcing.