### PR TITLE
PTI-320: Add master description as default flavour description.

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -110,7 +110,12 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
-      lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || '')
+      lngDescription: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
+          ''
+      )
     });
   }
 

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -121,10 +121,21 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
 
       // NRCED
-      nrcedSummary: new FormControl((this.currentRecord && this.nrcedFlavour && this.nrcedFlavour.summary) || ''),
+      nrcedSummary: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.nrcedFlavour && this.nrcedFlavour.summary) ||
+            (!this.nrcedFlavour && this.currentRecord.description))) ||
+          ''
+      ),
 
       // LNG
-      lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || '')
+      lngDescription: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
+          ''
+      )
     });
   }
 

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -111,7 +111,12 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
 
       // LNG
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),
-      lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || '')
+      lngDescription: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
+          ''
+      )
     });
   }
 

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -124,10 +124,21 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
 
       // NRCED
-      nrcedSummary: new FormControl((this.currentRecord && this.nrcedFlavour && this.nrcedFlavour.summary) || ''),
+      nrcedSummary: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.nrcedFlavour && this.nrcedFlavour.summary) ||
+            (!this.nrcedFlavour && this.currentRecord.description))) ||
+          ''
+      ),
 
       // LNG
-      lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || '')
+      lngDescription: new FormControl(
+        // default to using the master description if the flavour record does not exist
+        (this.currentRecord &&
+          ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
+          ''
+      )
     });
   }
 

