### PR TITLE
PTI-232: Enabled ability to link to imported EPIC docs

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -162,7 +162,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     // _epicMilestoneId
     // legislation
     // projectName
-    // documentURL
+    // attachments
 
     // TODO: For editing we should create an object with only the changed fields.
     const inspection = new Inspection({

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -89,7 +89,22 @@
         </div>
         <div class="grid-section-5">
           <div class="grid-item">
-            <span class="grid-item-value">{{ (data && data._master.attachments) || '-' }}</span>
+            <span *ngIf="
+            data &&
+            data._master.attachments &&
+            data._master.attachments.length > 0 &&
+            data._master.sourceSystemRef === 'epic'
+            ">
+              <span *ngFor="let attachment of data && data._master.attachments">
+                <a href="{{attachment.url}}" target=" _blank">{{attachment.fileName}}</a>
+              </span>
+            </span>
+            <span *ngIf="
+            !(data &&
+            data._master.attachments &&
+            data._master.attachments.length > 0 &&
+            data._master.sourceSystemRef === 'epic')
+              " class="grid-item-value">This record does not have attachemnts</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
@@ -34,7 +34,7 @@ export class InspectionDetailComponent extends RecordComponent implements OnInit
           (record.flavours &&
             record.flavours.map(flavourRecord => RecordUtils.getRecordModelInstance(flavourRecord))) ||
           []
-      };
+      }; 
 
       this.changeDetectionRef.detectChanges();
     });

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -165,7 +165,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     // _epicMilestoneId
     // legislation
     // projectName
-    // documentURL
+    // attachments
 
     // TODO: For editing we should create an object with only the changed fields.
     const order = new Order({

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -93,7 +93,22 @@
         </div>
         <div class="grid-section-5">
           <div class="grid-item">
-            <span class="grid-item-value">{{ (data && data._master.attachments) || '-' }}</span>
+            <span *ngIf="
+            data &&
+            data._master.attachments &&
+            data._master.attachments.length > 0 &&
+            data._master.sourceSystemRef === 'epic'
+            ">
+              <span *ngFor="let attachment of data && data._master.attachments">
+                <a href="{{attachment.url}}" target=" _blank">{{attachment.fileName}}</a>
+              </span>
+            </span>
+            <span *ngIf="
+            !(data &&
+            data._master.attachments &&
+            data._master.attachments.length > 0 &&
+            data._master.sourceSystemRef === 'epic')
+            " class="grid-item-value">This record does not have attachemnts</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
@@ -35,7 +35,6 @@ export class OrderDetailComponent extends RecordComponent implements OnInit, OnD
             record.flavours.map(flavourRecord => RecordUtils.getRecordModelInstance(flavourRecord))) ||
           []
       };
-
       this.changeDetectionRef.detectChanges();
     });
   }

