### PR TITLE
PTI-185: Legislation

### DIFF
--- a/angular/projects/admin-nrpti/src/app/app.component.html
+++ b/angular/projects/admin-nrpti/src/app/app.component.html
@@ -7,7 +7,7 @@
   </div>
   <div class="body-content" id="scrollTop">
     <lib-breadcrumb (navigateBreadcrumb)="navigateBreadcrumb($event)"></lib-breadcrumb>
-    <div class="content-component">
+    <div class="content-component" cdkScrollable>
       <router-outlet></router-outlet>
     </div>
   </div>

--- a/angular/projects/admin-nrpti/src/app/app.component.scss
+++ b/angular/projects/admin-nrpti/src/app/app.component.scss
@@ -19,7 +19,7 @@ app-header {
 }
 
 app-footer {
-  z-index: 1;
+  z-index: 1000;
 }
 
 app-toggle-button {
@@ -32,6 +32,10 @@ app-toggle-button {
   @media screen and (max-width: 768px) {
     margin-top: 3px;
   }
+}
+
+lib-breadcrumb {
+  z-index: 1000;
 }
 
 .app-body {
@@ -69,6 +73,10 @@ app-toggle-button {
   z-index: 2;
 
   .content-component {
+    @include flex-box();
+    @include flex(1 1 auto);
+    @include flex-direction(column);
+
     overflow: auto;
   }
 }

--- a/angular/projects/admin-nrpti/src/app/app.module.ts
+++ b/angular/projects/admin-nrpti/src/app/app.module.ts
@@ -6,6 +6,8 @@ import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPaginationModule } from 'ngx-pagination';
 import { BootstrapModalModule } from 'ng2-bootstrap-modal';
+import { Overlay, CloseScrollStrategy } from '@angular/cdk/overlay';
+import { MAT_AUTOCOMPLETE_SCROLL_STRATEGY } from '@angular/material';
 
 // modules
 import { GlobalModule } from 'nrpti-angular-components';
@@ -48,6 +50,10 @@ export function keycloakFactory(keycloakService: KeycloakService) {
   return () => keycloakService.init();
 }
 
+export function overlayScrollFactory(overlay: Overlay): () => CloseScrollStrategy {
+  return () => overlay.scrollStrategies.close();
+}
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -88,6 +94,12 @@ export function keycloakFactory(keycloakService: KeycloakService) {
       provide: HTTP_INTERCEPTORS,
       useClass: TokenInterceptor,
       multi: true
+    },
+    {
+      // Tells mat-autocomplete select box to close when the page is scrolled. Aligns with default select box behaviour.
+      provide: MAT_AUTOCOMPLETE_SCROLL_STRATEGY,
+      useFactory: overlayScrollFactory,
+      deps: [Overlay]
     },
     ApiService,
     DocumentService,

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
@@ -88,33 +88,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -106,7 +106,21 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -162,6 +176,13 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-administrative-penalty-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class AdministrativePenaltyDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class AdministrativePenaltyDetailComponent extends RecordComponent implem
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
@@ -88,33 +88,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -106,7 +106,21 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -162,6 +176,13 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-administrative-sanction-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class AdministrativeSanctionDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class AdministrativeSanctionDetailComponent extends RecordComponent imple
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.html
@@ -81,33 +81,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -94,7 +94,21 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
           ''
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -146,6 +160,13 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       recordSubtype: this.myForm.controls.recordSubtype.value,
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
           <div class="grid-item">
             <span class="grid-item-name">Source System</span>

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-certificate-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class CertificateDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class CertificateDetailComponent extends RecordComponent implements OnIni
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.html
@@ -1,0 +1,63 @@
+<form [formGroup]="formGroup">
+  <div class="flex-container">
+    <div class="label-pair">
+      <label for="act">Act</label>
+      <input
+        name="act"
+        id="act"
+        formControlName="act"
+        type="text"
+        class="form-control"
+        placeholder="Begin typing to filter acts..."
+        matInput
+        (keyup)="filterActsPicklist($event)"
+        (blur)="verifyKnownActValue($event)"
+        [matAutocomplete]="actAutocomplete"
+      />
+      <mat-autocomplete #actAutocomplete="matAutocomplete">
+        <mat-option (click)="onSelectAct()"></mat-option>
+        <mat-option *ngFor="let act of filteredActs" [value]="act" (click)="onSelectAct(act)" title="act">
+          {{ act }}
+        </mat-option>
+      </mat-autocomplete>
+    </div>
+    <div class="label-pair">
+      <label for="regulation">Regulation</label>
+      <input
+        name="regulation"
+        id="regulation"
+        formControlName="regulation"
+        type="text"
+        class="form-control"
+        placeholder="Begin typing to filter regulations..."
+        matInput
+        (keyup)="filterRegulationsPicklist($event)"
+        (blur)="verifyKnownRegulationValue($event)"
+        [matAutocomplete]="regulationAutocomplete"
+      />
+      <mat-autocomplete #regulationAutocomplete="matAutocomplete">
+        <mat-option (click)="onSelectRegulation()"></mat-option>
+        <mat-option
+          *ngFor="let regulation of filteredRegulations"
+          [value]="regulation"
+          (click)="onSelectRegulation(regulation)"
+          title="regulation"
+        >
+          {{ regulation }}
+        </mat-option>
+      </mat-autocomplete>
+    </div>
+    <div class="label-pair xsm">
+      <label for="section">Section</label>
+      <input name="section" id="section" formControlName="section" type="text" class="form-control" />
+    </div>
+    <div class="label-pair xsm">
+      <label for="subSection">Sub-Section</label>
+      <input name="subSection" id="subSection" formControlName="subSection" type="text" class="form-control" />
+    </div>
+    <div class="label-pair xsm">
+      <label for="paragraph">Paragraph</label>
+      <input name="paragraph" id="paragraph" formControlName="paragraph" type="text" class="form-control" />
+    </div>
+  </div>
+</form>

--- a/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.scss
+++ b/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.scss
@@ -1,0 +1,2 @@
+@import "assets/styles/base/base.scss";
+@import "assets/styles/components/add-edit.scss";

--- a/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.spec.ts
+++ b/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.spec.ts
@@ -1,0 +1,32 @@
+import { async, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material';
+import { TestBedHelper } from '../../../../../../common/src/app/spec/spec-utils';
+import { LegislationAddEditComponent } from './legislation-add-edit.component';
+
+describe('LegislationAddEditComponent', () => {
+  const testBedHelper = new TestBedHelper<LegislationAddEditComponent>(LegislationAddEditComponent);
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [LegislationAddEditComponent],
+      imports: [ReactiveFormsModule, MatAutocompleteModule]
+    }).compileComponents();
+  }));
+
+  it('should create', () => {
+    const { component, fixture } = testBedHelper.createComponent(false);
+
+    const act = new FormControl({});
+    const regulation = new FormControl({});
+    const section = new FormControl({});
+    const subSection = new FormControl({});
+    const paragraph = new FormControl({});
+
+    component.formGroup = new FormGroup({ act, regulation, section, subSection, paragraph });
+
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/common-components/legislation-add-edit/legislation-add-edit.component.ts
@@ -1,0 +1,322 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Picklists } from '../../../utils/constants/record-constants';
+
+@Component({
+  selector: 'app-legislation-add-edit',
+  templateUrl: './legislation-add-edit.component.html',
+  styleUrls: ['./legislation-add-edit.component.scss']
+})
+export class LegislationAddEditComponent implements OnInit {
+  @Input() formGroup: FormGroup;
+
+  // cache acts
+  public readonly actsMappedToRegulations: { [key: string]: string[] } = Picklists.legislationActsMappedToRegulations;
+  public readonly allActs = Object.keys(this.actsMappedToRegulations).sort();
+
+  // cache regulations
+  public readonly regulationsMappedToActs: {
+    [key: string]: string[];
+  } = Picklists.getLegislationRegulationsMappedToActs();
+  public readonly allRegulations = Object.keys(this.regulationsMappedToActs).sort();
+
+  public filteredActs: string[] = [];
+  public filteredRegulations: string[] = [];
+
+  ngOnInit(): void {
+    this.onSelectAct(this.formGroup.controls.act.value);
+    this.onSelectRegulation(this.formGroup.controls.regulation.value);
+  }
+
+  /**
+   * When typing in the acts input field, filter acts picklist options.
+   *
+   * @param {*} event
+   * @returns
+   * @memberof InspectionAddEditComponent
+   */
+  filterActsPicklist(event) {
+    if (!event.target.value) {
+      // Field is empty, reset to full list (or partial list if regulation is set)
+      if (this.formGroup.controls.regulation.value) {
+        this.filteredActs = this.getActsForRegulation(this.formGroup.controls.regulation.value);
+      } else {
+        this.filteredActs = this.allActs;
+      }
+      return;
+    }
+
+    if (event.keyCode === 13) {
+      // ENTER key pressed to select option, treat this the same as clicking an option
+      this.onSelectAct(event.target.value);
+      return;
+    }
+
+    if (!this.isValidFilterKeyCode(event.keyCode)) {
+      // Prevent key presses that aren't characters or backspace or delete from triggering the filtering
+      return;
+    }
+
+    this.filteredActs = this.getActsFromKeywords(event.target.value);
+
+    if (!this.filteredActs || !this.filteredActs.length) {
+      this.onEmptyAct();
+    }
+  }
+
+  /**
+   * When selecting an act value, update the acts/regulations picklists accordingly.
+   *
+   * @param {string} act
+   * @returns
+   * @memberof InspectionAddEditComponent
+   */
+  onSelectAct(act: string = null) {
+    if (!act) {
+      this.onEmptyAct();
+      return;
+    }
+
+    // An act was selected, limit the regulations picklist
+    this.filteredRegulations = this.getRegulationsForAct(act);
+  }
+
+  /**
+   * Clears the act control if the value is not a known (allowed) act.
+   *
+   * @memberof InspectionAddEditComponent
+   */
+  verifyKnownActValue(event) {
+    if (event && event.relatedTarget && event.relatedTarget.localName === 'mat-option') {
+      // When a user clicks an item from the overlay select drop-down box, the blur event triggers before the control
+      // is updated, which runs this function too early.  So, ignore blur events that are triggered by selecting a
+      // mat-option element.
+      return;
+    }
+
+    if (!event) {
+      this.formGroup.controls.act.reset();
+    }
+
+    if (!this.allActs.includes(event.target.value)) {
+      this.formGroup.controls.act.reset();
+      // Treat this as if the user chose to clear the value
+      this.onSelectAct(null);
+    }
+  }
+
+  /**
+   * When typing in the regulations input field, filter regulation picklist options.
+   *
+   * @param {*} event
+   * @returns
+   * @memberof InspectionAddEditComponent
+   */
+  filterRegulationsPicklist(event) {
+    if (!event.target.value) {
+      // Field is empty, reset to full list (or partial list if regulation is set)
+      if (this.formGroup.controls.act.value) {
+        this.filteredRegulations = this.getRegulationsForAct(this.formGroup.controls.act.value);
+      } else {
+        this.filteredRegulations = this.allRegulations;
+      }
+      return;
+    }
+
+    if (event.keyCode === 13) {
+      // ENTER key pressed to select option, treat this the same as clicking an option
+      this.onSelectRegulation(event.target.value);
+      return;
+    }
+
+    if (!this.isValidFilterKeyCode(event.keyCode)) {
+      // Prevent key presses that aren't characters or backspace or delete from triggering the filtering
+      return;
+    }
+
+    this.filteredRegulations = this.getRegulationsFromKeywords(event.target.value);
+  }
+
+  /**
+   * When selecting a regulation value, update the acts/regulations picklists accordingly.
+   *
+   * @param {string} regulation
+   * @returns
+   * @memberof InspectionAddEditComponent
+   */
+  onSelectRegulation(regulation: string = null) {
+    if (!regulation) {
+      this.onEmptyRegulation();
+      return;
+    }
+
+    // A regulation was selected, limit the acts picklist
+    this.filteredActs = this.getActsForRegulation(regulation);
+
+    if (this.filteredActs && this.filteredActs.length === 1) {
+      // Special case: regulations should always have 1 parent act, so auto-select the parent act.
+      this.formGroup.controls.act.setValue(this.filteredActs[0]);
+      this.onSelectAct(this.filteredActs[0]);
+    }
+  }
+
+  /**
+   * Clears the regulation control if the value is not a known (allowed) regulation.
+   *
+   * @memberof InspectionAddEditComponent
+   */
+  verifyKnownRegulationValue(event) {
+    if (event && event.relatedTarget && event.relatedTarget.localName === 'mat-option') {
+      // When a user clicks an item from the overlay select drop-down box, the blur event triggers before the control
+      // is updated, which runs this function too early.  So, ignore blur events that are triggered by selecting a
+      // mat-option element.
+      return;
+    }
+
+    if (!event) {
+      this.formGroup.controls.regulation.reset();
+    }
+
+    if (!this.allRegulations.includes(event.target.value)) {
+      this.formGroup.controls.regulation.reset();
+      // Treat this as if the user chose to clear the value
+      this.onSelectRegulation(null);
+    }
+  }
+
+  /**
+   * Given a space delimited string of keywords, return all acts that contain one or more of the keywords.
+   *
+   * Note: case insensitive.
+   *
+   * @memberof LegislationAddEditComponent
+   * @param {string} keywordString space delimited string of keywords
+   * @param {string} acts array of acts to filter. (optional)
+   * @returns {string[]} array of acts
+   */
+  public getActsFromKeywords(keywordString: string): string[] {
+    if (!keywordString) {
+      // if no keyword filters, return all acts
+      return this.filteredActs;
+    }
+
+    const actsToFilter = this.filteredActs || this.allActs;
+
+    // tokenize keyword string (spaces, commas, semi-colons) and remove any empty tokens
+    const keywords = keywordString
+      .split(/[\s,;]+/)
+      .filter(keyword => keyword)
+      .map(keyword => keyword.toLowerCase());
+
+    // filter the list of acts against the list of keywords
+    return actsToFilter.filter(act => keywords.some(keyword => act.toLowerCase().includes(keyword)));
+  }
+
+  /**
+   * Given a regulation string, return an array of acts that the regulation is under.
+   *
+   * @memberof LegislationAddEditComponent
+   * @param {string} regulation title text of the regulation
+   * @returns {string[]} array of acts or empty array
+   */
+  public getActsForRegulation(regulation: string): string[] {
+    if (!regulation) {
+      return [];
+    }
+
+    return this.regulationsMappedToActs[regulation] || [];
+  }
+
+  /**
+   * Given a space delimited string of keywords, return all regulations that contain one or more of the keywords.
+   *
+   * Note: case insensitive.
+   *
+   * @memberof LegislationAddEditComponent
+   * @param {string} keywordString space delimited string of keywords
+   * @param {string} regulations array of regulations to filter. (optional)
+   * @returns {string[]} array of regulations
+   */
+  public getRegulationsFromKeywords(keywordString: string): string[] {
+    if (!keywordString) {
+      // if no keyword filters, return all regulations
+      return this.filteredRegulations;
+    }
+
+    const regulationsToFilter = this.filteredRegulations || this.allRegulations;
+
+    // tokenize keyword string (split on spaces, commas, semi-colons) and remove any empty tokens
+    const keywords = keywordString
+      .split(/[\s,;]+/)
+      .filter(keyword => keyword)
+      .map(keyword => keyword.toLowerCase());
+
+    // filter the list of acts against the list of keywords
+    return regulationsToFilter.filter(regulation =>
+      keywords.some(keyword => regulation.toLowerCase().includes(keyword))
+    );
+  }
+
+  /**
+   * Given an act string, return an array of regulations that are under that act.
+   *
+   * @memberof LegislationAddEditComponent
+   * @param {string} act title text of the act
+   * @returns {string[]} array of regulations or empty array
+   */
+  public getRegulationsForAct(act: string): string[] {
+    if (!act) {
+      return [];
+    }
+
+    return this.actsMappedToRegulations[act] || [];
+  }
+
+  /**
+   * Business logic to run when the act control goes from not empty to empty.
+   *
+   * @memberof LegislationAddEditComponent
+   */
+  public onEmptyAct() {
+    // The acts control is empty, so reset the regulations picklist to show all values
+    this.filteredRegulations = this.allRegulations;
+    // Business Logic: if the act control is cleared, also clear the regulation control
+    this.formGroup.controls.regulation.reset();
+
+    if (!this.formGroup.controls.act.value) {
+      // The act control is also empty, so reset the regulations picklist to show all values
+      this.filteredRegulations = this.allRegulations;
+    }
+  }
+
+  /**
+   * Business logic to run when the regulation control goes from not empty to empty.
+   *
+   * @memberof LegislationAddEditComponent
+   */
+  public onEmptyRegulation() {
+    // The regulation control is empty, so reset the acts picklist to show all values
+    this.filteredActs = this.allActs;
+
+    if (!this.formGroup.controls.regulation.value) {
+      // The act control is also empty, so reset the regulations picklist to show all values
+      this.filteredRegulations = this.allRegulations;
+    }
+  }
+
+  /**
+   * Returns True if the keyCode should trigger filtering, false otherwise.
+   *
+   * @param {number} keyCode
+   * @returns
+   * @memberof LegislationAddEditComponent
+   */
+  public isValidFilterKeyCode(keyCode: number) {
+    if (keyCode !== 8 && keyCode !== 46 && (keyCode < 65 || keyCode > 90)) {
+      // Prevent key presses that aren't characters or backspace or delete from triggering the filtering
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
@@ -81,33 +81,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -106,7 +106,21 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -172,6 +186,13 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
           <div class="grid-item">
             <span class="grid-item-name">Source System</span>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-inspection-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class InspectionDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class InspectionDetailComponent extends RecordComponent implements OnInit
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
@@ -87,33 +87,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -112,7 +112,21 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -149,6 +163,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
   }
 
   togglePublish(flavour) {
+    console.log(this.myForm.controls.regulation);
     switch (flavour) {
       case 'lng':
         this.lngPublishStatus = this.lngPublishStatus === 'Unpublished' ? 'Published' : 'Unpublished';
@@ -194,6 +209,13 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -47,8 +47,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
           <div class="grid-item">
             <span class="grid-item-name">Source System</span>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-order-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class OrderDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -35,8 +38,17 @@ export class OrderDetailComponent extends RecordComponent implements OnInit, OnD
             record.flavours.map(flavourRecord => RecordUtils.getRecordModelInstance(flavourRecord))) ||
           []
       };
+
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.html
@@ -74,33 +74,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -94,7 +94,21 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
           ''
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -141,6 +155,13 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       recordSubtype: this.myForm.controls.recordSubtype.value,
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-permit-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class PermitDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class PermitDetailComponent extends RecordComponent implements OnInit, On
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/records.module.ts
+++ b/angular/projects/admin-nrpti/src/app/records/records.module.ts
@@ -18,6 +18,9 @@ import { RecordsListComponent } from './records-list/records-list.component';
 import { RecordsTableRowComponent } from './records-rows/records-table-row.component';
 import { RecordDetailDirective } from './utils/record-detail.directive';
 
+// records common components
+import { LegislationAddEditComponent } from './common-components/legislation-add-edit/legislation-add-edit.component';
+
 // Orders
 import { OrderAddEditComponent } from './orders/order-add-edit/order-add-edit.component';
 import { OrderDetailComponent } from './orders/order-detail/order-detail.component';
@@ -116,6 +119,8 @@ import { DateInputComponent } from '../explore-panel/date-input/date-input.compo
     RecordsListComponent,
     RecordsTableRowComponent,
     RecordDetailDirective,
+    // records common components
+    LegislationAddEditComponent,
     // orders
     OrderAddEditComponent,
     OrderDetailComponent,

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
@@ -88,33 +88,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -106,7 +106,21 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -162,6 +176,13 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-restorative-justice-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class RestorativeJusticeDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class RestorativeJusticeDetailComponent extends RecordComponent implement
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.html
@@ -88,33 +88,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -95,7 +95,21 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
@@ -142,6 +156,13 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,
       centroid: [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-self-report-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class SelfReportDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class SelfReportDetailComponent extends RecordComponent implements OnInit
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
@@ -81,33 +81,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -106,7 +106,21 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -162,6 +176,13 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-ticket-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class TicketDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class TicketDetailComponent extends RecordComponent implements OnInit, On
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
@@ -81,33 +81,7 @@
 
     <section>
       <h4>Legislation</h4>
-      <div class="flex-container">
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="legislation">Act/Legislation</label>
-          <select disabled name="legislation" id="legislation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair">
-          <label for="regulation">Regulation</label>
-          <select disabled name="regulation" id="regulation" class="form-control"></select>
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="section">Section</label>
-          <input disabled name="section" id="section" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection1">Sub-Section</label>
-          <input disabled name="subSection1" id="subSection1" type="text" class="form-control" />
-        </div>
-        <!-- TODO -->
-        <div class="label-pair xsm">
-          <label for="subSection2">Sub-Section</label>
-          <input disabled name="subSection2" id="subSection2" type="text" class="form-control" />
-        </div>
-      </div>
+      <app-legislation-add-edit [formGroup]="myForm"></app-legislation-add-edit>
     </section>
 
     <section>

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -106,7 +106,21 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       ),
       issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
       author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormControl((this.currentRecord && this.currentRecord.legislation) || ''),
+      act: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
+      ),
+      regulation: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
+      ),
+      section: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
+      ),
+      subSection: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
+      ),
+      paragraph: new FormControl(
+        (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
+      ),
       issuedTo: new FormControl((this.currentRecord && this.currentRecord.issuedTo) || ''),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
@@ -161,6 +175,13 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       dateIssued: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value),
       issuingAgency: this.myForm.controls.issuingAgency.value,
       author: this.myForm.controls.author.value,
