### PR TITLE
PTI-411: Update common models for new arch/schemas

### DIFF
--- a/angular/projects/common/src/app/models/lng/administrative-penalty-lng.ts
+++ b/angular/projects/common/src/app/models/lng/administrative-penalty-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * AdministrativePenalty LNG data model.
  *
@@ -7,10 +9,28 @@
 export class AdministrativePenaltyLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +38,52 @@ export class AdministrativePenaltyLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'AdministrativePenaltyLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/administrative-sanction-lng.ts
+++ b/angular/projects/common/src/app/models/lng/administrative-sanction-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * AdministrativeSanction LNG data model.
  *
@@ -7,10 +9,28 @@
 export class AdministrativeSanctionLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +38,52 @@ export class AdministrativeSanctionLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'AdministrativeSanctionLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/agreement-lng.ts
+++ b/angular/projects/common/src/app/models/lng/agreement-lng.ts
@@ -7,10 +7,20 @@
 export class AgreementLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  nationName: string;
+  projectName: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +28,44 @@ export class AgreementLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'AgreementLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.nationName = (obj && obj.nationName) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/certificate-lng.ts
+++ b/angular/projects/common/src/app/models/lng/certificate-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Certificate LNG data model.
  *
@@ -7,10 +9,25 @@
 export class CertificateLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  recordSubtype: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  documents: object[];
 
   description: string;
 
@@ -18,18 +35,49 @@ export class CertificateLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'CertificateLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.recordSubtype = (obj && obj.recordSubtype) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/construction-plan-lng.ts
+++ b/angular/projects/common/src/app/models/lng/construction-plan-lng.ts
@@ -7,31 +7,71 @@
 export class ConstructionPlanLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
 
-  relatedPhase: string;
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  agency: string;
+  author: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  documents: object[];
+
   description: string;
 
   dateAdded: Date;
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'ConstructionPlanLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.relatedPhase = (obj && obj.relatedPhase) || null;
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.agency = (obj && obj.agency) || '';
+    this.author = (obj && obj.author) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.documents = (obj && obj.documents) || [];
+
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/inspection-lng.ts
+++ b/angular/projects/common/src/app/models/lng/inspection-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Inspection LNG data model.
  *
@@ -7,10 +9,27 @@
 export class InspectionLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +37,51 @@ export class InspectionLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'InspectionLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/management-plan-lng.ts
+++ b/angular/projects/common/src/app/models/lng/management-plan-lng.ts
@@ -7,31 +7,71 @@
 export class ManagementPlanLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
 
-  relatedPhase: string;
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  agency: string;
+  author: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  documents: object[];
+
   description: string;
 
   dateAdded: Date;
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'ManagementPlanLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.relatedPhase = (obj && obj.relatedPhase) || null;
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.agency = (obj && obj.agency) || '';
+    this.author = (obj && obj.author) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.documents = (obj && obj.documents) || [];
+
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/order-lng.ts
+++ b/angular/projects/common/src/app/models/lng/order-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Order LNG data model.
  *
@@ -7,10 +9,28 @@
 export class OrderLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  recordSubtype: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +38,52 @@ export class OrderLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'OrderLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.recordSubtype = (obj && obj.recordSubtype) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/permit-lng.ts
+++ b/angular/projects/common/src/app/models/lng/permit-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Permit LNG data model.
  *
@@ -7,10 +9,24 @@
 export class PermitLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  recordSubtype: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  legislation: Legislation;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  documents: object[];
 
   description: string;
 
@@ -18,18 +34,48 @@ export class PermitLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'PermitLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.recordSubtype = (obj && obj.recordSubtype) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/restorative-justice-lng.ts
+++ b/angular/projects/common/src/app/models/lng/restorative-justice-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * RestorativeJustice LNG data model.
  *
@@ -7,10 +9,28 @@
 export class RestorativeJusticeLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +38,52 @@ export class RestorativeJusticeLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'RestorativeJusticeLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/self-report-lng.ts
+++ b/angular/projects/common/src/app/models/lng/self-report-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * SelfReport LNG data model.
  *
@@ -7,31 +9,73 @@
 export class SelfReportLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
 