--- a/angular/projects/common/src/app/models/master/inspection.ts
+++ b/angular/projects/common/src/app/models/master/inspection.ts
@@ -29,6 +29,7 @@ export class Inspection {
   sourceDateAdded: Date;
   sourceDateUpdated: Date;
   sourceSystemRef: string;
+  attachments: object[];
 
   InspectionNRCED: object;
   InspectionLNG: object;
@@ -53,6 +54,7 @@ export class Inspection {
     this.centroid = (obj && obj.centroid) || null;
     this.outcomeStatus = (obj && obj.outcomeStatus) || null;
     this.outcomeDescription = (obj && obj.outcomeDescription) || null;
+    this.attachments = (obj && obj.attachments) || null;
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;

--- a/angular/projects/common/src/app/models/master/order.ts
+++ b/angular/projects/common/src/app/models/master/order.ts
@@ -25,8 +25,9 @@ export class Order {
   centroid: number[];
   outcomeStatus: string; // epic value?
   outcomeDescription: string; // out of scope?
-  dateAdded: Date;
   dateUpdated: Date;
+  dateAdded: Date;
+  attachments: object[];
   sourceDateAdded: Date;
   sourceDateUpdated: Date;
   sourceSystemRef: string;
@@ -56,6 +57,7 @@ export class Order {
     this.centroid = (obj && obj.centroid) || null;
     this.outcomeStatus = (obj && obj.outcomeStatus) || null;
     this.outcomeDescription = (obj && obj.outcomeDescription) || null;
+    this.attachments = (obj && obj.attachments) || null;
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;

--- a/api/migrations/20200109220142-projectData.js
+++ b/api/migrations/20200109220142-projectData.js
@@ -162,7 +162,7 @@ let createAgreementRecord = async function (item, project, nrptiCollection) {
     // Prefer to store dates in the DB as ISO, not some random format.
     date: moment(item.date, 'DD-MM-YYYY').toDate(),
     nationName: item.nation,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
     dateAdded: new Date(),
@@ -211,7 +211,7 @@ let createPlanRecord = async function (item, project, nrptiCollection) {
     recordType: item.type || item.complianceDocumentType,
     recordPhase: item.phase || item.complianceDocumentSubtype,
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
     dateAdded: new Date(),
@@ -261,7 +261,7 @@ let createWarningLetterRecord = async function (item, project, nrptiCollection) 
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: moment(item.date, 'DD-MM-YYYY').toDate(),
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     author: item.author,
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
@@ -308,7 +308,7 @@ let createReportRecord = async function (item, project, nrptiCollection) {
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: moment(item.date, 'DD-MM-YYYY').toDate(),
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     author: item.author,
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
@@ -356,7 +356,7 @@ let createAuthorizationRecord = async function (item, project, nrptiCollection) 
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: moment(item.date, 'DD-MM-YYYY').toDate(),
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
     dateAdded: new Date(),
@@ -402,7 +402,7 @@ let createOrderRecord = async function (item, project, nrptiCollection) {
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: moment(item.date, 'DD-MM-YYYY').toDate(),
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     author: item.author,
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 
@@ -449,7 +449,7 @@ let createInspectionRecord = async function (item, project, nrptiCollection) {
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: moment(item.date, 'DD-MM-YYYY').toDate(),
     issuingAgency: item.agency,
-    documentURL: item.url,
+    attachments: [{ url: item.url }],
     author: item.author,
     projectName: project === '588511c4aaecd9001b825604' ? 'LNG Canada' : 'Coastal Gaslink',
 

--- a/api/src/integrations/epic/epic-inspections.js
+++ b/api/src/integrations/epic/epic-inspections.js
@@ -2,6 +2,7 @@
 
 const mongoose = require('mongoose');
 const defaultLog = require('../../utils/logger')('epic-inspections');
+const QueryUtils = require('../../utils/query-utils');
 
 /**
  * Epic Inspection record handler.
@@ -41,6 +42,17 @@ class EpicInspections {
       }
     }
 
+    // Generate a link that will get us the document when placed in an href.
+    var attachments = [];
+    if (epicRecord._id && epicRecord.documentFileName) {
+      attachments.push(
+        {
+          url: `https://projects.eao.gov.bc.ca/api/document/${epicRecord._id}/fetch/${encodeURIComponent(epicRecord.documentFileName)}`,
+          fileName: epicRecord.documentFileName
+        }
+      );
+    }
+
     return {
       _schemaName: 'Inspection',
       _epicProjectId: (epicRecord.project && epicRecord.project._id) || '',
@@ -63,6 +75,7 @@ class EpicInspections {
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
       // outcomeStatus: // No mapping
       // outcomeDescription: // No mapping
+      attachments: attachments,
 
       dateAdded: new Date(),
       dateUpdated: new Date(),

--- a/api/src/integrations/epic/epic-orders.js
+++ b/api/src/integrations/epic/epic-orders.js
@@ -41,6 +41,17 @@ class EpicOrders {
       }
     }
 
+    // Generate a link that will get us the document when placed in an href.
+    var attachments = [];
+    if (epicRecord._id && epicRecord.documentFileName) {
+      attachments.push(
+        {
+          url: `https://projects.eao.gov.bc.ca/api/document/${epicRecord._id}/fetch/${encodeURIComponent(epicRecord.documentFileName)}`,
+          fileName: epicRecord.documentFileName
+        }
+      );
+    }
+
     return {
       _schemaName: 'Order',
       _epicProjectId: (epicRecord.project && epicRecord.project._id) || '',
@@ -63,6 +74,7 @@ class EpicOrders {
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
       // outcomeStatus: // No mapping
       // outcomeDescription: // No mapping
+      attachments: attachments,
 
       dateAdded: new Date(),
       dateUpdated: new Date(),

--- a/api/src/models/master/agreement.js
+++ b/api/src/models/master/agreement.js
@@ -14,7 +14,7 @@ module.exports = require('../../utils/model-schema-generator')(
     recordName: { type: String, default: '' },
     date: { type: Date, default: Date.now() },
     nationName: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/authorization.js
+++ b/api/src/models/master/authorization.js
@@ -13,7 +13,7 @@ module.exports = require('../../utils/model-schema-generator')(
     recordSubType: { type: String, default: '' },
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/inspection.js
+++ b/api/src/models/master/inspection.js
@@ -23,7 +23,7 @@ module.exports = require('../../utils/model-schema-generator')(
     centroid: [{ type: Number, default: 0.0 }],
     outcomeStatus: { type: String, default: '' },
     outcomeDescription: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/order.js
+++ b/api/src/models/master/order.js
@@ -24,7 +24,7 @@ module.exports = require('../../utils/model-schema-generator')(
     centroid: [{ type: Number, default: 0.0 }],
     outcomeStatus: { type: String, default: '' },
     outcomeDescription: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: null },

--- a/api/src/models/master/plan.js
+++ b/api/src/models/master/plan.js
@@ -16,7 +16,7 @@ module.exports = require('../../utils/model-schema-generator')(
     recordPhase: { type: String, default: '' },
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/selfReport.js
+++ b/api/src/models/master/selfReport.js
@@ -16,7 +16,7 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/warningLetter.js
+++ b/api/src/models/master/warningLetter.js
@@ -16,7 +16,7 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    documentURL: { type: String, default: null },
+    attachments: [{ type: Object, default: null }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/utils/query-utils.js
+++ b/api/src/utils/query-utils.js
@@ -5,8 +5,9 @@
  */
 
 let mongoose = require('mongoose');
-
 let DEFAULT_PAGESIZE = 100;
+const encode = encodeURIComponent;
+
 
 /**
  * Removes properties from fields that are not present in allowedFields
@@ -15,8 +16,8 @@ let DEFAULT_PAGESIZE = 100;
  * @param {*} fields array of fields that will have all non-allowed fields removed.
  * @returns array of fields that is a subset of allowedFields.
  */
-exports.getSanitizedFields = function(allowedFields, fields) {
-  return fields.filter(function(field) {
+exports.getSanitizedFields = function (allowedFields, fields) {
+  return fields.filter(function (field) {
     return allowedFields.indexOf(allowedFields, field) !== -1;
   });
 };
@@ -29,7 +30,7 @@ exports.getSanitizedFields = function(allowedFields, fields) {
  * @param {*} query
  * @returns
  */
-exports.buildQuery = function(property, values, query) {
+exports.buildQuery = function (property, values, query) {
   let objectIDs = [];
   if (Array.isArray(values)) {
     for (let id in values) {
@@ -55,7 +56,7 @@ exports.buildQuery = function(property, values, query) {
  * @param {*} pageNum
  * @returns
  */
-exports.getSkipLimitParameters = function(pageSize, pageNum) {
+exports.getSkipLimitParameters = function (pageSize, pageNum) {
   const params = {};
 
   let ps = DEFAULT_PAGESIZE; // Default
@@ -73,7 +74,7 @@ exports.getSkipLimitParameters = function(pageSize, pageNum) {
   return params;
 };
 
-exports.recordAction = async function(action, meta, username, objId = null) {
+exports.recordAction = async function (action, meta, username, objId = null) {
   const Audit = mongoose.model('Audit');
   const audit = new Audit({
     _objectSchema: 'Query',


### PR DESCRIPTION
EPIC documents are now handled a little differently. Instead, a hot link will be created to the EPIC API to fetch documents. Also, within our records a new field has been created called attachments. Attachments is an array of objects which hold data that is required to fetch a document.

The array is as follows:

[{

url: ‘https://projects.eao.gov.bc.ca/api/document/58869414eed3c0016f85526e/fetch/Red%20Mountain%20Project%20-%201996%20Project%20Development%20Review%20Report%20contents%20include%20Purpose%20of%20Report%2C%20Introduction%20%28Background%20%26%20History%29%2C%20Geology%20%26%20Mineralization%2C%20Physiography%2C%20Environmental%20Setting%2C%20Native%20Land%20Use%2C%20Land%20Capability%20and%20Use%2C%20Socio-Economic.pdf’,

fileName: ‘Red Mountain Project - 1996 Project Development Review Report.pdf’

}]

 

This will allow us to have multiple documents associated with a record which is a future requirement.