### PR TITLE
PTI-344: Setting EPIC datePosted to map to NRPTI dateIssued

### DIFF
--- a/api/src/integrations/epic/epic-inspections.js
+++ b/api/src/integrations/epic/epic-inspections.js
@@ -53,7 +53,7 @@ class EpicInspections {
       recordName: epicRecord.displayName || '',
       recordType: 'Inspection',
       // recordSubtype: // No mapping
-      dateIssued: epicRecord.documentDate || null,
+      dateIssued: epicRecord.datePosted || null,
       issuingAgency: 'Environmental Assessment Office',
       author: epicRecord.documentAuthor || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',

--- a/api/src/integrations/epic/epic-orders.js
+++ b/api/src/integrations/epic/epic-orders.js
@@ -53,7 +53,7 @@ class EpicOrders {
       recordName: epicRecord.displayName || '',
       recordType: 'Order',
       // recordSubtype: // No mapping
-      dateIssued: epicRecord.documentDate || null,
+      dateIssued: epicRecord.datePosted || null,
       issuingAgency: 'Environmental Assessment Office',
       author: epicRecord.documentAuthor || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',


### PR DESCRIPTION
Had a meeting with EAO to figure this out. Turns out documentDate is a legacy field from middle EPIC. Their migration script was supposed to convert all documentDates over to datePosted. It seems to have failed and there is currently a ticket submitted for them to fix this issue. DatePosted is supposed to be the field we use to map to our dateIssued. However, EAO is unsure if even datePosted is correct for this mapping. Also, there are several issues with their datePosted field. Some new records such as their new Site C documents will have a datePosted of 1900. Also, some records will simply not have the datePosted field for whatever reason.

As of 2020-01-27, our importer will use datePosted as dateIssued. However, for some records, this field will remain blank or may be wrong. This will only be resolved after, EAO fixes their record data. As for us, we will need to just manually correct the data from our side.