-  relatedPhase: string;
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  documents: object[];
+
   description: string;
 
   dateAdded: Date;
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'SelfReportLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.relatedPhase = (obj && obj.relatedPhase) || null;
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.documents = (obj && obj.documents) || [];
+
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/ticket-lng.ts
+++ b/angular/projects/common/src/app/models/lng/ticket-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Ticket LNG data model.
  *
@@ -7,10 +9,28 @@
 export class TicketLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +38,52 @@ export class TicketLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'TicketLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/lng/warning-lng.ts
+++ b/angular/projects/common/src/app/models/lng/warning-lng.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Warning LNG data model.
  *
@@ -7,10 +9,27 @@
 export class WarningLNG {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   description: string;
 
@@ -18,18 +37,51 @@ export class WarningLNG {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'WarningLNG';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.description = (obj && obj.description) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/master/administrative-penalty.ts
+++ b/angular/projects/common/src/app/models/master/administrative-penalty.ts
@@ -22,7 +22,7 @@ export class AdministrativePenalty {
   issuingAgency: string;
   author: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
@@ -57,7 +57,7 @@ export class AdministrativePenalty {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/administrative-sanction.ts
+++ b/angular/projects/common/src/app/models/master/administrative-sanction.ts
@@ -22,7 +22,7 @@ export class AdministrativeSanction {
   issuingAgency: string;
   author: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
@@ -57,7 +57,7 @@ export class AdministrativeSanction {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/inspection.ts
+++ b/angular/projects/common/src/app/models/master/inspection.ts
@@ -21,18 +21,20 @@ export class Inspection {
   author: string;
   description: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
   outcomeStatus: string; // epic value?
   outcomeDescription: string; // out of scope?
+  documents: object[];
+
   dateAdded: Date;
   dateUpdated: Date;
+
   sourceDateAdded: Date;
   sourceDateUpdated: Date;
   sourceSystemRef: string;
-  documents: object[];
 
   InspectionNRCED: object;
   InspectionLNG: object;
@@ -52,7 +54,7 @@ export class Inspection {
     this.author = (obj && obj.author) || null;
     this.description = (obj && obj.description) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/order.ts
+++ b/angular/projects/common/src/app/models/master/order.ts
@@ -22,15 +22,17 @@ export class Order {
   author: string;
   description: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
   outcomeStatus: string; // epic value?
   outcomeDescription: string; // out of scope?
+  documents: object[];
+
   dateUpdated: Date;
   dateAdded: Date;
-  documents: object[];
+
   sourceDateAdded: Date;
   sourceDateUpdated: Date;
   sourceSystemRef: string;
@@ -55,7 +57,7 @@ export class Order {
     this.author = (obj && obj.author) || null;
     this.description = (obj && obj.description) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/restorative-justice.ts
+++ b/angular/projects/common/src/app/models/master/restorative-justice.ts
@@ -22,7 +22,7 @@ export class RestorativeJustice {
   issuingAgency: string;
   author: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
@@ -57,7 +57,7 @@ export class RestorativeJustice {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/ticket.ts
+++ b/angular/projects/common/src/app/models/master/ticket.ts
@@ -22,7 +22,7 @@ export class Ticket {
   issuingAgency: string;
   author: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
@@ -57,7 +57,7 @@ export class Ticket {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/master/warning.ts
+++ b/angular/projects/common/src/app/models/master/warning.ts
@@ -22,7 +22,7 @@ export class Warning {
   issuingAgency: string;
   author: string;
   legislation: Legislation;
-  issuedTo: string; // epic value?
+  issuedTo: string;
   projectName: string;
   location: string;
   centroid: number[];
@@ -56,7 +56,7 @@ export class Warning {
     this.issuingAgency = (obj && obj.issuingAgency) || null;
     this.author = (obj && obj.author) || null;
     this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
-    this.issuedTo = (obj && obj.issuedTo) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
     this.projectName = (obj && obj.projectName) || null;
     this.location = (obj && obj.location) || null;
     this.centroid = (obj && obj.centroid) || null;

--- a/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * AdministrativePenalty NRCED data model.
  *
@@ -7,10 +9,28 @@
 export class AdministrativePenaltyNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +38,52 @@ export class AdministrativePenaltyNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'AdministrativePenaltyNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/administrative-sanction-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/administrative-sanction-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * AdministrativeSanction NRCED data model.
  *
@@ -7,10 +9,28 @@
 export class AdministrativeSanctionNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +38,52 @@ export class AdministrativeSanctionNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'AdministrativeSanctionNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/inspection-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/inspection-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Inspection NRCED data model.
  *
@@ -7,10 +9,27 @@
 export class InspectionNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +37,51 @@ export class InspectionNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'InspectionNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/order-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/order-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Order NRCED data model.
  *
@@ -7,10 +9,28 @@
 export class OrderNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  recordSubtype: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +38,52 @@ export class OrderNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'OrderNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.recordSubtype = (obj && obj.recordSubtype) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/restorative-justice-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/restorative-justice-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * RestorativeJustice NRCED data model.
  *
@@ -7,10 +9,28 @@
 export class RestorativeJusticeNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +38,52 @@ export class RestorativeJusticeNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'RestorativeJusticeNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/ticket-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/ticket-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Ticket NRCED data model.
  *
@@ -7,10 +9,28 @@
 export class TicketNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  penalty: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +38,52 @@ export class TicketNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'TicketNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.penalty = (obj && obj.penalty) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }

--- a/angular/projects/common/src/app/models/nrced/warning-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/warning-nrced.ts
@@ -1,3 +1,5 @@
+import { Legislation } from '../master/common-models/legislation';
+
 /**
  * Warning NRCED data model.
  *
@@ -7,10 +9,27 @@
 export class WarningNRCED {
   _id: string;
   _schemaName: string;
-  _master: string;
+
+  _epicProjectId: string;
+  _sourceRefId: string;
+  _epicMilestoneId: string;
 
   read: string[];
   write: string[];
+
+  recordName: string;
+  recordType: string;
+  dateIssued: Date;
+  issuingAgency: string;
+  author: string;
+  legislation: Legislation;
+  issuedTo: string;
+  projectName: string;
+  location: string;
+  centroid: number[];
+  outcomeStatus: string;
+  outcomeDescription: string;
+  documents: object[];
 
   summary: string;
 
@@ -18,18 +37,51 @@ export class WarningNRCED {
   dateUpdated: Date;
   datePublished: Date;
 
+  addedBy: string;
+  updatedBy: string;
+  publishedBy: string;
+
+  sourceDateAdded: Date;
+  sourceDateUpdated: Date;
+  sourceSystemRef: string;
+
   constructor(obj?: any) {
     this._id = (obj && obj._id) || null;
     this._schemaName = (obj && obj._schemaName) || 'WarningNRCED';
-    this._master = (obj && obj._master) || null;
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
 
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
+
+    this.recordName = (obj && obj.recordName) || '';
+    this.recordType = (obj && obj.recordType) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.author = (obj && obj.author) || '';
+    this.legislation = (obj && obj.legislation && new Legislation(obj.legislation)) || null;
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.projectName = (obj && obj.projectName) || '';
+    this.location = (obj && obj.location) || '';
+    this.centroid = (obj && obj.centroid) || [];
+    this.outcomeStatus = (obj && obj.outcomeStatus) || '';
+    this.outcomeDescription = (obj && obj.outcomeDescription) || '';
+    this.documents = (obj && obj.documents) || [];
 
     this.summary = (obj && obj.summary) || null;
 
     this.dateAdded = (obj && obj.dateAdded) || null;
     this.dateUpdated = (obj && obj.dateUpdated) || null;
     this.datePublished = (obj && obj.datePublished) || null;
+
+    this.addedBy = (obj && obj.addedBy) || '';
+    this.updatedBy = (obj && obj.updatedBy) || '';
+    this.publishedBy = (obj && obj.publishedBy) || '';
+
+    this.sourceDateAdded = (obj && obj.sourceDateAdded) || null;
+    this.sourceDateUpdated = (obj && obj.sourceDateUpdated) || null;
+    this.sourceSystemRef = (obj && obj.sourceSystemRef) || '';
   }
 }


### PR DESCRIPTION
Realized I never actually updated the angular models when I did the re-arch/schema work.

Nothing was broken before, since we still were fetching master + flavours in admin, and referencing the same fields from each.

This came to light when I was trying to make some changes for the IssuedTo PR.