+      legislation: {
+        act: this.myForm.controls.act.value,
+        regulation: this.myForm.controls.regulation.value,
+        section: this.myForm.controls.section.value,
+        subSection: this.myForm.controls.subSection.value,
+        paragraph: this.myForm.controls.paragraph.value
+      },
       issuedTo: this.myForm.controls.issuedTo.value,
       projectName: this.myForm.controls.projectName.value,
       location: this.myForm.controls.location.value,

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -43,8 +43,8 @@
             <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
           <div class="grid-item">
-            <span class="grid-item-name">Act/Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <span class="grid-item-name">Legislation</span>
+            <span class="grid-item-value">{{ legislationString || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-border"></div>

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RecordComponent } from '../../utils/record-component';
 import { RecordUtils } from '../../utils/record-utils';
+import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 
 @Component({
   selector: 'app-warning-detail',
@@ -13,6 +14,8 @@ import { RecordUtils } from '../../utils/record-utils';
 })
 export class WarningDetailComponent extends RecordComponent implements OnInit, OnDestroy {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public legislationString = '';
 
   constructor(public route: ActivatedRoute, public router: Router, public changeDetectionRef: ChangeDetectorRef) {
     super();
@@ -36,8 +39,16 @@ export class WarningDetailComponent extends RecordComponent implements OnInit, O
           []
       };
 
+      this.populateTextFields();
+
       this.changeDetectionRef.detectChanges();
     });
