### PR TITLE
PTI-470: Improve epic import to support updates + new arch/models.

### DIFF
--- a/api/src/controllers/document-controller.js
+++ b/api/src/controllers/document-controller.js
@@ -40,7 +40,7 @@ exports.protectedPost = async function(args, res, next) {
       try {
         docResponse = await createDocument(
           args.swagger.params.fileName.value,
-          (this.auth_payload && this.auth_payload.displayName) || '',
+          (args.swagger.params.auth_payload && args.swagger.params.auth_payload.preferred_username) || '',
           args.swagger.params.url.value
         );
       } catch (e) {
@@ -56,7 +56,7 @@ exports.protectedPost = async function(args, res, next) {
       try {
         docResponse = await createDocument(
           args.swagger.params.fileName.value,
-          (this.auth_payload && this.auth_payload.displayName) || ''
+          (args.swagger.params.auth_payload && args.swagger.params.auth_payload.preferred_username) || ''
         );
       } catch (e) {
         defaultLog.info(`Error creating document meta for ${args.swagger.params.fileName.value}: ${e}`);
@@ -95,7 +95,7 @@ exports.protectedPost = async function(args, res, next) {
       recordResponse = await collection.findOneAndUpdate(
         { _id: new ObjectID(args.swagger.params.recordId.value) },
         { $addToSet: { documents: new ObjectID(docResponse._id) } },
-        { returnNewDocument: true }
+        { new: true }
       );
     } catch (e) {
       defaultLog.info(
@@ -116,7 +116,7 @@ exports.protectedPost = async function(args, res, next) {
           collection.findOneAndUpdate(
             { _id: new ObjectID(id) },
             { $addToSet: { documents: new ObjectID(docResponse._id) } },
-            { returnNewDocument: true }
+            { new: true }
           )
         );
       });
@@ -168,12 +168,7 @@ exports.protectedDelete = async function(args, res, next) {
     // We need to delete this document.
     if (docResponse.key) {
       try {
-        const s3DeleteResult = await s3
-          .deleteObject({
-            Bucket: process.env.OBJECT_STORE_bucket_name,
-            Key: docResponse.key
-          })
-          .promise();
+        const s3DeleteResult = await this.deleteS3Document(docResponse.key);
 
         s3Response = s3DeleteResult;
       } catch (e) {
@@ -196,7 +191,7 @@ exports.protectedDelete = async function(args, res, next) {
       recordResponse = await collection.findOneAndUpdate(
         { _id: new ObjectID(args.swagger.params.recordId.value) },
         { $pull: { documents: new ObjectID(docResponse._id) } },
-        { returnNewDocument: true }
+        { new: true }
       );
     } catch (e) {
       defaultLog.info(
@@ -217,7 +212,7 @@ exports.protectedDelete = async function(args, res, next) {
           collection.findOneAndUpdate(
             { _id: new ObjectID(id) },
             { $pull: { documents: new ObjectID(docResponse._id) } },
-            { returnNewDocument: true }
+            { new: true }
           )
         );
       });
@@ -263,3 +258,7 @@ async function createDocument(fileName, addedBy, url = null) {
   document.write = ['sysadmin'];
   return await document.save();
 }
+
+exports.deleteS3Document = async function(docKey) {
+  return await s3.deleteObject({ Bucket: process.env.OBJECT_STORE_bucket_name, Key: docKey }).promise();
+};

--- a/api/src/controllers/record-controller.js
+++ b/api/src/controllers/record-controller.js
@@ -117,43 +117,47 @@ exports.protectedPost = async function(args, res, next) {
     }
 
     if (data.orders) {
-      observables.push(processPostRequest(args, res, next, 'orders', data.orders));
+      observables.push(this.processPostRequest(args, res, next, 'orders', data.orders));
     }
     if (data.inspections) {
-      observables.push(processPostRequest(args, res, next, 'inspections', data.inspections));
+      observables.push(this.processPostRequest(args, res, next, 'inspections', data.inspections));
     }
     if (data.certificates) {
-      observables.push(processPostRequest(args, res, next, 'certificates', data.certificates));
+      observables.push(this.processPostRequest(args, res, next, 'certificates', data.certificates));
     }
     if (data.permits) {
-      observables.push(processPostRequest(args, res, next, 'permits', data.permits));
+      observables.push(this.processPostRequest(args, res, next, 'permits', data.permits));
     }
     if (data.agreements) {
-      observables.push(processPostRequest(args, res, next, 'agreements', data.agreements));
+      observables.push(this.processPostRequest(args, res, next, 'agreements', data.agreements));
     }
     if (data.selfReports) {
-      observables.push(processPostRequest(args, res, next, 'selfReports', data.selfReports));
+      observables.push(this.processPostRequest(args, res, next, 'selfReports', data.selfReports));
     }
     if (data.restorativeJustices) {
-      observables.push(processPostRequest(args, res, next, 'restorativeJustices', data.restorativeJustices));
+      observables.push(this.processPostRequest(args, res, next, 'restorativeJustices', data.restorativeJustices));
     }
     if (data.tickets) {
-      observables.push(processPostRequest(args, res, next, 'tickets', data.tickets));
+      observables.push(this.processPostRequest(args, res, next, 'tickets', data.tickets));
     }
     if (data.administrativePenalties) {
-      observables.push(processPostRequest(args, res, next, 'administrativePenalties', data.administrativePenalties));
+      observables.push(
+        this.processPostRequest(args, res, next, 'administrativePenalties', data.administrativePenalties)
+      );
     }
     if (data.administrativeSanctions) {
-      observables.push(processPostRequest(args, res, next, 'administrativeSanctions', data.administrativeSanctions));
+      observables.push(
+        this.processPostRequest(args, res, next, 'administrativeSanctions', data.administrativeSanctions)
+      );
     }
     if (data.warnings) {
-      observables.push(processPostRequest(args, res, next, 'warnings', data.warnings));
+      observables.push(this.processPostRequest(args, res, next, 'warnings', data.warnings));
     }
     if (data.constructionPlans) {
-      observables.push(processPostRequest(args, res, next, 'constructionPlans', data.constructionPlans));
+      observables.push(this.processPostRequest(args, res, next, 'constructionPlans', data.constructionPlans));
     }
     if (data.managementPlans) {
-      observables.push(processPostRequest(args, res, next, 'managementPlans', data.managementPlans));
+      observables.push(this.processPostRequest(args, res, next, 'managementPlans', data.managementPlans));
     }
 
     let response = await Promise.all(observables);
@@ -185,43 +189,47 @@ exports.protectedPut = async function(args, res, next) {
     }
 
     if (data.orders) {
-      observables.push(processPutRequest(args, res, next, 'orders', data.orders));
+      observables.push(this.processPutRequest(args, res, next, 'orders', data.orders));
     }
     if (data.inspections) {
-      observables.push(processPutRequest(args, res, next, 'inspections', data.inspections));
+      observables.push(this.processPutRequest(args, res, next, 'inspections', data.inspections));
     }
     if (data.certificates) {
-      observables.push(processPutRequest(args, res, next, 'certificates', data.certificates));
+      observables.push(this.processPutRequest(args, res, next, 'certificates', data.certificates));
     }
     if (data.permits) {
-      observables.push(processPutRequest(args, res, next, 'permits', data.permits));
+      observables.push(this.processPutRequest(args, res, next, 'permits', data.permits));
     }
     if (data.agreements) {
-      observables.push(processPutRequest(args, res, next, 'agreements', data.agreements));
+      observables.push(this.processPutRequest(args, res, next, 'agreements', data.agreements));
     }
     if (data.selfReports) {
-      observables.push(processPutRequest(args, res, next, 'selfReports', data.selfReports));
+      observables.push(this.processPutRequest(args, res, next, 'selfReports', data.selfReports));
     }
     if (data.restorativeJustices) {
-      observables.push(processPutRequest(args, res, next, 'restorativeJustices', data.restorativeJustices));
+      observables.push(this.processPutRequest(args, res, next, 'restorativeJustices', data.restorativeJustices));
     }
     if (data.tickets) {
-      observables.push(processPutRequest(args, res, next, 'tickets', data.tickets));
+      observables.push(this.processPutRequest(args, res, next, 'tickets', data.tickets));
     }
     if (data.administrativePenalties) {
-      observables.push(processPutRequest(args, res, next, 'administrativePenalties', data.administrativePenalties));
+      observables.push(
+        this.processPutRequest(args, res, next, 'administrativePenalties', data.administrativePenalties)
+      );
     }
     if (data.administrativeSanctions) {
-      observables.push(processPutRequest(args, res, next, 'administrativeSanctions', data.administrativeSanctions));
+      observables.push(
+        this.processPutRequest(args, res, next, 'administrativeSanctions', data.administrativeSanctions)
+      );
     }
     if (data.warnings) {
-      observables.push(processPutRequest(args, res, next, 'warnings', data.warnings));
+      observables.push(this.processPutRequest(args, res, next, 'warnings', data.warnings));
     }
     if (data.constructionPlans) {
-      observables.push(processPutRequest(args, res, next, 'constructionPlans', data.constructionPlans));
+      observables.push(this.processPutRequest(args, res, next, 'constructionPlans', data.constructionPlans));
     }
     if (data.managementPlans) {
-      observables.push(processPutRequest(args, res, next, 'managementPlans', data.managementPlans));
+      observables.push(this.processPutRequest(args, res, next, 'managementPlans', data.managementPlans));
     }
 
     let response = await Promise.all(observables);
@@ -336,7 +344,7 @@ exports.publicGet = function(args, res, next) {
   return queryActions.sendResponse(res, 501);
 };
 
-let processPostRequest = async function(args, res, next, property, data) {
+exports.processPostRequest = async function(args, res, next, property, data) {
   if (data.length === 0) {
     return {
       status: 'success',
@@ -406,7 +414,7 @@ let processPostRequest = async function(args, res, next, property, data) {
   }
 };
 
-let processPutRequest = async function(args, res, next, property, data) {
+exports.processPutRequest = async function(args, res, next, property, data) {
   if (data.length === 0) {
     return {
       status: 'success',

--- a/api/src/integrations/epic/base-record-utils.js
+++ b/api/src/integrations/epic/base-record-utils.js
@@ -76,6 +76,16 @@ class BaseRecordUtils {
 
     const documentIds = nrptiRecord.documents.map(id => new ObjectID(id));
 
+    // Check if any documents uploaded to S3, and delete if any
+    for (let idx = 0; idx < documentIds.length; idx++) {
+      const document = await DocumentModel.findOne({ _id: documentIds[idx] });
+
+      if (document && document.key) {
+        await DocumentController.deleteS3Document(document.key);
+      }
+    }
+
+    // Delete local document record/meta
     await DocumentModel.deleteMany({ _id: { $in: documentIds } });
   }
 

--- a/api/src/integrations/epic/base-record-utils.js
+++ b/api/src/integrations/epic/base-record-utils.js
@@ -171,7 +171,7 @@ class BaseRecordUtils {
 
     try {
       // build update Obj, which needs to include the flavour record ids
-      const updateObj = { ...nrptiRecord };
+      const updateObj = { ...nrptiRecord, _id: existingRecord._id };
       existingRecord._flavourRecords.forEach(flavourRecord => {
         updateObj[flavourRecord._schemaName] = { _id: flavourRecord._id, addRole: 'public' };
       });

--- a/api/src/integrations/epic/base-record-utils.js
+++ b/api/src/integrations/epic/base-record-utils.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const mongoose = require('mongoose');
+const ObjectID = require('mongodb').ObjectID;
 const defaultLog = require('../../utils/logger')('epic-base-record-utils');
 const EpicUtils = require('./epic-utils');
 const DocumentController = require('./../../controllers/document-controller');
+const RecordController = require('./../../controllers/record-controller');
 
 const EPIC_PUBLIC_HOSTNAME = process.env.EPIC_PUBLIC_HOSTNAME || 'https://projects.eao.gov.bc.ca';
 
@@ -34,13 +36,13 @@ class BaseRecordUtils {
   }
 
   /**
-   * Persist an epic record to the database, and return an array of ObjectIds.
+   * Create a new document, and return an array of _ids.
    *
    * @param {*} epicRecord Epic record
    * @returns {Array<string>} array of ObjectIds
    * @memberof BaseRecordUtils
    */
-  async saveDocument(epicRecord) {
+  async createDocument(epicRecord) {
     const documents = [];
 
     if (epicRecord && epicRecord._id && epicRecord.documentFileName) {
@@ -56,6 +58,25 @@ class BaseRecordUtils {
     }
 
     return documents;
+  }
+
+  /**
+   * Deletes any document records linked to by the provided NRPTI record.
+   *
+   * @param {object} nrptiRecord NRPTI record.
+   * @returns
+   * @memberof BaseRecordUtils
+   */
+  async removeDocuments(nrptiRecord) {
+    if (!nrptiRecord || !nrptiRecord.documents || !nrptiRecord.documents.length) {
+      return;
+    }
+
+    const DocumentModel = mongoose.model('Document');
+
+    const documentIds = nrptiRecord.documents.map(id => new ObjectID(id));
+
+    await DocumentModel.deleteMany({ _id: { $in: documentIds } });
   }
 
   /**
@@ -77,17 +98,11 @@ class BaseRecordUtils {
     // Apply common Epic pre-processing/transformations
     epicRecord = EpicUtils.preTransformRecord(epicRecord, this.recordType);
 
-    // Creating and saving a document object if we are given a link to an EPIC document.
-    const documents = await this.saveDocument(epicRecord);
-
     return {
       _schemaName: this.recordType._schemaName,
       _epicProjectId: (epicRecord.project && epicRecord.project._id) || '',
-      _sourceRefId: epicRecord._id || '',
+      _sourceRefId: new ObjectID(epicRecord._id) || '',
       _epicMilestoneId: epicRecord.milestone || '',
-
-      read: ['sysadmin'],
-      write: ['sysadmin'],
 
       recordName: epicRecord.displayName || '',
       recordType: this.recordType.displayName,
@@ -96,10 +111,11 @@ class BaseRecordUtils {
       projectName: (epicRecord.project && epicRecord.project.name) || '',
       location: (epicRecord.project && epicRecord.project.location) || '',
       centroid: (epicRecord.project && epicRecord.project.centroid) || '',
-      documents: documents,
 
       dateAdded: new Date(),
       dateUpdated: new Date(),
+
+      addedBy: (this.auth_payload && this.auth_payload.displayName) || '',
       updatedBy: (this.auth_payload && this.auth_payload.displayName) || '',
 
       sourceDateAdded: epicRecord.dateAdded || epicRecord._createdDate || null,
@@ -109,28 +125,97 @@ class BaseRecordUtils {
   }
 
   /**
-   * Persist a NRPTI record to the database.
+   * Searches for an existing master record, and returns it if found.
+   *
+   * @param {*} nrptiRecord
+   * @returns {object} existing NRPTI master record or null if none found
+   * @memberof BaseRecordUtils
+   */
+  async findExistingRecord(nrptiRecord) {
+    const masterRecordModel = mongoose.model(this.recordType._schemaName);
+
+    return await masterRecordModel
+      .findOne({
+        _schemaName: this.recordType._schemaName,
+        _sourceRefId: nrptiRecord._sourceRefId
+      })
+      .populate('_flavourRecords');
+  }
+
+  /**
+   * Update an existing NRPTI master record and its flavour records (if any).
+   *
+   * @param {*} nrptiRecord
+   * @param {*} existingRecord
+   * @returns {object} object containing the update master and flavour records (if any)
+   * @memberof BaseRecordUtils
+   */
+  async updateRecord(nrptiRecord, existingRecord) {
+    if (!nrptiRecord) {
+      throw Error('updateRecord - required nrptiRecord must be non-null.');
+    }
+
+    if (!existingRecord) {
+      throw Error('updateRecord - required existingRecord must be non-null.');
+    }
+
+    try {
+      // build update Obj, which needs to include the flavour record ids
+      const updateObj = { ...nrptiRecord };
+      existingRecord._flavourRecords.forEach(flavourRecord => {
+        updateObj[flavourRecord._schemaName] = { _id: flavourRecord._id, addRole: 'public' };
+      });
+
+      return await RecordController.processPutRequest(
+        { swagger: { params: { auth_payload: this.auth_payload } } },
+        null,
+        null,
+        this.recordType.recordControllerName,
+        [updateObj]
+      );
+    } catch (error) {
+      defaultLog.error(`Failed to save ${this.recordType._schemaName} record: ${error.message}`);
+    }
+  }
+
+  /**
+   * Create a new NRPTI master record.
    *
    * @async
    * @param {object} nrptiRecord NRPTI record (required)
-   * @returns {string} status of the add/update operations.
+   * @returns {object} object containing the newly inserted master and flavour records
    * @memberof BaseRecordUtils
    */
-  async saveRecord(nrptiRecord) {
+  async createRecord(nrptiRecord) {
     if (!nrptiRecord) {
       throw Error('saveRecord - required nrptiRecord must be non-null.');
     }
 
     try {
-      const nrptiRecordModel = mongoose.model(this.recordType._schemaName);
+      // build create Obj, which should include the flavour record details
+      const createObj = { ...nrptiRecord };
 
-      const record = await nrptiRecordModel.findOneAndUpdate(
-        { _schemaName: this.recordType._schemaName, _sourceRefId: nrptiRecord._sourceRefId },
-        { $set: nrptiRecord },
-        { upsert: true, new: true }
+      if (this.recordType.flavours.lng) {
+        createObj[this.recordType.flavours.lng._schemaName] = {
+          description: nrptiRecord.description || '',
+          addRole: 'public'
+        };
+      }
+
+      if (this.recordType.flavours.nrced) {
+        createObj[this.recordType.flavours.nrced._schemaName] = {
+          summary: nrptiRecord.description || '',
+          addRole: 'public'
+        };
+      }
+
+      return await RecordController.processPostRequest(
+        { swagger: { params: { auth_payload: this.auth_payload } } },
+        null,
+        null,
+        this.recordType.recordControllerName,
+        [createObj]
       );
-
-      return record;
     } catch (error) {
       defaultLog.error(`Failed to save ${this.recordType._schemaName} record: ${error.message}`);
     }

--- a/api/src/integrations/epic/epic-record-type-enum.js
+++ b/api/src/integrations/epic/epic-record-type-enum.js
@@ -37,6 +37,10 @@ const EPIC_RECORD_TYPE = Object.freeze({
       // type and milestone from legislation 2002
       type: { name: 'Certificate Package', typeId: '5cf00c03a266b7e1877504d5' },
       milestone: { name: 'Certificate', milestoneId: '5cf00c03a266b7e1877504eb' },
+      projects: [
+        { name: 'LNG', projectId: '588511c4aaecd9001b825604' },
+        { name: 'Coastal Gaslink', projectId: '588510cdaaecd9001b815f84' }
+      ],
       getUtil: auth_payload => {
         return new (require('./certificates-utils'))(auth_payload, RECORD_TYPE.Certificate);
       }
@@ -45,6 +49,10 @@ const EPIC_RECORD_TYPE = Object.freeze({
       // type and milestone from legislation 2002
       type: { name: 'Amendment Package', typeId: '5cf00c03a266b7e1877504d7' },
       milestone: { name: 'Amendment', milestoneId: '5cf00c03a266b7e1877504f2' },
+      projects: [
+        { name: 'LNG', projectId: '588511c4aaecd9001b825604' },
+        { name: 'Coastal Gaslink', projectId: '588510cdaaecd9001b815f84' }
+      ],
       getUtil: auth_payload => {
         return new (require('./certificates-amendment-utils'))(auth_payload, RECORD_TYPE.Certificate);
       }
@@ -55,15 +63,22 @@ const EPIC_RECORD_TYPE = Object.freeze({
       // type and milestone from legislation 2002
       type: { name: 'Plan', typeId: '5cf00c03a266b7e1877504ce' },
       milestone: { name: 'Post-Decision Materials', milestoneId: '5cf00c03a266b7e1877504f1' },
+      projects: [
+        { name: 'LNG', projectId: '588511c4aaecd9001b825604' },
+        { name: 'Coastal Gaslink', projectId: '588510cdaaecd9001b815f84' }
+      ],
       getUtil: auth_payload => {
         return new (require('./management-plans-utils'))(auth_payload, RECORD_TYPE.ManagementPlan);
       }
     },
-
     {
       // type and milestone from legislation 2018 ('Management Plan' doesn't exist in Legislation 2002)
       type: { name: 'Management Plan', typeId: '5df79dd77b5abbf7da6f51c2' },
       milestone: { name: 'Post-Decision Materials', milestoneId: '5df79dd77b5abbf7da6f51fa' },
+      projects: [
+        { name: 'LNG', projectId: '588511c4aaecd9001b825604' },
+        { name: 'Coastal Gaslink', projectId: '588510cdaaecd9001b815f84' }
+      ],
       getUtil: auth_payload => {
         return new (require('./management-plans-utils'))(auth_payload, RECORD_TYPE.ManagementPlan);
       }

--- a/api/src/integrations/epic/inspections-utils.js
+++ b/api/src/integrations/epic/inspections-utils.js
@@ -56,12 +56,10 @@ class Inspections extends BaseRecordUtils {
       legislation: legislation,
       legislationDescription: 'Inspection to verify compliance with regulatory requirement',
       issuedTo: {
-        write: ['sysadmin'],
-        read: ['sysadmin'],
-
         // Epic doesn't support `Individual` proponents
         type: 'Company',
-        companyName: epicRecord.project.company || ''
+        companyName: epicRecord.project.company || '',
+        fullName: epicRecord.project.company || ''
       }
     };
   }

--- a/api/src/integrations/epic/orders-utils.js
+++ b/api/src/integrations/epic/orders-utils.js
@@ -55,12 +55,10 @@ class Orders extends BaseRecordUtils {
       legislation: legislation,
       legislationDescription: 'Order to cease or remedy.',
       issuedTo: {
-        write: ['sysadmin'],
-        read: ['sysadmin'],
-
         // Epic doesn't support `Individual` proponents
         type: 'Company',
-        companyName: epicRecord.project.company || ''
+        companyName: epicRecord.project.company || '',
+        fullName: epicRecord.project.company || ''
       }
     };
   }

--- a/api/src/integrations/nris/datasource.js
+++ b/api/src/integrations/nris/datasource.js
@@ -197,7 +197,8 @@ class NrisDataSource {
         read: ['sysadmin'],
 
         type: 'Company',
-        companyName: record.client[0].orgName || ''
+        companyName: record.client[0].orgName || '',
+        fullName: record.client[0].orgName || ''
       };
     }
 

--- a/api/src/tasks/import-task.js
+++ b/api/src/tasks/import-task.js
@@ -54,7 +54,7 @@ async function runTask(nrptiDataSource, auth_payload, params = null, recordTypes
 
     await taskAuditRecord.updateTaskRecord({ dataSourceLabel: nrptiDataSource.dataSourceLabel, startDate: new Date() });
 
-    const dataSource = new nrptiDataSource.dataSourceClass(auth_payload, params, recordTypes);
+    const dataSource = new nrptiDataSource.dataSourceClass(taskAuditRecord, auth_payload, params, recordTypes);
 
     if (!dataSource) {
       throw Error(`runTask - ${nrptiDataSource.dataSourceLabel} - failed - could not create instance of dataSource`);
@@ -63,10 +63,10 @@ async function runTask(nrptiDataSource, auth_payload, params = null, recordTypes
     // Run the datasource loop, passing in the audit object.
     const res = await dataSource.run(taskAuditRecord);
 
-    defaultLog.info(`runTask - ${nrptiDataSource.dataSourceLabel} - ${res.status}`);
+    defaultLog.info(`runTask - ${nrptiDataSource.dataSourceLabel} - completed`);
 
     // Update task as completed (does not necessarily mean all records were successfully updated)
-    await taskAuditRecord.updateTaskRecord({ status: res.status, finishDate: new Date(), ...res });
+    await taskAuditRecord.updateTaskRecord({ status: 'completed', finishDate: new Date(), ...res });
   } catch (error) {
     defaultLog.error(
       `runTask - ${nrptiDataSource.dataSourceLabel} - ${error.status} - unexpected error: ${error.message}`

--- a/api/src/utils/constants/record-type-enum.js
+++ b/api/src/utils/constants/record-type-enum.js
@@ -5,11 +5,13 @@ const RECORD_TYPE = Object.freeze({
   AdministrativePenalty: {
     _schemaName: 'AdministrativePenalty',
     displayName: 'Administrative Penalty',
+    recordControllerName: 'administrativePenalties',
     flavours: { lng: { _schemaName: 'AdministrativePenaltyLNG' }, nrced: { _schemaName: 'AdministrativePenaltyNRCED' } }
   },
   AdministrativeSanction: {
     _schemaName: 'AdministrativeSanction',
     displayName: 'Administrative Sanction',
+    recordControllerName: 'administrativeSanctions',
     flavours: {
       lng: { _schemaName: 'AdministrativeSanctionLNG' },
       nrced: { _schemaName: 'AdministrativeSanctionNRCED' }
@@ -19,11 +21,13 @@ const RECORD_TYPE = Object.freeze({
   Certificate: {
     _schemaName: 'Certificate',
     displayName: 'Certificate',
+    recordControllerName: 'agreements',
     flavours: { lng: { _schemaName: 'CertificateLNG' } }
   },
   ConstructionPlan: {
     _schemaName: 'ConstructionPlan',
     displayName: 'Construction Plan',
+    recordControllerName: 'constructionPlans',
     flavours: { lng: { _schemaName: 'ConstructionPlanLNG' } }
   },
   CourtConviction: {
@@ -34,37 +38,44 @@ const RECORD_TYPE = Object.freeze({
   Inspection: {
     _schemaName: 'Inspection',
     displayName: 'Inspection',
+    recordControllerName: 'inspections',
     flavours: { lng: { _schemaName: 'InspectionLNG' }, nrced: { _schemaName: 'InspectionNRCED' } }
   },
   ManagementPlan: {
     _schemaName: 'ManagementPlan',
     displayName: 'Management Plan',
+    recordControllerName: 'managementPlans',
     flavours: { lng: { _schemaName: 'ManagementPlanLNG' } }
   },
   Order: {
     _schemaName: 'Order',
     displayName: 'Order',
+    recordControllerName: 'orders',
     flavours: { lng: { _schemaName: 'OrderLNG' }, nrced: { _schemaName: 'OrderNRCED' } }
   },
   Permit: { _schemaName: 'Permit', displayName: 'Permit', flavours: { lng: { _schemaName: 'PermitLNG' } } },
   RestorativeJustice: {
     _schemaName: 'RestorativeJustice',
     displayName: 'Restorative Justice',
+    recordControllerName: 'restorativeJustices',
     flavours: { lng: { _schemaName: 'RestorativeJusticeLNG' }, nrced: { _schemaName: 'RestorativeJusticeNRCED' } }
   },
   SelfReport: {
     _schemaName: 'SelfReport',
     displayName: 'Compliance Self-Report',
+    recordControllerName: 'selfReports',
     flavours: { lng: { _schemaName: 'SelfReportLNG' } }
   },
   Ticket: {
     _schemaName: 'Ticket',
     displayName: 'Ticket',
+    recordControllerName: 'tickets',
     flavours: { lng: { _schemaName: 'TicketLNG' }, nrced: { _schemaName: 'TicketNRCED' } }
   },
   Warning: {
     _schemaName: 'Warning',
     displayName: 'Warning',
+    recordControllerName: 'warnings',
     flavours: { lng: { _schemaName: 'WarningLNG' }, nrced: { _schemaName: 'WarningNRCED' } }
   }
 });

--- a/api/src/utils/constants/record-type-enum.js
+++ b/api/src/utils/constants/record-type-enum.js
@@ -21,7 +21,7 @@ const RECORD_TYPE = Object.freeze({
   Certificate: {
     _schemaName: 'Certificate',
     displayName: 'Certificate',
-    recordControllerName: 'agreements',
+    recordControllerName: 'certificates',
     flavours: { lng: { _schemaName: 'CertificateLNG' } }
   },
   ConstructionPlan: {


### PR DESCRIPTION
PTI-408: Refine import to only fetch some record types from LNG projects only.

## Updates:
- Supports the new arch/models + supports updates properly
  - Tries to find an existing record
    - If Found
      - Transform record and call recordController.processPutRequest which has all of the logic for editing records, including their flavours
    - If Not Found
      - Transform record and call recordController.processPostRequest which has all of the logic for creating records, including their flavours
- Utilizes the taskAuditRecord to update counts/totals live.