### PR TITLE
PTI-411: Improve search performance + sort fix.

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/records-list/records-list.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/records-list/records-list.component.ts
@@ -37,7 +37,7 @@ export class RecordsListComponent implements OnInit, OnDestroy {
   public tableColumns: IColumnObject[] = [
     {
       name: 'Issued To',
-      value: 'projectName',
+      value: 'issuedTo',
       width: 'col-2'
     },
     {

--- a/angular/projects/public-nrpti/src/app/records/records-list/records-list.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/records-list/records-list.component.ts
@@ -52,7 +52,7 @@ export class RecordsListComponent implements OnInit, OnDestroy {
     },
     {
       name: 'Issued To',
-      value: 'documentFileName',
+      value: 'issuedTo',
       width: 'col-3'
     },
     {


### PR DESCRIPTION
I was playing with the admin list page, and noticed that the page still took a while to load.

Poked around at the search.js and noticed the $lookup for documents and flavours happened before the page limit step.  Moved it to after this step and now its much faster.

The only drawback is that, currently, you wouldn't be able to filter on documents or flavours, since the $lookup would need to happen earlier for that to work.  If we even need that ability, we would probably need to add some kind of check that recognized a sort on a document or flavour field, and then tack on the $lookup earlier, rather than later.

Also included 2 minor table column sorting fixes, because I happened to notice they were wrong during this testing.