+  }
+
+  populateTextFields() {
+    if (this.data && this.data._master && this.data._master.legislation) {
+      this.legislationString = CommonUtils.buildLegislationString(this.data._master.legislation);
+    }
   }
 
   navigateToEditPage() {

--- a/angular/projects/admin-nrpti/src/app/shared/shared.module.ts
+++ b/angular/projects/admin-nrpti/src/app/shared/shared.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { MatSnackBarModule, MatSlideToggleModule } from '@angular/material';
+import { MatSnackBarModule, MatSlideToggleModule, MatAutocompleteModule } from '@angular/material';
 
 import { DatePipe } from '@angular/common';
 import { OrderByPipe } from '../pipes/order-by.pipe';
@@ -9,10 +9,10 @@ import { ObjectFilterPipe } from '../pipes/object-filter.pipe';
 import { LinkifyPipe } from '../pipes/linkify.pipe';
 
 @NgModule({
-  imports: [BrowserModule, MatSlideToggleModule, MatSnackBarModule],
+  imports: [BrowserModule, MatSlideToggleModule, MatSnackBarModule, MatAutocompleteModule],
   declarations: [OrderByPipe, NewlinesPipe, ObjectFilterPipe, LinkifyPipe],
   providers: [DatePipe],
-  exports: [MatSlideToggleModule, MatSnackBarModule, OrderByPipe, NewlinesPipe, LinkifyPipe],
+  exports: [MatSlideToggleModule, MatSnackBarModule, MatAutocompleteModule, OrderByPipe, NewlinesPipe, LinkifyPipe],
   entryComponents: []
 })
 export class SharedModule {}

--- a/angular/projects/admin-nrpti/src/app/utils/constants/record-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/record-constants.ts
@@ -66,4 +66,584 @@ export class Picklists {
   public static readonly authorPicklist = ['BC Government', 'Proponent', 'Other'];
 
   public static readonly outcomeStatusPicklist = ['Closed', 'Open'];
+
+  /**
+   * Contains a mapping of acts to regulations.
+   *
+   * Object spec:
+   * {
+   *   "Act1": ["RegulationA", "RegulationB", ...]
+   *   "Act2": ["regulationC", ...]
+   *   ...
+   * }
+   *
+   * @static
+   * @memberof Picklists
+   */
+  public static readonly legislationActsMappedToRegulations = {
+    'Agricultural Land Commission Act': ['Agricultural Land Reserve Use, Subdivision and Procedure Regulation'],
+    'Agrologists Act': [],
+    'Animal Health Act': [
+      'Animal Products and Byproducts Regulation',
+      'Bee Regulation',
+      'Enforcement Regulation',
+      'Fur Farm Regulation',
+      'Game Farm Regulation',
+      'Laboratory Fees Regulation',
+      'Livestock Licensing Regulation',
+      'Poultry Health and Buying Regulation',
+      'Reportable and Notifiable Disease Regulation'
+    ],
+    'BC Hydro Public Power Legacy and Heritage Contract Act': ['Remote Communities Regulation'],
+    'Boundary Act': [],
+    'Canada Shipping Act': [
+      'Boating Restriction Regulations',
+      'Competency of Operators of Pleasure Craft Regulations',
+      'Small Vessel Regulation'
+    ],
+    'Canadian Pacific Railway (Stone and Timber) Settlement Act': [],
+    'Clean Energy Act': [
+      'Authorization For Burrard Thermal Electricity Regulation',
+      "British Columbia's Energy Objectives Regulation",
+      'Clean or Renewable Resource Regulation',
+      'Domestic Long-Term Sales Contracts Regulation',
+      'Electricity Self-Sufficiency Regulation',
+      'Exempt Projects, Programs, Contracts and Expenditures Regulation',
+      'First Nations Clean Energy Business Fund Regulation',
+      'Greenhouse Gas Reduction (Clean Energy) Regulation',
+      'Improvement Financing Regulation',
+      'Rate Comparison Regulation',
+      'Smart Meters and Smart Grid Regulation',
+      'Standing Offer Program Regulation'
+    ],
+    'Climate Change Accountability Act': [],
+    'Coal Act': ['Coal Act Regulation'],
+    'Coalbed Gas Act': [],
+    'College of Applied Biology Act': [],
+    'Controlled Drugs and Substances Act': [],
+    'Creston Valley Wildlife Act': [
+      'Discharge of Firearms Regulation',
+      'Fees for General Uses',
+      'Permit Regulations',
+      'Summit Creek Campground and Recreation Area Regulations'
+    ],
+    'Criminal Code (Canada)': [],
+    'Dike Maintenance Act': [],
+    'Drainage, Ditch and Dike Act': [],
+    'Drinking Water Protection Act': [],
+    'Ecological Reserve Act': [
+      'Application of Park Legislation to Ecological Reserves Regulation',
+      'Ecological Reserve Regulations'
+    ],
+    'Energy Efficiency Act': ['Energy Efficiency Standards Regulation'],
+    'Environment and Land Use Act': [],
+    'Environmental Assessment Act': [
+      'Concurrent Approval Regulation',
+      'Environmental Assessment Fee Regulation',
+      'Exemption Regulation',
+      'Prescribed Time Limits Regulation',
+      'Public Consultation Policy Regulation',
+      'Reviewable Projects Regulation',
+      'Transition Regulation'
+    ],
+    'Environmental Management Act': [
+      'Administrative Penalties (Environmental Management Act) Regulation',
+      'Agricultural Waste Control Regulation',
+      'Antifreeze Regulation',
+      'Antisapstain Chemical Waste Control Regulation',
+      'Asphalt Plant Regulation',
+      'Cleaner Gasoline Regulation',
+      'Code of Practice for Industrial Non-Hazardous Waste Landfills Incidental to the Wood Processing Industry',
+      'Code of Practice for Soil Amendments',
+      'Code of Practice for the Concrete and Concrete Products Industry',
+      'Code of Practice for the Slaughter and Poultry Processing Industries',
+      'Conservation Officer Service Authority Regulation',
+      'Contaminated Sites Regulation',
+      'Environmental Appeal Board Procedure Regulation',
+      'Environmental Data Quality Assurance Regulation',
+      'Environmental Impact Assessment Regulation',
+      'Gasoline Vapour Control Regulation',
+      'Hazardous Waste Regulation',
+      'Land-based Finfish Waste Control Regulation',
+      'Landfill Gas Management Regulation',
+      'Municipal Wastewater Regulation',
+      'Mushroom Compost Facilities Regulation',
+      'Oil and Gas Waste Regulation',
+      'Open Burning Smoke Control Regulation',
+      'Organic Matter Recycling Regulation',
+      'Ozone Depleting Substances and Other Halocarbons Regulation',
+      'Permit Fees Regulation',
+      'Petroleum Storage and Distribution Facilities Storm Water Regulation',
+      'Placer Mining Waste Control Regulation',
+      'Public Notification Regulation',
+      'Pulp Mill and Pulp and Paper Mill Liquid Effluent Control Regulation',
+      'Recycling Regulation',
+      'Solid Fuel Burning Domestic Appliance Regulation',
+      'Spill Cost Recovery Regulation',
+      'Spill Reporting Regulation',
+      'Storage of Recyclable Material Regulation',
+      'Vehicle Dismantling and Recycling Industry Environmental Planning Regulation',
+      'Waste Discharge Regulation',
+      'Wood Residue Burner and Incinerator Regulation'
+    ],
+    'Farm Income Insurance Act': ['Farm Income Plans Regulation'],
+    'Farm Practices Protection (Right to Farm) Act': [
+      'British Columbia Farm Industry Review Board Regulation',
+      'Specialty Farm Operations Regulation'
+    ],
+    'Farmers and Womens Institutes Act': ['Farmers and Womens Institutes Act Regulation'],
+    'Farming and Fishing Industries Development Act': [
+      'Blueberry Industry Development Fund Regulation',
+      'British Columbia Salmon Marketing Council Regulation',
+      'British Columbia Wine Grape Council Regulation',
+      'Cattle Industry Development Council Regulation',
+      'Dairy Industry Development Council Regulation',
+      'Grain Industry Development Fund Regulation',
+      'New Tree Fruit Varieties Development Council Regulation',
+      'Raspberry Industry Development Council Regulation',
+      'Woodlot Product Development Council Regulation'
+    ],
+    'Federal Port Development Act': [],
+    'Firearm Act': [],
+    'Firearms Act': [],
+    "First Peoples' Heritage, Language and Culture Act": ["First Peoples' Heritage, Language and Culture Regulation"],
+    'Fish and Seafood Act': ['Enforcement Regulation', 'Fish and Seafood Licensing Regulation'],
+    'Fisheries Act (Canada)': [
+      'Fishing (General) Regulations ',
+      'Pacific Fishery Regulations',
+      'Sport Fishing Regulation'
+    ],
+    'Fisheries Act (Provincial)': [],
+    'Flathead Watershed Area Conservation Act': [],
+    'FNCIDA Implementation Act': [],
+    'Food and Agricultural Products Classification Act': [
+      'Egg Grading and Standards Regulation',
+      'Enforcement Regulation',
+      'Organic Certification Regulation',
+      'Wines of Marked Quality Regulation'
+    ],
+    'Food Safety Act': ['Meat Inspection Regulation'],
+    'Forest Act': [
+      'Administrative Boundaries Regulation',
+      'Advertising, Deposits, Disposition and Extension Regulation',
+      'Allowable Annual Cut Administration Regulation',
+      'Allowable Annual Cut Partition Regulation',
+      'Annual Rent Regulation',
+      'BC Timber Sales Account Regulation',
+      'BC Timber Sales Business Areas Regulation',
+      'BC Timber Sales Regulation',
+      'Christmas Tree Regulation',
+      'Community Tenures Regulation',
+      'Cut Control Regulation',
+      'Cutting Permit Postponement Regulation',
+      'Designated Areas',
+      'Effective Director Regulation',
+      'First Nation Tenures Regulation',
+      'Forest Accounts Receivable Interest Regulation',
+      'Forest Act Regulations',
+      'Forest Licence Regulation',
+      'Forest Revenue Audit Regulation',
+      'Free Use Permit Regulation',
+      'Innovative Forestry Practices Regulation',
+      'Interest Rate Under Various Statutes Regulation',
+      'Licence to Cut Regulation',
+      'Log Salvage Regulation for the Vancouver Log Salvage District',
+      'Manufactured Forest Products Regulation',
+      'Minimum Stumpage Rate Regulation',
+      'Mountain Pine Beetle Salvage Areas',
+      'Performance Based Harvesting Regulation',
+      'Scaling Regulation',
+      'Special Forest Products Regulation',
+      'Surrender Regulation',
+      'Timber Definition Regulation',
+      'Timber Harvesting Contract and Subcontract Regulation',
+      'Timber Marketing Regulation',
+      'Timber Marking and Transportation Regulation',
+      'Transfer Regulation',
+      'Tree Farm Licence Area-based Allowable Annual Cut Trial Program Regulation',
+      'Tree Farm Licence Management Plan Regulation',
+      'Woodlot Licence Regulation'
+    ],
+    'Forest and Range Practices Act': [
+      'Administrative Orders and Remedies Regulation',
+      'Administrative Review and Appeal Procedure Regulation',
+      'Forest Planning and Practices Regulation',
+      'Forest Practices Board Regulation',
+      'Forest Recreation Regulation',
+      'Forest Service Road Use Regulation',
+      'Fort St. John Pilot Project Regulation',
+      'Government Actions Regulation',
+      'Invasive Plants Regulation',
+      'Range Planning and Practices Regulation',
+      'Security for Forest and Range Practice Liabilities Regulation',
+      'Woodlot Licence Planning and Practices Regulation'
+    ],
+    'Forest Practices Code of British Columbia Act': [
+      'Administrative Review and Appeal Procedure Regulation',
+      'Forest Road Regulation',
+      'Forest Service Road Use Regulation',
+      'Provincial Forest Use Regulation',
+      'Stillwater Pilot Project Regulation'
+    ],
+    'Forest Stand Management Fund Act': [],
+    'Foresters Act': [],
+    'Forestry Revitalization Act': [],
+    'Forestry Service Providers Protection Act': ['Forestry Service Providers Compensation Fund Regulation'],
+    'Gas Utility Act': [],
+    'Geothermal Resources Act': [
+      'Geothermal Geophysical Exploration Regulation',
+      'Geothermal Operations Regulation',
+      'Geothermal Resources General Regulation'
+    ],
+    'Great Bear Rainforest (Forest Management) Act': [
+      'Great Bear Rainforest (Forest Management) Regulation',
+      'Great Bear Rainforest (Special Forest Management Area) Regulation'
+    ],
+    'Greenbelt Act': [],
+    'Greenhouse Gas Industrial Reporting and Control Act': [
+      'Greenhouse Gas Emission Administrative Penalties and Appeals Regulation',
+      'Greenhouse Gas Emission Control Regulation',
+      'Greenhouse Gas Emission Reporting Regulation'
+    ],
+    'Greenhouse Gas Reduction (Renewable and Low Carbon Fuel Requirements) Act': [
+      'Renewable and Low Carbon Fuel Requirements Regulation'
+    ],
+    'Greenhouse Gas Reduction (Vehicle Emissions Standards) [not in force] Act': [],
+    'Greenhouse Gas Reduction Targets Act': ['Carbon Neutral Government Regulation'],
+    'Haida Gwaii Reconciliation Act': [],
+    'Heritage Conservation Act': ['Application Regulation'],
+    'Hunting and Fishing Heritage Act': [],
+    'Hydro and Power Authority Act': [
+      'Applicability Regulation No. 1',
+      'Applicability Regulation No. 2',
+      'Applicability Regulation No. 5',
+      'Applicability Regulation No. 6',
+      'Applicability Regulation No. 7'
+    ],
+    'Hydro Power Measures Act': [],
+    'Indian Advisory Act': [],
+    'Indian Cut-off Lands Disputes Act': [],
+    'Industrial Development Act': [],
+    'Industrial Operation Compensation Act': [],
+    'Insurance for Crops Act': ['Continuous Crop Insurance Regulation'],
+    'Integrated Pest Management Act': [
+      'Administrative Penalties (Integrated Pest Management Act) Regulation',
+      'Integrated Pest Management Regulation '
+    ],
+    'Land (Spouse Protection) Act': ['Forms Regulation'],
+    'Land Act': [
+      'Administrative Boundaries Regulation',
+      'Base Mapping and Geomatic Services Product and Services Price List Regulation',
+      'Crown Land Fees Regulation',
+      'Fossil Definition Regulation',
+      'Integrated Land and Resource Registry Regulation',
+      'Land Act Interest Rate Regulation',
+      'Land Act Regulation',
+      'Land Use Objectives Regulation',
+      'Subscription Fee Regulation'
+    ],
+    'Land Settlement and Development (Repeal) Act': [],
+    'Land Survey Act': ['Subdivision Plan Regulation'],
+    'Land Surveyors Act': [],
+    'Land Title Act': [
+      'Application for Subdivision Approval Regulation',
+      'Incompatibility Regulation',
+      'Land Title Act (Board of Directors) Regulation',
+      'Land Title Act Regulation',
+      'Sechelt Indian Band Designation Regulation',
+      'Torrens System Application Regulation'
+    ],
+    'Land Title and Survey Authority Act': [],
+    'Land Title Inquiry Act': [],
+    'Land Transfer Form Act': [],
+    'Libby Dam Reservoir Act': [],
+    'Liquor Control and Licensing Act': [],
+    'Livestock Act': ['Livestock Regulations', 'Pound Districts Regulation'],
+    'Livestock Identification Act': ['Livestock Identification Regulation'],
+    'Livestock Lien Act': [],
+    'Local Government Act': [],
+    'Maa-nulth First Nations Final Agreement Act': ['Maa-nulth Forest Compensation Interim Regulation'],
+    'McLeod Lake Indian Band Treaty No. 8 Adhesion and Settlement Agreement Act': [],
+    'Migratory Birds Convention Act': ['Migratory Bird Regulations', 'Migratory Bird Sanctuary Regulations'],
+    'Milk Industry Act': ['Milk Industry Standards Regulation'],
+    'Mineral Land Tax Act': [
+      'Agricultural Mineral Land Regulation',
+      'Certificate of Forfeiture Form Regulation',
+      'Mineral Land Tax Adjustment Regulation',
+      'Mineral Land Tax Interest Rate Regulation',
+      'Small Amount Notices Regulation',
+      'Surrender of Interests in Mineral Land Regulations'
+    ],
+    'Mineral Tax Act': [
+      'Mineral Tax Costs and Expenditures Regulation',
+      'Mineral Tax Disposition of a Mine Regulation',
+      'Mineral Tax General Regulation',
+      'Mineral Tax Reclamation Regulation',
+      'Mineral Tax Return Form Regulation',
+      'Mineral Tax Transitional Regulation',
+      'Partnership Election Form Regulation',
+      'Quarry Operator Election Form Regulation'
+    ],
+    'Mineral Tenure Act': [
+      'Mineral and Coal Land Reserve (No Mineral Claim Registrations) Regulation',
+      'Mineral and Coal Land Reserve (No Mineral or Placer Claim Registrations) Regulation',
+      'Mineral Definition Modification Regulation',
+      'Mineral Land Reserve (Conditional Mineral and Placer Claim Registrations) Regulation',
+      'Mineral Land Reserve (Conditional Mineral Claim Registrations) Regulation',
+      'Mineral Land Reserve (No Mineral Claim Registrations) Regulation',
+      'Mineral Land Reserve (No Mineral or Placer Claim Registrations) Regulation',
+      'Mineral Land Reserve (No Placer Claim Registrations) Regulation',
+      'Mineral Tenure Act Regulation',
+      'Mineral Title Online Grid Regulation',
+      'Mining Rights Compensation Regulation'
+    ],
+    'Mines Act': [
+      'Administrative Penalties (Mines) Regulation',
+      'Mine Reclamation Fund Regulation',
+      'Mines Fee Regulation',
+      'Mines Regulation',
+      'Notice of Debt Form Regulation',
+      'Permit Regulation',
+      'Workplace Hazardous Materials Information System Regulation (Mines)'
+    ],
+    'Mining Right of Way Act': [],
+    'Ministry of Agriculture and Food Act': ['Laboratory Fees Regulation'],
+    'Ministry of Energy and Mines Act': ['Mount Polley Investigation and Inquiry Regulation'],
+    'Ministry of Environment Act': [],
+    'Ministry of Forests and Range Act': [],
+    'Ministry of Lands, Parks and Housing Act': [
+      'Affordable Housing Purposes Regulation',
+      'British Columbia Housing Management Commission Regulation',
+      'Certificate Regulation',
+      'Crown Land Fees Regulation',
+      'Sole Proponent Fees Regulation'
+    ],
+    'Motor Vehicle (all terrain) Act': [],
+    'Motor Vehicle Act': ['Motor Vehicle Act Regulations'],
+    'Muskwa-Kechika Management Area Act': ['Muskwa-Kechika Management Plan Regulation'],
+    'Musqueam Reconciliation, Settlement and Benefits Agreement Implementation Act': [
+      'Musqueam Reconciliation, Settlement and Benefits Agreement Implementation Regulation'
+    ],
+    'Natural Gas Price Act': ['Natural Gas Price Act Regulation No. 2'],
+    'Natural Products Marketing (BC) Act': [
+      'B.C. Egg Marketing Board Powers and Duties Regulation No. 1',
+      'B.C. Egg Marketing Board Powers and Duties Regulation No. 3',
+      'British Columbia Broiler Hatching Egg Scheme',
+      'British Columbia Chicken Marketing Scheme, 1961',
+      'British Columbia Cranberry Marketing Scheme, 1968',
+      'British Columbia Egg Marketing Scheme, 1967',
+      'British Columbia Hog Marketing Scheme',
+      'British Columbia Milk Marketing Board Regulation',
+      'British Columbia Turkey Marketing Scheme',
+      'British Columbia Vegetable Scheme',
+      'Natural Products Marketing (BC) Act Regulations'
+    ],
+    'Natural Resource Compliance Act': ['Natural Resource Officer Authority Regulation'],
+    'New Relationship Trust Act': [],
+    "Nisga'a Final Agreement Act": [],
+    'Off-Road Vehicle Act': ['Off-Road Vehicle Regulation'],
+    'Oil and Gas Activities Act': [
+      'Administrative Penalties Regulation',
+      'Consultation and Notification Regulation',
+      'Direction No. 1 to the Oil and Gas Commission',
+      'Drilling and Production Regulation',
+      'Emergency Management Regulation',
+      'Environmental Protection and Management Regulation',
+      'Fee, Levy and Security Regulation',
+      'Geophysical Exploration Regulation',
+      'Liquefied Natural Gas Facility Regulation',
+      'Oil and Gas Activities Act General Regulation',
+      'Oil and Gas Road Regulation',
+      'Pipeline Crossings Regulation',
+      'Pipeline Regulation',
+      'Service Regulation'
+    ],
+    'Park Act': [
+      'Application of Park Legislation to Ecological Reserves Regulation',
+      'BC Parks Recreation User Fees Regulation',
+      'Class C Parks Regulations',
+      'Park, Conservancy and Recreation Area Regulation'
+    ],
+    'Petroleum and Natural Gas (Vancouver Island Railway Lands) Act': [],
+    'Petroleum and Natural Gas Act': [
+      'Long Term Royalty Agreements Regulation',
+      'Net Profit Royalty Regulation',
+      'Petroleum and Natural Gas Act Fee, Rental and Work Requirement Regulation',
+      'Petroleum and Natural Gas Drilling Licence and Lease Regulation',
+      'Petroleum and Natural Gas General Regulation',
+      'Petroleum and Natural Gas Grid Regulation',
+      'Petroleum and Natural Gas Royalty and Freehold Production Tax Regulation',
+      'Petroleum and Natural Gas Storage Reservoir Regulation',
+      'Surface Lease Information Regulation',
+      'Surface Lease Regulation'
+    ],
+    'Plant Protection Act': [
+      'Bacterial Ring Rot Regulation',
+      'Balsam Woolly Adelgid Regulation',
+      'Blueberry Maggot Control Regulation',
+      'Domestic Bacterial Ring Rot Regulation',
+      'Golden Nematode Regulation',
+      'Little Cherry Control Regulation',
+      'North American Gypsy Moth Eradication Regulation, 2017'
+    ],
+    'Power for Jobs Development Act': [],
+    'Prevention of Cruelty to Animals Act': [
+      'Cattery and Kennel Regulation',
+      'Dairy Cattle Regulation',
+      'Prevention of Cruelty to Animals Regulation',
+      'Sled Dog Standards of Care Regulation'
+    ],
+    'Private Managed Forest Land Act': [
+      'Private Managed Forest Land Council Matters Regulation',
+      'Private Managed Forest Land Council Regulation',
+      'Private Managed Forest Land Regulation'
+    ],
+    'Protected Areas Forests Compensation Act': [],
+    'Protected Areas of British Columbia Act': [],
+    'Railway Act': [],
+    'Range Act': ['Range Regulation'],
+    'Resort Timber Administration Act': [
+      'Controlled Recreation Area (Resort Timber Administration Act) Regulation',
+      'Resort Timber Administration Act (Specified Enactment) Regulation'
+    ],
+    'Riparian Areas Protection Act': ['Riparian Areas Regulation'],
+    'Sechelt Indian Government District Enabling Act': [
+      'Sechelt Indian Government District - Sunshine Coast Regional District Participation Regulation',
+      'Sechelt Indian Government District Advisory Council Regulation',
+      'Sechelt Indian Government District Enabling Act Continuation Regulation',
+      'Sechelt Indian Government District Municipal Benefits Regulation',
+      'Sechelt Indian Government District Property Taxation Suspension Regulation',
+      'Taxation Rate Cap for Class 2 Property Regulation'
+    ],
+    'Seed Potato Act': [
+      'Cariboo Certified Seed Potato Control Area Regulation',
+      'Pemberton Certified Seed Potato Control Area Regulation',
+      'Seed Potato Regulation'
+    ],
+    'Skagit Environmental Enhancement Act': [],
+    'Special Accounts Appropriation and Control Act': [],
+    'Sustainable Environment Fund Act': ['Sustainable Environment Fund Revenue Regulation'],
+    "Tla'amin Final Agreement Act": [
+      "Tla'amin Final Agreement Forest Compensation Regulation",
+      "Tla'amin Final Agreement Interim Regulation"
+    ],
+    'Treaty Commission Act': [],
+    'Treaty First Nation Taxation Act': [],
+    'Trespass Act': [],
+    'Tsawwassen First Nation Final Agreement Act': [
+      'Tsawwassen First Nation Final Agreement Interim Regulations',
+      'Tsawwassen First Nation Membership in the Greater Vancouver Water District Regulation'
+    ],
+    'Tugboat Worker Lien Act': ['Tugboat Worker Lien Fee Regulation'],
+    'University Endowment Land Act': [],
+    'Vancouver Island Natural Gas Pipeline Act': [
+      'Terasen Amalgamation Regulation',
+      'Vancouver Island Natural Gas Pipeline Exemption Regulation'
+    ],
+    'Veterinarians Act': [],
+    'Veterinary Drugs Act': ['Veterinary Drug and Medicated Feed Regulation'],
+    'Waste Management Act': [],
+    'Water Act': ['Water Regulation'],
+    'Water Protection Act': [],
+    'Water Sustainability Act': [
+      'Dam Safety Regulation',
+      'Ground Water Protection Regulation',
+      'Groundwater Protection Regulation',
+      'Water Districts Regulation',
+      'Water Sustainability Fees, Rentals and Charges Tariff Regulation',
+      'Water Sustainability Regulation'
+    ],
+    "Water User's Communities Act": [],
+    'Water Utility Act': [],
+    'Weed Control Act': ['Weed Control Regulation'],
+    'Wild Animal and Plant Protection Act': [],
+    'Wildlife Act': [
+      'Angling & Scientific Collection Regulation',
+      'Angling and Scientific Collection Regulation',
+      'Closed Areas Regulation',
+      'Controlled Alien Species Regulation',
+      'Designation and Exemption Regulation',
+      'Designation of Officers Regulation',
+      'Freshwater Fish Regulation',
+      'Forest Practices Board Regulation',
+      'Guiding Territory Certificate Regulation',
+      'Hunter Safety and Training Regulation',
+      'Hunter Safety Training Regulation',
+      'Hunting Licensing Regulation',
+      'Hunting Regulation',
+      'Limited Entry Hunting Regulation',
+      'Management Unit Regulation',
+      'Motor Vehicle Prohibition Regulation',
+      'Motor Vehicle Prohibition Regulations',
+      'Permit Regulation',
+      'Public Access Prohibition Regulation',
+      'Wildfire Regulation',
+      'Wildlife Act Commercial Activities Regulation',
+      'Wildlife Act General Regulation',
+      'Wildlife Management Area Use and Access Regulation',
+      'Wildlife Management Areas Regulation'
+    ],
+    'Wood First Act': [],
+    'Woodworker Lien Act': ['Woodworker Lien Fee Regulation'],
+    'Yale First Nation Final Agreement Act': [],
+    'Zero Net Deforestation Act': []
+  };
+
+  /**
+   * Returns an array of all supported legislation act strings.
+   *
+   * @static
+   * @memberof Picklists
+   * @returns {string[]} sorted array of acts
+   */
+  public static getAllActs = function(): string[] {
+    return Object.keys(this.legislationActsMappedToRegulations).sort();
+  };
+
+  /**
+   * Returns an array of all supported regulation strings.
+   *
+   * @static
+   * @memberof Picklists
+   * @returns {string[]} sorted array of regulations
+   */
+  public static getAllRegulations = function(): string[] {
+    const regulations = [];
+
+    Object.keys(this.legislationActsMappedToRegulations).forEach(act =>
+      regulations.push(...this.legislationActsMappedToRegulations[act])
+    );
+
+    return Array.from(new Set<string>(regulations)).sort();
+  };
+
+  /**
+   * Returns an object containing a mapping of regulations to acts.
+   *
+   * Object spec:
+   * {
+   *   "Regulation1": ["actA", "actB", ...]
+   *   "Regulation2": ["actC", ...]
+   *   ...
+   * }
+   *
+   * @static
+   * @memberof Picklists
+   * @returns {{ [key: string]: string[] }}
+   */
+  public static getLegislationRegulationsMappedToActs = function(): { [key: string]: string[] } {
+    const regulations = {};
+
+    Object.keys(this.legislationActsMappedToRegulations).forEach(act =>
+      this.legislationActsMappedToRegulations[act].map(regulation => {
+        if (regulations[regulation]) {
+          regulations[regulation].push(act);
+        } else {
+          regulations[regulation] = [act];
+        }
+      })
+    );
+
+    return regulations;
+  };
 }

--- a/angular/projects/common/src/app/models/master/administrative-penalty.ts
+++ b/angular/projects/common/src/app/models/master/administrative-penalty.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * AdministrativePenalty data model.
  *
@@ -19,7 +21,7 @@ export class AdministrativePenalty {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -54,7 +56,7 @@ export class AdministrativePenalty {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/administrative-sanction.ts
+++ b/angular/projects/common/src/app/models/master/administrative-sanction.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * AdministrativeSanction data model.
  *
@@ -19,7 +21,7 @@ export class AdministrativeSanction {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -54,7 +56,7 @@ export class AdministrativeSanction {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/certificate.ts
+++ b/angular/projects/common/src/app/models/master/certificate.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Certificate data model.
  *
@@ -22,7 +24,7 @@ export class Certificate {
   issuingAgency: string;
   author: string;
   description: string;
-  legislation: string;
+  legislation: Legislation;
   projectName: string;
   location: string;
   centroid: number[];
@@ -56,7 +58,7 @@ export class Certificate {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.description = (obj && obj.description) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/common-models/legislation.ts
+++ b/angular/projects/common/src/app/models/master/common-models/legislation.ts
@@ -1,0 +1,22 @@
+/**
+ * Legislation schema-field specification.
+ *
+ * Note: This is not itself a schema.  This is a field of existing schema(s).
+ *
+ * @class Legislation
+ */
+export class Legislation {
+  act: string;
+  regulation: string;
+  section: string;
+  subSection: string;
+  paragraph: string;
+
+  constructor(obj?: any) {
+    this.act = (obj && obj.act) || null;
+    this.regulation = (obj && obj.regulation) || null;
+    this.section = (obj && obj.section) || null;
+    this.subSection = (obj && obj.subSection) || null;
+    this.paragraph = (obj && obj.paragraph) || null;
+  }
+}

--- a/angular/projects/common/src/app/models/master/inspection.ts
+++ b/angular/projects/common/src/app/models/master/inspection.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Inspection data model.
  *
@@ -18,7 +20,7 @@ export class Inspection {
   issuingAgency: string;
   author: string;
   description: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -49,7 +51,7 @@ export class Inspection {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.description = (obj && obj.description) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/order.ts
+++ b/angular/projects/common/src/app/models/master/order.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Order data model.
  *
@@ -19,7 +21,7 @@ export class Order {
   issuingAgency: string;
   author: string;
   description: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -52,7 +54,7 @@ export class Order {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.description = (obj && obj.description) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/permit.ts
+++ b/angular/projects/common/src/app/models/master/permit.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Permit data model.
  *
@@ -19,7 +21,7 @@ export class Permit {
   recordSubtype: string;
   dateIssued: Date;
   issuingAgency: string;
-  legislation: string;
+  legislation: Legislation;
   projectName: string;
   location: string;
   centroid: number[];
@@ -50,7 +52,7 @@ export class Permit {
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/restorative-justice.ts
+++ b/angular/projects/common/src/app/models/master/restorative-justice.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * RestorativeJustice data model.
  *
@@ -19,7 +21,7 @@ export class RestorativeJustice {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -54,7 +56,7 @@ export class RestorativeJustice {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/self-report.ts
+++ b/angular/projects/common/src/app/models/master/self-report.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * SelfReport data model.
  *
@@ -19,7 +21,7 @@ export class SelfReport {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   projectName: string;
   location: string;
   centroid: number[];
@@ -50,7 +52,7 @@ export class SelfReport {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/ticket.ts
+++ b/angular/projects/common/src/app/models/master/ticket.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Ticket data model.
  *
@@ -19,7 +21,7 @@ export class Ticket {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -54,7 +56,7 @@ export class Ticket {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/models/master/warning.ts
+++ b/angular/projects/common/src/app/models/master/warning.ts
@@ -1,3 +1,5 @@
+import { Legislation } from './common-models/legislation';
+
 /**
  * Warning data model.
  *
@@ -19,7 +21,7 @@ export class Warning {
   dateIssued: Date;
   issuingAgency: string;
   author: string;
-  legislation: string;
+  legislation: Legislation;
   issuedTo: string; // epic value?
   projectName: string;
   location: string;
@@ -53,7 +55,7 @@ export class Warning {
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
-    this.legislation = (obj && obj.legislation) || null;
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
     this.issuedTo = (obj && obj.issuedTo) || null;
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;

--- a/angular/projects/common/src/app/utils/utils.ts
+++ b/angular/projects/common/src/app/utils/utils.ts
@@ -1,0 +1,40 @@
+import { Legislation } from '../models/master/common-models/legislation';
+
+export class Utils {
+  /**
+   * Given a Legislation object, return a formatted legislation string.
+   *
+   * @param {Legislation} obj
+   * @returns {string} formatted legislation string, or empty string if no legislation values are set.
+   * @memberof Utils
+   */
+  public static buildLegislationString(obj: Legislation): string {
+    if (!obj) {
+      return '';
+    }
+
+    const legistrationStrings = [];
+
+    if (obj.act) {
+      legistrationStrings.push(obj.act);
+    }
+
+    if (obj.regulation) {
+      legistrationStrings.push(obj.regulation);
+    }
+
+    if (obj.section) {
+      legistrationStrings.push(obj.section);
+    }
+
+    if (obj.subSection) {
+      legistrationStrings.push(`(${obj.subSection})`);
+    }
+
+    if (obj.paragraph) {
+      legistrationStrings.push(`(${obj.paragraph})`);
+    }
+
+    return legistrationStrings.join(' ');
+  }
+}

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -25,65 +25,92 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Penalty</span>
-            <span class="grid-item-value">{{ (data && data._master.penalty) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.penalty) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -25,65 +25,92 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Penalty</span>
-            <span class="grid-item-value">{{ (data && data._master.penalty) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.penalty) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -25,61 +25,88 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -25,61 +25,88 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -25,65 +25,92 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Penalty</span>
-            <span class="grid-item-value">{{ (data && data._master.penalty) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.penalty) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -25,65 +25,92 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Penalty</span>
-            <span class="grid-item-value">{{ (data && data._master.penalty) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.penalty) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -25,61 +25,88 @@
     <section class="content-section" *ngIf="isTabActive('detail')">
       <div class="content-grid">
         <div class="grid-section-1">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity</span>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued To</span>
-            <span class="grid-item-value">{{ (data && data._master.issuedTo) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuedTo) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Activity Type</span>
-            <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issued On</span>
             <span class="gird-item-value">{{ (data && data._master.dateIssued | date: 'mediumDate') || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-2">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Summary</span>
-            <span class="grid-item-value">{{ (data && data.summary) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data.summary) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Issuing Agency</span>
-            <span class="grid-item-value">{{ (data && data._master.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.issuingAgency) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Legislation</span>
-            <span class="grid-item-value">{{ (data && data._master.legislation) || '-' }}</span>
+            <div class="grid-item-value">
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Act</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.act) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__flex">
+                <span class="grid-item-name">Regulation</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.regulation) || '-' }}
+                </span>
+              </div>
+              <div class="grid-item__row">
+                <span class="grid-item-name">Section (Sub-Section) (Paragraph)</span>
+                <span class="grid-item-value">
+                  {{ (data && data._master && data._master.legislation && data._master.legislation.section) || '-' }}
+                  ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.subSection) || '-'
+                  }}) ({{
+                    (data && data._master && data._master.legislation && data._master.legislation.paragraph) || '-'
+                  }})
+                </span>
+              </div>
+            </div>
           </div>
         </div>
         <div class="grid-section-3">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Site/Project</span>
-            <span class="grid-item-value">{{ (data && data._master.projectName) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.projectName) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Location Description</span>
-            <span class="grid-item-value">{{ (data && data._master.location) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.location) || '-' }}</span>
           </div>
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Lat/Long</span>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
           </div>
         </div>
         <div class="grid-section-5">
-          <div class="grid-item">
+          <div class="grid-item__row">
             <span class="grid-item-name">Documents</span>
-            <span class="grid-item-value" *ngIf="data && data._master.documents && data._master.documents.length > 0">
+            <span
+              class="grid-item-value__col"
+              *ngIf="data && data._master.documents && data._master.documents.length > 0"
+            >
               <span *ngFor="let document of data && data._master.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>
             <span
-              class="grid-item-value"
+              class="grid-item-value__col"
               *ngIf="!(data && data._master.documents && data._master.documents.length > 0)"
             >
               This record does not have documents

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.scss
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.scss
@@ -1,147 +1,59 @@
-.detail-page {
-  .nav-section {
-    font-weight: 600;
-    text-align: center;
+// base scss found in record-details.scss
 
-    .nav-items {
-      padding: 0;
-      list-style-type: none;
-      border-bottom: 1px solid black;
+.grid-section-1 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 2fr 2fr;
+}
 
-      .nav-item {
-        margin: 0 2rem;
-        font-weight: 600;
-        cursor: pointer;
-        display: inline-block;
+.grid-section-2 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        &.active {
-          border-bottom: 4px solid black;
-        }
+.grid-section-3 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: 3fr 2fr 4fr;
+}
 
-        .nav-item-icon {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.5rem;
-        }
+.grid-section-4 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+}
 
-        .nav-item-value {
-          display: inline;
-          vertical-align: middle;
-          font-size: 1.25rem;
-          margin-left: 0.25rem;
-        }
-      }
+.grid-section-5 {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: auto;
+}
 
-      @media screen and (max-width: 768px) {
-        .nav-item {
-          margin: 0 0.5rem;
-        }
-      }
-    }
+@media screen and (max-width: 768px) {
+  .grid-section-1 {
+    grid-template-columns: none;
   }
 
-  .content-section {
-    margin: 0.5rem;
-    padding: 0.5rem;
+  .grid-section-2 {
+    grid-template-columns: none;
+  }
 
-    .content-grid {
-      display: grid;
-      grid-template-rows: auto;
-      grid-gap: 1.25rem;
+  .grid-section-3 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-1 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 2fr 2fr;
-      }
+  .grid-section-4 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-2 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
+  .grid-section-5 {
+    grid-template-columns: none;
+  }
 
-      .grid-section-3 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: 3fr 2fr 4fr;
-      }
-
-      .grid-section-4 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      }
-
-      .grid-section-5 {
-        display: grid;
-        grid-gap: 0.75rem;
-        grid-template-columns: auto;
-      }
-
-      .grid-item {
-        display: grid;
-        grid-template-rows: auto;
-        grid-gap: 0.25rem;
-
-        .grid-item-name {
-          font-weight: 600;
-          font-size: 1rem;
-        }
-
-        .grid-item-value {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-          font-weight: 400;
-          font-size: 1rem;
-
-          .grid-sub-item {
-            display: grid;
-            grid-template-rows: auto;
-            grid-gap: 0.25rem;
-
-            .grid-sub-item-name {
-              display: grid;
-              font-weight: 600;
-              font-size: 0.75rem;
-            }
-
-            .grid-sub-item-value {
-              display: grid;
-              font-weight: 400;
-              font-size: 0.75rem;
-            }
-          }
-        }
-      }
-
-      @media screen and (max-width: 768px) {
-        .grid-section-1 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-2 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-3 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-4 {
-          grid-template-columns: none;
-        }
-
-        .grid-section-5 {
-          grid-template-columns: none;
-        }
-
-        .grid-item {
-          grid-template-rows: none;
-          grid-template-columns: 1fr 2fr;
-          grid-gap: 0.625rem;
-        }
-      }
-    }
+  .grid-item__row {
+    grid-template-rows: none;
+    grid-template-columns: 1fr 2fr;
+    grid-gap: 0.625rem;
   }
 }

--- a/angular/projects/public-nrpti/src/app/services/api.service.ts
+++ b/angular/projects/public-nrpti/src/app/services/api.service.ts
@@ -89,7 +89,9 @@ export class ApiService {
 
   private downloadResource(id: string): Promise<Blob> {
     const queryString = `document/${id}/download`;
-    return this.http.get<Blob>(this.pathAPI + '/' + queryString, { responseType: 'blob' as 'json' }).toPromise();
+    return this.http
+      .get<Blob>(this.pathAPI + '/' + queryString, { responseType: 'blob' as 'json' })
+      .toPromise();
   }
 
   public async downloadDocument(document: Document): Promise<void> {

--- a/angular/projects/public-nrpti/src/assets/styles/components/record-details.scss
+++ b/angular/projects/public-nrpti/src/assets/styles/components/record-details.scss
@@ -1,0 +1,114 @@
+.detail-page {
+  .nav-section {
+    font-weight: 600;
+    text-align: center;
+
+    .nav-items {
+      padding: 0;
+      list-style-type: none;
+      border-bottom: 1px solid black;
+
+      .nav-item {
+        margin: 0 2rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-block;
+
+        &.active {
+          border-bottom: 4px solid black;
+        }
+
+        .nav-item-icon {
+          display: inline;
+          vertical-align: middle;
+          font-size: 1.5rem;
+        }
+
+        .nav-item-value {
+          display: inline;
+          vertical-align: middle;
+          font-size: 1.25rem;
+          margin-left: 0.25rem;
+        }
+      }
+
+      @media screen and (max-width: 768px) {
+        .nav-item {
+          margin: 0 0.5rem;
+        }
+      }
+    }
+  }
+
+  .content-section {
+    margin: 0.5rem;
+    padding: 0.5rem;
+
+    .content-grid {
+      display: grid;
+      grid-template-rows: auto;
+      grid-gap: 1.25rem;
+      font-size: 1.25rem; // Child items use 0.8em, allowing <grid-item> to be nested inside <grid-item-value> and having the font-size scale automatically.
+
+      // Can also be nested inside <grid-item-value> - font-size scales automatically (re: 0.8em).
+      .grid-item {
+        display: grid;
+        grid-gap: 0.25rem;
+        font-size: 0.8em;
+
+        &__col {
+          @extend .grid-item;
+
+          grid-gap: 0.75rem;
+          grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+        }
+
+        &__row {
+          @extend .grid-item;
+
+          grid-template-rows: min-content;
+        }
+
+        &__flex {
+          @extend .grid-item;
+
+          grid-gap: 0.5rem;
+          display: flex;
+        }
+
+        .grid-item-name {
+          font-weight: 600;
+
+          &__col {
+            @extend .grid-item-value;
+
+            grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+          }
+
+          &__row {
+            @extend .grid-item-value;
+
+            grid-template-rows: repeat(auto-fit, minmax(0, max-content));
+          }
+        }
+
+        .grid-item-value {
+          display: grid;
+          font-weight: 400;
+
+          &__col {
+            @extend .grid-item-value;
+
+            grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+          }
+
+          &__row {
+            @extend .grid-item-value;
+
+            grid-template-rows: repeat(auto-fit, minmax(100px, max-content));
+          }
+        }
+      }
+    }
+  }
+}

--- a/angular/projects/public-nrpti/src/styles.scss
+++ b/angular/projects/public-nrpti/src/styles.scss
@@ -35,6 +35,7 @@
 @import "assets/styles/components/spinner.scss";
 @import "assets/styles/components/tab-nav.scss";
 @import "assets/styles/components/table.scss";
+@import "assets/styles/components/record-details.scss"; // record list detail expand
 
 // Third-party Components
 // Required for Angular Material styling: (ref: https://material.angular.io/guide/theming)

--- a/api/migrations/20200211065122-nrcedData.js
+++ b/api/migrations/20200211065122-nrcedData.js
@@ -16,13 +16,13 @@ const CSV_FILENAME = 'nrced-data.csv';
  * We receive the dbmigrate dependency from dbmigrate initially.
  * This enables us to not have to rely on NODE_PATH.
  */
-exports.setup = function (options, seedLink) {
+exports.setup = function(options, seedLink) {
   dbm = options.dbmigrate;
   type = dbm.dataType;
   seed = seedLink;
 };
 
-exports.up = async function (db) {
+exports.up = async function(db) {
   console.log('---------------------------------------------------------------');
   console.log(`Inserting records from csv file: '${CSV_FILENAME}'`);
 
@@ -119,7 +119,7 @@ exports.up = async function (db) {
     });
 };
 
-const createAdministrativePenalty = async function (row, nrptiCollection) {
+const createAdministrativePenalty = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.AdministrativePenalty._schemaName,
     read: ['sysadmin'],
@@ -133,7 +133,13 @@ const createAdministrativePenalty = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '').replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -141,7 +147,7 @@ const createAdministrativePenalty = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     penalty: row[19],
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -172,7 +178,7 @@ const createAdministrativePenalty = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createAdministrativeSanction = async function (row, nrptiCollection) {
+const createAdministrativeSanction = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.AdministrativeSanction._schemaName,
     read: ['sysadmin'],
@@ -186,7 +192,13 @@ const createAdministrativeSanction = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -194,7 +206,7 @@ const createAdministrativeSanction = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     penalty: row[19],
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -225,12 +237,12 @@ const createAdministrativeSanction = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createCourtConviction = async function (row, nrptiCollection) {
+const createCourtConviction = async function(row, nrptiCollection) {
   // TODO when court convictions are ready
   return;
 };
 
-const createInspection = async function (row, nrptiCollection) {
+const createInspection = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.Inspection._schemaName,
     read: ['sysadmin'],
@@ -244,7 +256,13 @@ const createInspection = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -252,7 +270,7 @@ const createInspection = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     // penalty: '',
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -283,7 +301,7 @@ const createInspection = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createOrder = async function (row, nrptiCollection) {
+const createOrder = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.Order._schemaName,
     read: ['sysadmin'],
@@ -297,7 +315,13 @@ const createOrder = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -305,7 +329,7 @@ const createOrder = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     // penalty: '',
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -336,7 +360,7 @@ const createOrder = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createRestorativeJustice = async function (row, nrptiCollection) {
+const createRestorativeJustice = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.RestorativeJustice._schemaName,
     read: ['sysadmin'],
@@ -350,7 +374,13 @@ const createRestorativeJustice = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -358,7 +388,7 @@ const createRestorativeJustice = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     penalty: row[19],
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -389,7 +419,7 @@ const createRestorativeJustice = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createTicket = async function (row, nrptiCollection) {
+const createTicket = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.Ticket._schemaName,
     read: ['sysadmin'],
@@ -403,7 +433,13 @@ const createTicket = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
@@ -411,7 +447,7 @@ const createTicket = async function (row, nrptiCollection) {
     // outcomeStatus: '',
     // outcomeDescription: '',
     penalty: row[19],
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -442,7 +478,7 @@ const createTicket = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-const createWarning = async function (row, nrptiCollection) {
+const createWarning = async function(row, nrptiCollection) {
   const masterRecord = {
     _schemaName: RECORD_TYPE.Warning._schemaName,
     read: ['sysadmin'],
@@ -457,14 +493,20 @@ const createWarning = async function (row, nrptiCollection) {
       .toDate(),
     // issuingAgency: '',
     // author: '',
-    legislation: `${row[11]} ${row[12]} ${row[13]} ${row[14].replace(/^-(.*)/, '($1)')} ${row[15]}`,
+    legislation: {
+      act: row[11],
+      regulation: row[12],
+      section: row[13],
+      subSection: row[14].replace(/[()]/g, ''),
+      paragraph: row[15].replace(/[()]/g, '')
+    },
     issuedTo: row[3],
     // projectName: '',
     location: row[10],
     // centroid: '',
     // outcomeStatus: '',
     // outcomeDescription: '',
-    documents: [],
+    // attachments: null,
 
     dateAdded: new Date(),
     dateUpdated: new Date(),
@@ -495,7 +537,7 @@ const createWarning = async function (row, nrptiCollection) {
   // console.log('Inserted FlavourNRCEDID:', responseflavourNRCED.insertedId.toString());
 };
 
-exports.down = function (db) {
+exports.down = function(db) {
   return null;
 };
 

--- a/api/src/controllers/document-controller.js
+++ b/api/src/controllers/document-controller.js
@@ -12,11 +12,11 @@ const s3 = new AWS.S3({
   signatureVersion: 'v4'
 });
 
-exports.protectedOptions = function (args, res, next) {
+exports.protectedOptions = function(args, res, next) {
   res.status(200).send();
 };
 
-exports.protectedPost = async function (args, res, next) {
+exports.protectedPost = async function(args, res, next) {
   if (args.swagger.params.data && args.swagger.params.data.value) {
     let data = args.swagger.params.data.value;
 
@@ -29,17 +29,13 @@ exports.protectedPost = async function (args, res, next) {
       if (data[i].url) {
         // If the document already has a url we can assume it's a link
         promises.push(
-          createLinkDocument(
-            data[i].fileName,
-            (this.auth_payload && this.auth_payload.displayName) || '',
-            data[i].url
-          )
+          createLinkDocument(data[i].fileName, (this.auth_payload && this.auth_payload.displayName) || '', data[i].url)
         );
       } else {
         // TODO: If it doesn't then we are uploading to S3.
       }
     }
-    // Execute 
+    // Execute
     try {
       let response = await Promise.all(promises);
       return queryActions.sendResponse(res, 200, response);
@@ -49,10 +45,10 @@ exports.protectedPost = async function (args, res, next) {
   } else {
     return queryActions.sendResponse(res, 400, { error: 'You must provide data' });
   }
-}
+};
 
 // WIP
-exports.protectedPut = async function (args, res, next) {
+exports.protectedPut = async function(args, res, next) {
   if (args.swagger.params.data && args.swagger.params.data.value) {
     const data = args.swagger.params.data.value;
 
@@ -97,7 +93,7 @@ async function createLinkDocument(fileName, addedBy, url) {
   document.read = ['public', 'sysadmin'];
   document.write = ['sysadmin'];
   return await document.save();
-};
+}
 
 // WIP
 function createSignedUrl(operation, key) {

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -40,6 +40,21 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (administrativePenalty.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativePenalty.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (administrativePenalty.author = incomingObj.author);
+  incomingObj.legislation &&
+    incomingObj.legislation.act &&
+    (administrativePenalty.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (administrativePenalty.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (administrativePenalty.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (administrativePenalty.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (administrativePenalty.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (administrativePenalty.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (administrativePenalty.projectName = incomingObj.projectName);
   incomingObj.location && (administrativePenalty.location = incomingObj.location);

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -40,6 +40,21 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (administrativeSanction.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativeSanction.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (administrativeSanction.author = incomingObj.author);
+  incomingObj.legislation &&
+    incomingObj.legislation.act &&
+    (administrativeSanction.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (administrativeSanction.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (administrativeSanction.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (administrativeSanction.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (administrativeSanction.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (administrativeSanction.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (administrativeSanction.projectName = incomingObj.projectName);
   incomingObj.location && (administrativeSanction.location = incomingObj.location);

--- a/api/src/controllers/post/certificate.js
+++ b/api/src/controllers/post/certificate.js
@@ -39,7 +39,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   certificate.recordType = RECORD_TYPE.Certificate.displayName;
   incomingObj.dateIssued && (certificate.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (certificate.issuingAgency = incomingObj.issuingAgency);
-  incomingObj.legislation && (certificate.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (certificate.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (certificate.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (certificate.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (certificate.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (certificate.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (certificate.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (certificate.projectName = incomingObj.projectName);
   incomingObj.location && (certificate.location = incomingObj.location);

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -34,7 +34,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (inpsection.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (inpsection.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (inpsection.author = incomingObj.author);
-  incomingObj.legislation && (inpsection.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (inpsection.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (inpsection.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (inpsection.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (inpsection.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (inpsection.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (inpsection.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (inpsection.projectName = incomingObj.projectName);
   incomingObj.location && (inpsection.location = incomingObj.location);

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -35,7 +35,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (order.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (order.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (order.author = incomingObj.author);
-  incomingObj.legislation && (order.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (order.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (order.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (order.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (order.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (order.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (order.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (order.projectName = incomingObj.projectName);
   incomingObj.location && (order.location = incomingObj.location);
@@ -56,7 +68,7 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   let documents = [];
   if (incomingObj.documents && Array.isArray(incomingObj.documents)) {
     for (let i = 0; i < incomingObj.documents.length; i++) {
-      ObjectId.isValid(incomingObj.documents[i]) && (documents.push(incomingObj.documents[i]));
+      ObjectId.isValid(incomingObj.documents[i]) && documents.push(incomingObj.documents[i]);
     }
   }
   order.documents = documents;

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -40,7 +40,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.recordSubtype && (permit.recordName = incomingObj.recordSubtype);
   incomingObj.dateIssued && (permit.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (permit.issuingAgency = incomingObj.issuingAgency);
-  incomingObj.legislation && (permit.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (permit.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (permit.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (permit.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (permit.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (permit.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (permit.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (permit.projectName = incomingObj.projectName);
   incomingObj.location && (permit.location = incomingObj.location);

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -40,6 +40,21 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (restorativeJustice.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (restorativeJustice.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (restorativeJustice.author = incomingObj.author);
+  incomingObj.legislation &&
+    incomingObj.legislation.act &&
+    (restorativeJustice.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (restorativeJustice.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (restorativeJustice.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (restorativeJustice.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (restorativeJustice.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (restorativeJustice.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (restorativeJustice.projectName = incomingObj.projectName);
   incomingObj.location && (restorativeJustice.location = incomingObj.location);

--- a/api/src/controllers/post/self-report.js
+++ b/api/src/controllers/post/self-report.js
@@ -40,7 +40,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (selfReport.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (selfReport.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (selfReport.author = incomingObj.author);
-  incomingObj.legislation && (selfReport.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (selfReport.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (selfReport.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (selfReport.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (selfReport.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (selfReport.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.projectName && (selfReport.projectName = incomingObj.projectName);
   incomingObj.location && (selfReport.location = incomingObj.location);
   incomingObj.centroid && (selfReport.centroid = incomingObj.centroid);

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -40,7 +40,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (ticket.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (ticket.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (ticket.author = incomingObj.author);
-  incomingObj.legislation && (ticket.legislation = incomingObj.legislation);
+  incomingObj.legislation && incomingObj.legislation.act && (ticket.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (ticket.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (ticket.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (ticket.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (ticket.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (ticket.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (ticket.projectName = incomingObj.projectName);
   incomingObj.location && (ticket.location = incomingObj.location);

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -40,6 +40,19 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   incomingObj.dateIssued && (warning.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (warning.issuingAgency = incomingObj.issuingAgency);
   incomingObj.author && (warning.author = incomingObj.author);
+  incomingObj.legislation && incomingObj.legislation.act && (warning.legislation.act = incomingObj.legislation.act);
+  incomingObj.legislation &&
+    incomingObj.legislation.regulation &&
+    (warning.legislation.regulation = incomingObj.legislation.regulation);
+  incomingObj.legislation &&
+    incomingObj.legislation.section &&
+    (warning.legislation.section = incomingObj.legislation.section);
+  incomingObj.legislation &&
+    incomingObj.legislation.subSection &&
+    (warning.legislation.subSection = incomingObj.legislation.subSection);
+  incomingObj.legislation &&
+    incomingObj.legislation.paragraph &&
+    (warning.legislation.paragraph = incomingObj.legislation.paragraph);
   incomingObj.issuedTo && (warning.issuedTo = incomingObj.issuedTo);
   incomingObj.projectName && (warning.projectName = incomingObj.projectName);
   incomingObj.location && (warning.location = incomingObj.location);

--- a/api/src/controllers/put/order.js
+++ b/api/src/controllers/put/order.js
@@ -42,7 +42,7 @@ exports.editMaster = async function(args, res, next, incomingObj) {
   let documents = [];
   if (incomingObj.documents && Array.isArray(incomingObj.documents)) {
     for (let i = 0; i < incomingObj.documents.length; i++) {
-      ObjectId.isValid(incomingObj.documents[i]) && (documents.push(incomingObj.documents[i]));
+      ObjectId.isValid(incomingObj.documents[i]) && documents.push(incomingObj.documents[i]);
     }
   }
   incomingObj.documents = documents;

--- a/api/src/models/master/administrativePenalty.js
+++ b/api/src/models/master/administrativePenalty.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/administrativeSanction.js
+++ b/api/src/models/master/administrativeSanction.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/certificate.js
+++ b/api/src/models/master/certificate.js
@@ -17,7 +17,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
     description: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],

--- a/api/src/models/master/inspection.js
+++ b/api/src/models/master/inspection.js
@@ -18,7 +18,13 @@ module.exports = require('../../utils/model-schema-generator')(
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
     description: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/order.js
+++ b/api/src/models/master/order.js
@@ -18,7 +18,13 @@ module.exports = require('../../utils/model-schema-generator')(
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
     description: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/permit.js
+++ b/api/src/models/master/permit.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],

--- a/api/src/models/master/restorativeJustice.js
+++ b/api/src/models/master/restorativeJustice.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/selfReport.js
+++ b/api/src/models/master/selfReport.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],

--- a/api/src/models/master/ticket.js
+++ b/api/src/models/master/ticket.js
@@ -16,7 +16,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: Date.now() },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },

--- a/api/src/models/master/warning.js
+++ b/api/src/models/master/warning.js
@@ -17,7 +17,13 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },
     author: { type: String, default: '' },
-    legislation: { type: String, default: '' },
+    legislation: {
+      act: { type: String, default: '' },
+      regulation: { type: String, default: '' },
+      section: { type: String, default: '' },
+      subSection: { type: String, default: '' },
+      paragraph: { type: String, default: '' }
+    },
     issuedTo: { type: String, default: '' },
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },


### PR DESCRIPTION
I've tried to keep the commits distinct (see commit messages for each).

### Commit 1
- Created common-components/legislation-add-edit.component.ts
  - This contains all of the logic needed to make the legislation section work, specific to our records add-edit pages.
- Added acts/regulations to record constants file

### Commit 2
- Update angular models.

### Commit 3
- Update api models.

### Commit 4
- Update api controllers.

### Commit 5
- Build and display legislation string on the admin details pages.

### Commit 6
- Display Legislation fields on the public nrced details expand pages.
  - Updated the scss to render the legislation details properly.
- Moved all shared scss to a new scss file in assets.
  - There is little or no duplication of scss now, as they all use classes in the base class, and only specify component specific logic, like what their unique field layouts are.
    - This same type of change could be done for other classes, but I only updated these detail expand ones because I needed to touch the scss anyways, so it seemed like an appropriate time to simplify it all.

### Commit 7
- Update nrced csv migration to use new legislation schema