### PR TITLE
PTI-357: Add Orders import.

### DIFF
--- a/api/src/integrations/epic/epic-datasource.test.js
+++ b/api/src/integrations/epic/epic-datasource.test.js
@@ -23,6 +23,29 @@ describe('EpicDataSource', () => {
     });
   });
 
+  describe('updateRecords', () => {
+    it('catches any thrown exceptions and returns gracefully', async () => {
+      // mock function to throw an error
+      const mock_updateRecords = jest.fn(() => {
+        throw Error('unexpected error!');
+      });
+
+      const epicDataSource = new EpicDataSource();
+
+      epicDataSource._updateRecords = mock_updateRecords;
+
+      const status = await epicDataSource.updateRecords();
+
+      expect(status).toEqual({
+        message: 'updateRecords - unexpected error',
+        error: 'unexpected error!',
+        itemsProcessed: 0,
+        itemTotal: 0,
+        typeStatus: []
+      });
+    });
+  });
+
   describe('_updateRecords', () => {
     it('catches any thrown exceptions and returns gracefully', async () => {
       // mock function to throw an error
@@ -34,9 +57,9 @@ describe('EpicDataSource', () => {
 
       epicDataSource.updateRecordType = mockUpdateRecordType;
 
-      const status = await epicDataSource.updateRecords();
+      await epicDataSource._updateRecords([{}]);
 
-      expect(status).toEqual({
+      expect(epicDataSource.status).toEqual({
         message: '_updateRecords - unexpected error',
         error: 'unexpected error!',
         itemsProcessed: 0,

--- a/api/src/integrations/epic/epic-orders-other.js
+++ b/api/src/integrations/epic/epic-orders-other.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const defaultLog = require('../../utils/logger')('epic-orders');
+const RECORD_TYPE = require('../../utils/constants/record-type-enum');
+const { preTransformRecord } = require('./epic-utils');
+
+/**
+ * Epic Order record handler for { type: 'Order', milestone: 'Other' }.
+ *
+ * Must contain the following functions:
+ * - transformRecord: (object) => Order
+ * - saveRecord: (Order) => any
+ *
+ * @class EpicOrdersOther
+ */
+class EpicOrdersOther {
+  /**
+   * Creates an instance of EpicOrdersOther.
+   *
+   * @param {*} auth_payload user information for auditing
+   * @memberof EpicOrdersOther
+   */
+  constructor(auth_payload) {
+    this.auth_payload = auth_payload;
+  }
+
+  /**
+   * Transform an Epic order record into a NRPTI Order record.
+   *
+   * @param {object} epicRecord Epic order record (required)
+   * @returns {Order} NRPTI order record.
+   * @throws {Error} if record is not provided.
+   * @memberof EpicOrdersOther
+   */
+  async transformRecord(epicRecord) {
+    if (!epicRecord) {
+      throw Error('transformRecord - required record must be non-null.');
+    }
+
+    // Apply common Epic pre-processing/transformations
+    epicRecord = preTransformRecord(epicRecord);
+
+    return {
+      _schemaName: RECORD_TYPE.Order._schemaName,
+      _epicProjectId: (epicRecord.project && epicRecord.project._id) || '',
+      _sourceRefId: epicRecord._id || '',
+      _epicMilestoneId: epicRecord.milestone || '',
+
+      read: ['sysadmin'],
+      write: ['sysadmin'],
+
+      recordName: epicRecord.displayName || '',
+      recordType: RECORD_TYPE.Order.displayName,
+      dateIssued: epicRecord.documentDate || null,
+      issuingAgency: 'Environmental Assessment Office',
+      author: epicRecord.documentAuthor || '',
+      legislation: (epicRecord.project && epicRecord.project.legislation) || '',
+      projectName: (epicRecord.project && epicRecord.project.name) || '',
+      location: (epicRecord.project && epicRecord.project.location) || '',
+      centroid: (epicRecord.project && epicRecord.project.centroid) || '',
+
+      dateAdded: new Date(),
+      dateUpdated: new Date(),
+      updatedBy: (this.auth_payload && this.auth_payload.displayName) || '',
+      sourceDateAdded: epicRecord.dateAdded || epicRecord._createdDate || null,
+      sourceDateUpdated: epicRecord.dateUpdated || epicRecord._updatedDate || null,
+      sourceSystemRef: 'epic'
+    };
+  }
+
+  /**
+   * Persist a NRPTI Order record to the database.
+   *
+   * @async
+   * @param {Order} orderRecord NRPTI Order record (required)
+   * @returns {string} status of the add/update operations.
+   * @memberof EpicOrdersOther
+   */
+  async saveRecord(orderRecord) {
+    if (!orderRecord) {
+      throw Error('saveRecord - required record must be non-null.');
+    }
+
+    try {
+      const Order = mongoose.model(RECORD_TYPE.Order._schemaName);
+
+      const record = await Order.findOneAndUpdate(
+        { _schemaName: RECORD_TYPE.Order._schemaName, _sourceRefId: orderRecord._sourceRefId },
+        { $set: orderRecord },
+        { upsert: true, new: true }
+      );
+
+      return record;
+    } catch (error) {
+      defaultLog.error(`Failed to save Epic Order record: ${error.message}`);
+      defaultLog.debug(`Failed to save Epic Order record - error.stack: ${error.stack}`);
+    }
+  }
+}
+
+module.exports = EpicOrdersOther;

--- a/api/src/integrations/epic/epic-record-type-enum.js
+++ b/api/src/integrations/epic/epic-record-type-enum.js
@@ -2,32 +2,44 @@
  * Supported EPIC record types.
  */
 const EPIC_RECORD_TYPE = Object.freeze({
-  Order: {
-    // type and milestone from legislation 2002
-    type: { name: 'Order', typeId: '5cf00c03a266b7e1877504d1' },
-    milestone: { name: 'Compliance & Enforcement', milestoneId: '5cf00c03a266b7e1877504ef' },
-    getUtil: (...args) => {
-      return new (require('./epic-orders'))(...args);
+  Order: [
+    {
+      // type and milestone from legislation 2002
+      type: { name: 'Order', typeId: '5cf00c03a266b7e1877504d1' },
+      milestone: { name: 'Compliance & Enforcement', milestoneId: '5cf00c03a266b7e1877504ef' },
+      getUtil: (...args) => {
+        return new (require('./epic-orders'))(...args);
+      }
+    },
+    {
+      // type and milestone from legislation 2002
+      type: { name: 'Order', typeId: '5cf00c03a266b7e1877504d1' },
+      milestone: { name: 'Other', milestoneId: '5d0d212c7d50161b92a80eed' },
+      getUtil: (...args) => {
+        return new (require('./epic-orders-other'))(...args);
+      }
     }
-  },
-  Inspection: {
-    // type and milestone from legislation 2002
-    type: { name: 'Inspection Record', typeId: '5cf00c03a266b7e1877504d9' },
-    milestone: { name: 'Compliance & Enforcement', milestoneId: '5cf00c03a266b7e1877504ef' },
-    getUtil: (...args) => {
-      return new (require('./epic-inspections'))(...args);
+  ],
+  Inspection: [
+    {
+      // type and milestone from legislation 2002
+      type: { name: 'Inspection Record', typeId: '5cf00c03a266b7e1877504d9' },
+      milestone: { name: 'Compliance & Enforcement', milestoneId: '5cf00c03a266b7e1877504ef' },
+      getUtil: (...args) => {
+        return new (require('./epic-inspections'))(...args);
+      }
     }
-  },
+  ],
 
   /**
    * Get a subset of all supported EPIC record types.
    *
    * @param {*} recordTypes  EPIC record types to return.
-   * @returns array of a subset of EPIC record types.
+   * @returns flattened array of a subset of EPIC record types.
    */
   getSome: function(recordTypes) {
-    if (!recordTypes || !recordTypes.length) {
-      return null;
+    if (!recordTypes || recordTypes.length) {
+      return [];
     }
 
     const types = [];
@@ -36,7 +48,7 @@ const EPIC_RECORD_TYPE = Object.freeze({
       const epicRecordType = this[type];
 
       if (epicRecordType) {
-        types.push(epicRecordType);
+        types.push(...epicRecordType);
       }
     });
 
@@ -46,10 +58,10 @@ const EPIC_RECORD_TYPE = Object.freeze({
   /**
    * Get all supported EPIC record types.
    *
-   * @returns array of all EPIC record types.
+   * @returns flattened array of all EPIC record types.
    */
   getAll: function() {
-    return [this.Order, this.Inspection];
+    return [...this.Order, ...this.Inspection];
   }
 });
 


### PR DESCRIPTION
Expands the import to also fetch [type: order, milestone: other], which is persisted as [_schemaName: Order].
 - _original order import was [type: order, milestone: compliance & enforcement]_