--- a/angular/projects/common/src/app/models/master/certificate.ts
+++ b/angular/projects/common/src/app/models/master/certificate.ts
@@ -21,6 +21,7 @@ export class Certificate {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
+  description: string;
   legislation: string;
   projectName: string;
   location: string;
@@ -54,6 +55,7 @@ export class Certificate {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
+    this.description = (obj && obj.description) || null;
     this.legislation = (obj && obj.legislation) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/inspection.ts
+++ b/angular/projects/common/src/app/models/master/inspection.ts
@@ -17,6 +17,7 @@ export class Inspection {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
+  description: string;
   legislation: string;
   issuedTo: string; // epic value?
   projectName: string;
@@ -47,6 +48,7 @@ export class Inspection {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
+    this.description = (obj && obj.description) || null;
     this.legislation = (obj && obj.legislation) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;

--- a/angular/projects/common/src/app/models/master/management-plan.ts
+++ b/angular/projects/common/src/app/models/master/management-plan.ts
@@ -20,9 +20,11 @@ export class ManagementPlan {
   dateIssued: Date;
   agency: string;
   author: string;
+  description: string;
   projectName: string;
   location: string;
   centroid: number[];
+  documents: object[];
 
   dateAdded: Date;
   dateUpdated: Date;
@@ -50,9 +52,11 @@ export class ManagementPlan {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.agency = (obj && obj.agency) || null;
     this.author = (obj && obj.author) || null;
+    this.description = (obj && obj.description) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;
+    this.documents = (obj && obj.documents) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;

--- a/angular/projects/common/src/app/models/master/order.ts
+++ b/angular/projects/common/src/app/models/master/order.ts
@@ -18,6 +18,7 @@ export class Order {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
+  description: string;
   legislation: string;
   issuedTo: string; // epic value?
   projectName: string;
@@ -50,6 +51,7 @@ export class Order {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
+    this.description = (obj && obj.description) || null;
     this.legislation = (obj && obj.legislation) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;

--- a/api/src/integrations/epic/certificates-amendment-utils.js
+++ b/api/src/integrations/epic/certificates-amendment-utils.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const defaultLog = require('../../utils/logger')('epic-amendments');
 const RECORD_TYPE = require('../../utils/constants/record-type-enum');
 const EpicUtils = require('./epic-utils');
+const DocumentController = require('./../../controllers/document-controller');
 
 /**
  * Epic Amendment record handler for { type: 'Amendment Package', milestone: 'Amendment' }.
@@ -68,6 +69,7 @@ class CertificatesAmendment {
       recordSubtype: 'Amendment',
       dateIssued: epicRecord.documentDate || null,
       issuingAgency: 'Environmental Assessment Office',
+      description: epicRecord.description || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',

--- a/api/src/integrations/epic/certificates-utils.js
+++ b/api/src/integrations/epic/certificates-utils.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const defaultLog = require('../../utils/logger')('epic-certificates');
 const RECORD_TYPE = require('../../utils/constants/record-type-enum');
 const EpicUtils = require('./epic-utils');
+const DocumentController = require('./../../controllers/document-controller');
 
 /**
  * Epic Certificate record handler for { type: 'Certificate Package', milestone: 'Certificate' }.
@@ -67,6 +68,7 @@ class Certificates {
       recordType: RECORD_TYPE.Certificate.displayName,
       dateIssued: epicRecord.documentDate || null,
       issuingAgency: 'Environmental Assessment Office',
+      description: epicRecord.description || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',

--- a/api/src/integrations/epic/inspections-utils.js
+++ b/api/src/integrations/epic/inspections-utils.js
@@ -66,17 +66,14 @@ class Inspections {
 
       recordName: epicRecord.displayName || '',
       recordType: RECORD_TYPE.Inspection.displayName,
-      // recordSubtype: // No mapping
       dateIssued: epicRecord.datePosted || null,
       issuingAgency: 'Environmental Assessment Office',
       author: epicRecord.documentAuthor || '',
+      description: epicRecord.description || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',
-      // issuedTo: // No mapping
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
-      // outcomeStatus: // No mapping
-      // outcomeDescription: // No mapping
       documents: documents,
 
       dateAdded: new Date(),

--- a/api/src/integrations/epic/management-plans-utils.js
+++ b/api/src/integrations/epic/management-plans-utils.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const defaultLog = require('../../utils/logger')('epic-management-plans');
 const RECORD_TYPE = require('../../utils/constants/record-type-enum');
 const EpicUtils = require('./epic-utils');
+const DocumentController = require('./../../controllers/document-controller');
 
 /**
  * Epic ManagementPlan record handler for { type: 'ManagementPlan Package', milestone: 'ManagementPlan' }.
@@ -41,6 +42,19 @@ class ManagementPlans {
     // Apply common Epic pre-processing/transformations
     epicRecord = EpicUtils.preTransformRecord(epicRecord);
 
+    // Creating and saving a document object if we are given a link to an EPIC document.
+    const documents = [];
+    if (epicRecord._id && epicRecord.documentFileName) {
+      const savedDocument = await DocumentController.createLinkDocument(
+        epicRecord.documentFileName,
+        (this.auth_payload && this.auth_payload.displayName) || '',
+        `https://projects.eao.gov.bc.ca/api/document/${epicRecord._id}/fetch/${encodeURIComponent(
+          epicRecord.documentFileName
+        )}`
+      );
+      documents.push(savedDocument);
+    }
+
     return {
       _schemaName: RECORD_TYPE.ManagementPlan._schemaName,
       _epicProjectId: (epicRecord.project && epicRecord.project._id) || '',
@@ -55,10 +69,12 @@ class ManagementPlans {
       dateIssued: epicRecord.documentDate || null,
       agency: 'Environmental Assessment Office',
       author: epicRecord.documentAuthor || '',
+      description: epicRecord.description || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
+      documents: documents,
 
       dateAdded: new Date(),
       dateUpdated: new Date(),

--- a/api/src/integrations/epic/orders-utils.js
+++ b/api/src/integrations/epic/orders-utils.js
@@ -66,17 +66,14 @@ class Orders {
 
       recordName: epicRecord.displayName || '',
       recordType: RECORD_TYPE.Order.displayName,
-      // recordSubtype: // No mapping
       dateIssued: epicRecord.datePosted || null,
       issuingAgency: 'Environmental Assessment Office',
       author: epicRecord.documentAuthor || '',
+      description: epicRecord.description || '',
       legislation: (epicRecord.project && epicRecord.project.legislation) || '',
-      // issuedTo: // No mapping
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
-      // outcomeStatus: // No mapping
-      // outcomeDescription: // No mapping
       documents: documents,
 
       dateAdded: new Date(),

--- a/api/src/models/master/certificate.js
+++ b/api/src/models/master/certificate.js
@@ -16,6 +16,7 @@ module.exports = require('../../utils/model-schema-generator')(
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
+    description: { type: String, default: '' },
     legislation: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/inspection.js
+++ b/api/src/models/master/inspection.js
@@ -16,8 +16,9 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' }, // section, sub section, reg, etc
-    issuedTo: { type: String, default: '' }, // first, middle, last OR company
+    description: { type: String, default: '' },
+    legislation: { type: String, default: '' },
+    issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],

--- a/api/src/models/master/managementPlan.js
+++ b/api/src/models/master/managementPlan.js
@@ -16,9 +16,11 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     agency: { type: String, default: '' },
     author: { type: String, default: '' },
+    description: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],
+    documents: [{ type: 'ObjectId', default: null, index: true }],
 
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: Date.now() },

--- a/api/src/models/master/order.js
+++ b/api/src/models/master/order.js
@@ -17,6 +17,7 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
+    description: { type: String, default: '' },
     legislation: { type: String, default: '' },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },


### PR DESCRIPTION
Commit 1:
- Update API models and imports (for the types the import supports) to include description in the master record.
- I also added attachments support to imports that were missing it.

Commit 2:
- Update Flavour add/edit (for the types the import supports) to use the master description if the flavour record does not exist.
- I also added the attachments field to the model for a type that was missing it.