### PR TITLE
Remove 'Warning' from NRCED activity type filters

### DIFF
--- a/angular/projects/common/src/app/models/master/common-models/entity.ts
+++ b/angular/projects/common/src/app/models/master/common-models/entity.ts
@@ -65,7 +65,24 @@ export class Entity {
     }
 
     if (this.type === ENTITY_TYPE.Individual) {
-      return [[this.lastName || '-', this.firstName || '-'].join(', '), this.middleName || '-'].join(' ');
+      let entityString = '';
+
+      const entityNameParts = [];
+      if (this.lastName) {
+        entityNameParts.push(this.lastName);
+      }
+
+      if (this.firstName) {
+        entityNameParts.push(this.firstName);
+      }
+
+      entityString = entityNameParts.join(', ');
+
+      if (this.middleName) {
+        entityString += ` ${this.middleName}`;
+      }
+
+      return entityString;
     }
   }
 }

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -48,8 +48,7 @@ export class Picklists {
     Inspection: { displayName: 'Inspection', _schemaName: 'InspectionNRCED' },
     Order: { displayName: 'Order', _schemaName: 'OrderNRCED' },
     RestorativeJustice: { displayName: 'Restorative Justice', _schemaName: 'RestorativeJusticeNRCED' },
-    Ticket: { displayName: 'Ticket', _schemaName: 'TicketNRCED' },
-    Warning: { displayName: 'Warning', _schemaName: 'WarningNRCED' }
+    Ticket: { displayName: 'Ticket', _schemaName: 'TicketNRCED' }
   };
 
   /**

--- a/angular/projects/global/src/lib/components/table-template/table-object.ts
+++ b/angular/projects/global/src/lib/components/table-template/table-object.ts
@@ -13,8 +13,7 @@ export const DEFAULT_TABLE_PAGE_SIZE_OPTIONS: IPageSizePickerOption[] = [
   { displayText: '10', value: 10 },
   { displayText: '25', value: 25 },
   { displayText: '50', value: 50 },
-  { displayText: '100', value: 100 },
-  { displayText: 'All', value: Number.MAX_SAFE_INTEGER }
+  { displayText: '100', value: 100 }
 ];
 export const DEFAULT_TABLE_CURRENT_PAGE = 1;
 export const DEFAULT_TABLE_SORT_BY = '';

--- a/angular/projects/public-nrpti/src/app/records/records-row/records-table-row.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/records-row/records-table-row.component.ts
@@ -23,7 +23,7 @@ export class RecordsTableRowComponent extends TableRowComponent implements OnIni
   public displayDetailsComponent = false;
   public componentRef: ComponentRef<any>;
 
-  public entityString = '';
+  public entityString = 'Unpublished'; // if the issuedTo object is completely missing (redacted) show 'Unpublished'
 
   constructor(public factoryService: FactoryService) {
     super();

--- a/api/migrations/20200211065122-nrcedData.js
+++ b/api/migrations/20200211065122-nrcedData.js
@@ -850,10 +850,6 @@ const getIssuedToObject = function(row, addPublicRole) {
     write: ['sysadmin']
   };
 
-  if (addPublicRole) {
-    issuedToObject.read.push('public');
-  }
-
   if (!row) {
     return issuedToObject;
   }
@@ -863,6 +859,10 @@ const getIssuedToObject = function(row, addPublicRole) {
     issuedToObject.companyName = row[2];
 
     issuedToObject.fullName = setIssuedToFullNameValue(issuedToObject);
+
+    if (addPublicRole) {
+      issuedToObject.read.push('public');
+    }
   } else if (row[3] || row[4] || row[5]) {
     issuedToObject.type = 'Individual';
     issuedToObject.firstName = row[3];
@@ -871,7 +871,12 @@ const getIssuedToObject = function(row, addPublicRole) {
     issuedToObject.dateOfBirth = null;
 
     issuedToObject.fullName = setIssuedToFullNameValue(issuedToObject);
+
+    if (addPublicRole) {
+      issuedToObject.read.push('public');
+    }
   } else {
+    // Individual is anonymous, so don't set read role
     issuedToObject.type = 'Individual';
     issuedToObject.firstName = '';
     issuedToObject.middleName = '';
@@ -902,9 +907,24 @@ const setIssuedToFullNameValue = function(issuedToObj) {
   }
 
   if (issuedToObj.type === 'Individual') {
-    return [[issuedToObj.lastName || '-', issuedToObj.firstName || '-'].join(', '), issuedToObj.middleName || '-'].join(
-      ' '
-    );
+    let entityString = '';
+
+    const entityNameParts = [];
+    if (issuedToObj.lastName) {
+      entityNameParts.push(issuedToObj.lastName);
+    }
+
+    if (issuedToObj.firstName) {
+      entityNameParts.push(issuedToObj.firstName);
+    }
+
+    entityString = entityNameParts.join(', ');
+
+    if (issuedToObj.middleName) {
+      entityString += ` ${issuedToObj.middleName}`;
+    }
+
+    return entityString;
   }
 };
 

--- a/api/src/utils/post-utils.js
+++ b/api/src/utils/post-utils.js
@@ -22,8 +22,23 @@ exports.getIssuedToFullNameValue = function(issuedToObj) {
   }
 
   if (issuedToObj.type === 'Individual') {
-    return [[issuedToObj.lastName || '-', issuedToObj.firstName || '-'].join(', '), issuedToObj.middleName || '-'].join(
-      ' '
-    );
+    let entityString = '';
+
+    const entityNameParts = [];
+    if (issuedToObj.lastName) {
+      entityNameParts.push(issuedToObj.lastName);
+    }
+
+    if (issuedToObj.firstName) {
+      entityNameParts.push(issuedToObj.firstName);
+    }
+
+    entityString = entityNameParts.join(', ');
+
+    if (issuedToObj.middleName) {
+      entityString += ` ${issuedToObj.middleName}`;
+    }
+
+    return entityString;
   }
 };


### PR DESCRIPTION
Remove 'Warning' from NRCED activity type filters
Remove 'ALL' option from records-list page size
Update issuedTo display string to not show dashes, etc.
Show 'Unpublished' on NRCED if no issuedTO object exists (redacted).
Update nrced migration to not add issuedTo public role if its an anonymous person.