### PR TITLE
PTI-536: Anonymous Records

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-administrative-penalty-add-edit',
@@ -152,8 +153,12 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -307,7 +312,8 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       administrativePenalty['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -318,6 +324,12 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        administrativePenalty['issuedTo']['removeRole'] = 'public';
+      } else {
+        administrativePenalty['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -363,6 +375,10 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     if (!this.isEditing) {
       this.factoryService.createAdministrativePenalty(administrativePenalty).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -398,6 +414,10 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
 
       this.factoryService.editAdministrativePenalty(administrativePenalty).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -406,11 +426,73 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'administrative-penalties', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-inspection-add-edit',
@@ -153,8 +154,12 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -253,7 +258,8 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       inspection['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -264,6 +270,12 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        inspection['issuedTo']['removeRole'] = 'public';
+      } else {
+        inspection['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -310,6 +322,10 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.createInspection(inspection).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -345,6 +361,10 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
 
       this.factoryService.editInspection(inspection).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -353,11 +373,73 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'inspections', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-order-add-edit',
@@ -155,8 +156,12 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -256,7 +261,8 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       order['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -267,6 +273,12 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        order['issuedTo']['removeRole'] = 'public';
+      } else {
+        order['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -312,6 +324,10 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.createOrder(order).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -347,6 +363,10 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
 
       this.factoryService.editOrder(order).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -355,11 +375,73 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'orders', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-restorative-justice-add-edit',
@@ -152,8 +153,12 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -306,7 +311,8 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       restorativeJustice['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -317,6 +323,12 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        restorativeJustice['issuedTo']['removeRole'] = 'public';
+      } else {
+        restorativeJustice['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -362,6 +374,10 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.createRestorativeJustice(restorativeJustice).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -397,6 +413,10 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
 
       this.factoryService.editRestorativeJustice(restorativeJustice).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -405,11 +425,73 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'restorative-justices', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-ticket-add-edit',
@@ -152,8 +153,12 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -303,7 +308,8 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       ticket['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -314,6 +320,12 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        ticket['issuedTo']['removeRole'] = 'public';
+      } else {
+        ticket['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -358,6 +370,10 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.createTicket(ticket).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -393,6 +409,10 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
 
       this.factoryService.editTicket(ticket).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -401,11 +421,73 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'tickets', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/records/utils/record-utils.ts
+++ b/angular/projects/admin-nrpti/src/app/records/utils/record-utils.ts
@@ -259,6 +259,7 @@ export class RecordUtils {
       const formData = new FormData();
       formData.append('fileName', link.fileName);
       formData.append('url', link.url);
+      formData.append('addRole', link.addRole);
       promises.push(factoryService.createDocument(formData, recordId));
     });
 
@@ -267,6 +268,7 @@ export class RecordUtils {
       const formData = new FormData();
       formData.append('fileName', doc.fileName);
       formData.append('upfile', doc.upfile);
+      formData.append('addRole', doc.addRole);
       promises.push(factoryService.createDocument(formData, recordId));
     });
 

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -10,6 +10,7 @@ import { Utils } from 'nrpti-angular-components';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
 import { RecordUtils } from '../../utils/record-utils';
 import { LoadingScreenService } from 'nrpti-angular-components';
+import { Document } from '../../../../../../common/src/app/models/document';
 
 @Component({
   selector: 'app-warning-add-edit',
@@ -153,8 +154,12 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
             ''
         ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
+        markRecordAsAnonymous: new FormControl(
+          // set to true if this is an edit and the record's issuedTo read array does not contain `public`
+          this.isEditing &&
+            this.currentRecord &&
+            this.currentRecord.issuedTo &&
+            !this.currentRecord.issuedTo.read.includes('public')
         )
       }),
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
@@ -242,7 +247,8 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       this.myForm.get('issuedTo.middleName').dirty ||
       this.myForm.get('issuedTo.lastName').dirty ||
       this.myForm.get('issuedTo.fullName').dirty ||
-      this.myForm.get('issuedTo.dateOfBirth').dirty
+      this.myForm.get('issuedTo.dateOfBirth').dirty ||
+      this.myForm.get('issuedTo.markRecordAsAnonymous').dirty
     ) {
       warning['issuedTo'] = {
         type: this.myForm.get('issuedTo.type').value,
@@ -253,6 +259,12 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
         fullName: this.myForm.get('issuedTo.fullName').value,
         dateOfBirth: this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('issuedTo.dateOfBirth').value)
       };
+
+      if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+        warning['issuedTo']['removeRole'] = 'public';
+      } else {
+        warning['issuedTo']['addRole'] = 'public';
+      }
     }
 
     // Project name logic
@@ -298,6 +310,10 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.createWarning(warning).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -333,6 +349,10 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
 
       this.factoryService.editWarning(warning).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        this.links = this.setNewDocumentRoles(this.links);
+        this.documents = this.setNewDocumentRoles(this.documents);
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
@@ -341,11 +361,73 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
           this.factoryService
         );
 
+        await this.updateExistingDocumentRoles(
+          this.currentRecord.documents.filter(doc => !this.documentsToDelete.includes(doc._id))
+        );
+
         console.log(docResponse);
         this.loadingScreenService.setLoadingState(false, 'main');
         this.router.navigate(['records', 'warnings', this.currentRecord._id, 'detail']);
       });
     }
+  }
+
+  /**
+   * Conditionally sets the `public` read role for new documents.
+   *
+   * @param {object[]} documents
+   * @returns {object[]}
+   * @memberof CourtConvictionAddEditComponent
+   */
+  setNewDocumentRoles(documents: object[]): object[] {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    if (!this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // not marked anonymous - add `public` roles to documents
+      documents = documents.map((document: object) => {
+        document['addRole'] = 'public';
+        return document;
+      });
+    }
+
+    return documents;
+  }
+
+  /**
+   * Conditionally updates the `public` read role for the provided document ids.
+   *
+   * @param {object[]} documents
+   * @returns
+   * @memberof CourtConvictionAddEditComponent
+   */
+  async updateExistingDocumentRoles(documents: Document[]) {
+    if (!documents || !documents.length) {
+      return;
+    }
+
+    const documentPromises = [];
+
+    if (this.myForm.get('issuedTo.markRecordAsAnonymous').value) {
+      // marked anonymous - remove public roles from documents
+      for (const document of documents) {
+        if (document.read.includes('public')) {
+          // Don't unpublish documents that are already not public
+          documentPromises.push(this.factoryService.unpublishDocument(document._id));
+        }
+      }
+    } else {
+      // not marked anonymous - add public roles to documents
+      for (const document of documents) {
+        if (!document.read.includes('public')) {
+          // Don't publish documents that are already public
+          documentPromises.push(this.factoryService.publishDocument(document._id));
+        }
+      }
+    }
+
+    await Promise.all(documentPromises);
   }
 
   cancel() {

--- a/angular/projects/admin-nrpti/src/app/services/document.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/document.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
-
 import { ApiService } from './api.service';
 import { Document } from '../../../../common/src/app/models/document';
 import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 /**
  * Provides methods for retrieving and working with documents.
@@ -15,28 +14,6 @@ import { HttpClient } from '@angular/common/http';
 export class DocumentService {
   constructor(public apiService: ApiService, public http: HttpClient) {}
 
-  /**
-   * Return all documents that match the provided filters.
-   *
-   * @param {IRecordQueryParamSet[]} queryParamSet array of query parameter sets.
-   * @returns {Observable<Document[]>} total results from all query param sets. Not guaranteed to be unique.
-   * @memberof DocumentService
-   */
-  public getAll(/* queryParamSets: IDocumentQueryParamSet[] */): Observable<Document[]> {
-    return of([] as Document[]);
-  }
-
-  /**
-   * Get a count of all documents that match the provided filters.
-   *
-   * @param {IRecordQueryParamSet[]} queryParamSet array of query parameter sets.
-   * @returns {Observable<number>} total results from all query param sets. Not guaranteed to be unique.
-   * @memberof DocumentService
-   */
-  public getCount(/* queryParamSets: IDocumentQueryParamSet[] */): Observable<number> {
-    return of(0);
-  }
-
   public createDocument(document: FormData, recordId: string): Promise<any> {
     const queryString = `record/${recordId}/document`;
     return this.http.post<any>(`${this.apiService.pathAPI}/${queryString}`, document, {}).toPromise();
@@ -45,6 +22,33 @@ export class DocumentService {
   public deleteDocument(docId: string, recordId: string): Promise<any> {
     const queryString = `record/${recordId}/document/${docId}`;
     return this.http.delete<any>(`${this.apiService.pathAPI}/${queryString}`).toPromise();
+  }
+
+  public publishDocument(docId: string): Promise<any> {
+    if (!document) {
+      throw Error('DocumentService - publishDocument - missing required docId param');
+    }
+
+    const queryString = `document/${docId}/publish`;
+    return this.http.post<any>(`${this.apiService.pathAPI}/${queryString}`, null).toPromise();
+  }
+
+  public unpublishDocument(docId: string): Promise<any> {
+    if (!document) {
+      throw Error('DocumentService - unpublishDocument - missing required docId param');
+    }
+
+    const queryString = `document/${docId}/unpublish`;
+    return this.http.post<any>(`${this.apiService.pathAPI}/${queryString}`, null).toPromise();
+  }
+
+  public getS3SignedUrl(docId: string): Observable<any> {
+    if (!document) {
+      throw Error('DocumentService - getS3SignedUrl - missing required docId param');
+    }
+
+    const queryString = `document/${docId}/signedurl`;
+    return this.http.get<any>(`${this.apiService.pathAPI}/${queryString}`);
   }
 
   private downloadResource(id: string): Promise<Blob> {

--- a/angular/projects/common/src/app/common.module.ts
+++ b/angular/projects/common/src/app/common.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatAutocompleteModule, MatCheckboxModule } from '@angular/material';
+import { MatAutocompleteModule, MatCheckboxModule, MatSlideToggleModule } from '@angular/material';
 
 // modules
 import { GlobalModule } from 'nrpti-angular-components';
@@ -44,7 +44,8 @@ import { PenaltyDetailComponent as PenaltyDetailPublicComponent } from './penalt
     FormsModule,
     ReactiveFormsModule,
     MatAutocompleteModule,
-    MatCheckboxModule
+    MatCheckboxModule,
+    MatSlideToggleModule
   ],
   providers: [],
   exports: [

--- a/angular/projects/common/src/app/document-read-only/document-read-only.component.html
+++ b/angular/projects/common/src/app/document-read-only/document-read-only.component.html
@@ -7,7 +7,7 @@
         </span>
         <span class="cell name" [title]="document || ''">
           <span class="cell__txt-content">
-            <a title="" href="{{ document.url }}" target="_blank">{{ document.fileName }}</a>
+            <a title="" href="{{ document.signedUrl || document.url }}" target="_blank">{{ document.fileName }}</a>
           </span>
         </span>
       </li>

--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
@@ -9,9 +9,7 @@
         </option>
       </select>
     </div>
-  </div>
 
-  <div class="flex-container">
     <!-- Company -->
     <ng-container *ngIf="UIType === ENTITY_TYPE.Company">
       <div class="label-pair">
@@ -21,46 +19,59 @@
     </ng-container>
 
     <!-- Individual* -->
-    <ng-container *ngIf="UIType === ENTITY_TYPE.Individual || UIType === ENTITY_TYPE.IndividualCombined">
-      <!-- IndividualCombined -->
-      <ng-container *ngIf="UIType === ENTITY_TYPE.Individual">
-        <div class="label-pair">
-          <label for="firstName">First Name</label>
-          <input name="firstName" id="firstName" formControlName="firstName" type="text" class="form-control" />
-        </div>
-        <div class="label-pair">
-          <label for="middleName">Middle Name</label>
-          <input name="middleName" id="middleName" formControlName="middleName" type="text" class="form-control" />
-        </div>
-        <div class="label-pair">
-          <label for="lastName">Last Name</label>
-          <input name="lastName" id="lastName" formControlName="lastName" type="text" class="form-control" />
-        </div>
-      </ng-container>
-
-      <!-- Individual -->
-      <ng-container *ngIf="UIType === ENTITY_TYPE.IndividualCombined">
-        <div class="label-pair">
-          <label for="fullName">Full Name</label>
-          <input name="fullName" id="fullName" formControlName="fullName" type="text" class="form-control" />
-        </div>
-      </ng-container>
+    <ng-container
+      *ngIf="
+        (UIType === ENTITY_TYPE.Individual || UIType === ENTITY_TYPE.IndividualCombined) &&
+        this.formGroup.get('markRecordAsAnonymous').value
+      "
+    >
       <div class="label-pair">
-        <label for="dateOfBirth">Date of Birth</label>
-        <div class="input-group">
-          <input
-            class="form-control"
-            placeholder="yyyy-mm-dd"
-            name="dp"
-            formControlName="dateOfBirth"
-            ngbDatepicker
-            #d="ngbDatepicker"
-          />
-          <div class="input-group-append">
-            <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
-          </div>
-        </div>
+        <label>Anonymous</label>
+        <span class="d-block">Name and documents will not be published</span>
       </div>
     </ng-container>
+  </div>
+
+  <div class="flex-container" *ngIf="UIType === ENTITY_TYPE.Individual || UIType === ENTITY_TYPE.IndividualCombined">
+    <!-- IndividualCombined -->
+    <ng-container *ngIf="UIType === ENTITY_TYPE.Individual">
+      <div class="label-pair">
+        <label for="firstName">First Name</label>
+        <input name="firstName" id="firstName" formControlName="firstName" type="text" class="form-control" />
+      </div>
+      <div class="label-pair">
+        <label for="middleName">Middle Name</label>
+        <input name="middleName" id="middleName" formControlName="middleName" type="text" class="form-control" />
+      </div>
+      <div class="label-pair">
+        <label for="lastName">Last Name</label>
+        <input name="lastName" id="lastName" formControlName="lastName" type="text" class="form-control" />
+      </div>
+    </ng-container>
+
+    <!-- Individual -->
+    <ng-container *ngIf="UIType === ENTITY_TYPE.IndividualCombined">
+      <div class="label-pair">
+        <label for="fullName">Full Name</label>
+        <input name="fullName" id="fullName" formControlName="fullName" type="text" class="form-control" />
+      </div>
+    </ng-container>
+    <div class="label-pair">
+      <label for="dateOfBirth">Date of Birth</label>
+      <div class="input-group">
+        <input
+          class="form-control"
+          placeholder="yyyy-mm-dd"
+          name="dp"
+          formControlName="dateOfBirth"
+          (ngModelChange)="updateMarkRecordAsAnonymous()"
+          ngbDatepicker
+          #d="ngbDatepicker"
+        />
+        <div class="input-group-append">
+          <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        </div>
+      </div>
+    </div>
   </div>
 </form>

--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.scss
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.scss
@@ -1,6 +1,53 @@
 @import "../../../assets/styles/base/base.scss";
-@import "../../../../../admin-nrpti/src/assets/styles/components/add-edit.scss";
 
 mat-slide-toggle {
   display: block;
+}
+
+// from add-edit.scss
+
+label {
+  margin-bottom: 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.label-single {
+  @extend .label-pair;
+
+  padding-top: $fc-line-height + 0.25rem;
+}
+
+.label-pair {
+  line-height: $fc-line-height;
+  margin-bottom: 1rem;
+  position: relative;
+
+  @media screen and (min-width: 800px) {
+    width: 32%;
+    margin-right: 1%;
+    display: inline-block;
+    vertical-align: top;
+
+    &.sm {
+      width: 15.5%;
+    }
+
+    &.med {
+      width: 65%;
+    }
+
+    &.lrg {
+      width: 100%;
+    }
+  }
+}
+
+button.calendar,
+button.calendar:active {
+  width: 2.75rem;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAcCAYAAAAEN20fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAEUSURBVEiJ7ZQxToVAEIY/YCHGxN6XGOIpnpaEsBSeQC9ArZbm9TZ6ADyBNzAhQGGl8Riv4BLAWAgmkpBYkH1b8FWT2WK/zJ8ZJ4qiI6XUI3ANnGKWBnht2/ZBDRK3hgVGNsCd7/ui+JkEIrKtqurLpEWaphd933+IyI3LEIdpCYCiKD6HcuOa/nwOa0ScJEnk0BJg0UTUWJRl6RxCYEzEmomsIlPU3IPW+grIAbquy+q6fluy/28RIBeRMwDXdXMgXLj/B2uimRXpui4D9sBeRLKl+1N+L+t6RwbWrZliTTTr1oxYtzVWiTQAcRxvTX+eJMnlUDaO1vpZRO5NS0x48sIwfPc87xg4B04MCzQi8hIEwe4bl1DnFMCN2zsAAAAASUVORK5CYII=') !important;
+  background-repeat: no-repeat;
+  background-size: 23px;
+  background-position: center;
 }

--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.spec.ts
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.spec.ts
@@ -26,7 +26,7 @@ describe('EntityAddEditComponent', () => {
       lastName: new FormControl({}),
       fullName: new FormControl({}),
       dateOfBirth: new FormControl({}),
-      anonymous: new FormControl({})
+      markRecordAsAnonymous: new FormControl({})
     });
 
     fixture.detectChanges();

--- a/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.html
+++ b/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.html
@@ -3,21 +3,25 @@
     <label class="grid-item-name">Entity Type</label>
     <span class="grid-item-value">{{ (data && data.type) || '-' }}</span>
   </div>
-</div>
 
-<!--Company -->
-<ng-container *ngIf="UIType === ENTITY_TYPE.Company">
-  <div class="grid-section section-2">
+  <!--Company -->
+  <ng-container *ngIf="UIType === ENTITY_TYPE.Company">
     <div class="grid-item__row">
       <label class="grid-item-name">Company Name</label>
       <span class="grid-item-value">{{ (data && data.companyName) || '-' }}</span>
     </div>
+  </ng-container>
+
+  <!-- Individual* -->
+  <div *ngIf="markRecordAsAnonymous" class="grid-item">
+    <span class="grid-item-name">Anonymous</span>
+    <span class="grid-item-value">Name and documents are not published</span>
   </div>
-</ng-container>
+</div>
 
 <!-- IndividualCombined -->
 <ng-container *ngIf="UIType === ENTITY_TYPE.Individual">
-  <div class="grid-section section-3">
+  <div class="grid-section section-2">
     <div class="grid-item__row">
       <label class="grid-item-name">First Name</label>
       <span class="grid-item-value">{{ (data && data.firstName) || '-' }}</span>
@@ -39,7 +43,7 @@
 
 <!-- Individual -->
 <ng-container *ngIf="UIType === ENTITY_TYPE.IndividualCombined">
-  <div class="grid-section section-4">
+  <div class="grid-section section-3">
     <div class="grid-item__row">
       <label class="grid-item-name">Full Name</label>
       <span class="grid-item-value">{{ (data && data.fullName) || '-' }}</span>

--- a/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.scss
+++ b/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.scss
@@ -27,22 +27,17 @@
 }
 
 .section-2 {
-  grid-template-columns: 10fr 56fr;
-}
-
-.section-3 {
   grid-template-columns: 10fr 10fr 10fr 36fr;
 }
 
-.section-4 {
+.section-3 {
   grid-template-columns: 10fr 56fr;
 }
 
 @media screen and (max-width: 768px) {
   .section-1,
   .section-2,
-  .section-3,
-  .section-4 {
+  .section-3 {
     grid-template-columns: none;
   }
 

--- a/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.ts
+++ b/angular/projects/common/src/app/entity/entity-detail/entity-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit, ChangeDetectorRef, SimpleChanges, OnChanges } from '@angular/core';
 import { Entity, ENTITY_TYPE } from '../../models/master/common-models/entity';
+import moment from 'moment';
 
 @Component({
   selector: 'app-entity-detail',
@@ -12,6 +13,8 @@ export class EntityDetailComponent implements OnInit, OnChanges {
   public ENTITY_TYPE = ENTITY_TYPE; // make available in template
   public UIType: ENTITY_TYPE = null;
 
+  public markRecordAsAnonymous = false;
+
   constructor(public _changeDetectionRef: ChangeDetectorRef) {}
 
   ngOnInit(): void {
@@ -20,6 +23,7 @@ export class EntityDetailComponent implements OnInit, OnChanges {
 
   updateUI() {
     this.updateUIType();
+    this.markRecordAsAnonymous = this.isRecordConsideredAnonymous();
 
     this._changeDetectionRef.detectChanges();
   }
@@ -61,5 +65,34 @@ export class EntityDetailComponent implements OnInit, OnChanges {
     }
 
     this.UIType = ENTITY_TYPE.NotSet;
+  }
+
+  /**
+   * Check if the entity information marks the record as anonymous.
+   *
+   * @returns {boolean} true if the record is marked as anonymous, false otherwise.
+   * @memberof EntityDetailComponent
+   */
+  isRecordConsideredAnonymous(): boolean {
+    if (!this.data) {
+      return false;
+    }
+
+    if (this.data.type !== ENTITY_TYPE.Individual && this.data.type !== ENTITY_TYPE.IndividualCombined) {
+      // only individuals are compared against anonymous business logic
+      return false;
+    }
+
+    if (!this.data.dateOfBirth) {
+      // if no date of birth set, must be anonymous
+      return true;
+    }
+
+    if (moment().diff(moment(this.data.dateOfBirth), 'years') < 19) {
+      // if date of birth indicates a minor, must be anonymous
+      return true;
+    }
+
+    return false;
   }
 }

--- a/angular/projects/common/src/app/models/document.ts
+++ b/angular/projects/common/src/app/models/document.ts
@@ -6,6 +6,10 @@
  */
 export class Document {
   _id: string;
+
+  write: string[];
+  read: string[];
+
   _addedBy: string;
   fileName: string;
   key: string;

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -327,10 +326,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     administrativePenaltyLNG.read.push('public');
     administrativePenaltyLNG.datePublished = new Date();
     administrativePenaltyLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(administrativePenaltyLNG)) {
-      administrativePenaltyLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    administrativePenaltyLNG.issuedTo.read.push('public');
   }
 
   return await administrativePenaltyLNG.save();
@@ -456,10 +456,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     administrativePenaltyNRCED.read.push('public');
     administrativePenaltyNRCED.datePublished = new Date();
     administrativePenaltyNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(administrativePenaltyNRCED)) {
-      administrativePenaltyNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    administrativePenaltyNRCED.issuedTo.read.push('public');
   }
 
   return await administrativePenaltyNRCED.save();

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -187,6 +186,7 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (administrativeSanction.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (administrativeSanction.projectName = incomingObj.projectName);
   incomingObj.location && (administrativeSanction.location = incomingObj.location);
   incomingObj.centroid && (administrativeSanction.centroid = incomingObj.centroid);
@@ -304,6 +304,7 @@ exports.createLNG = async function(args, res, next, incomingObj) {
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (administrativeSanctionLNG.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (administrativeSanctionLNG.projectName = incomingObj.projectName);
   incomingObj.location && (administrativeSanctionLNG.location = incomingObj.location);
   incomingObj.centroid && (administrativeSanctionLNG.centroid = incomingObj.centroid);
@@ -323,10 +324,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     administrativeSanctionLNG.read.push('public');
     administrativeSanctionLNG.datePublished = new Date();
     administrativeSanctionLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(administrativeSanctionLNG)) {
-      administrativeSanctionLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    administrativeSanctionLNG.issuedTo.read.push('public');
   }
 
   return await administrativeSanctionLNG.save();
@@ -431,6 +433,7 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (administrativeSanctionNRCED.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (administrativeSanctionNRCED.projectName = incomingObj.projectName);
   incomingObj.location && (administrativeSanctionNRCED.location = incomingObj.location);
   incomingObj.centroid && (administrativeSanctionNRCED.centroid = incomingObj.centroid);
@@ -450,10 +453,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     administrativeSanctionNRCED.read.push('public');
     administrativeSanctionNRCED.datePublished = new Date();
     administrativeSanctionNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(administrativeSanctionNRCED)) {
-      administrativeSanctionNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    administrativeSanctionNRCED.issuedTo.read.push('public');
   }
 
   return await administrativeSanctionNRCED.save();

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -321,10 +320,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     courtConvictionLNG.read.push('public');
     courtConvictionLNG.datePublished = new Date();
     courtConvictionLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(courtConvictionLNG)) {
-      courtConvictionLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    courtConvictionLNG.issuedTo.read.push('public');
   }
 
   return await courtConvictionLNG.save();
@@ -449,10 +449,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     courtConvictionNRCED.read.push('public');
     courtConvictionNRCED.datePublished = new Date();
     courtConvictionNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(courtConvictionNRCED)) {
-      courtConvictionNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    courtConvictionNRCED.issuedTo.read.push('public');
   }
 
   return await courtConvictionNRCED.save();

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -177,6 +176,7 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (inspection.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (inspection.projectName = incomingObj.projectName);
   incomingObj.location && (inspection.location = incomingObj.location);
   incomingObj.centroid && (inspection.centroid = incomingObj.centroid);
@@ -291,6 +291,7 @@ exports.createLNG = async function(args, res, next, incomingObj) {
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (inspectionLNG.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (inspectionLNG.projectName = incomingObj.projectName);
   incomingObj.location && (inspectionLNG.location = incomingObj.location);
   incomingObj.centroid && (inspectionLNG.centroid = incomingObj.centroid);
@@ -311,10 +312,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     inspectionLNG.read.push('public');
     inspectionLNG.datePublished = new Date();
     inspectionLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(inspectionLNG)) {
-      inspectionLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    inspectionLNG.issuedTo.read.push('public');
   }
 
   return await inspectionLNG.save();
@@ -416,6 +418,7 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   incomingObj.issuedTo &&
     incomingObj.issuedTo.dateOfBirth &&
     (inspectionNRCED.issuedTo.dateOfBirth = incomingObj.issuedTo.dateOfBirth);
+
   incomingObj.projectName && (inspectionNRCED.projectName = incomingObj.projectName);
   incomingObj.location && (inspectionNRCED.location = incomingObj.location);
   incomingObj.centroid && (inspectionNRCED.centroid = incomingObj.centroid);
@@ -436,10 +439,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     inspectionNRCED.read.push('public');
     inspectionNRCED.datePublished = new Date();
     inspectionNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(inspectionNRCED)) {
-      inspectionNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    inspectionNRCED.issuedTo.read.push('public');
   }
 
   return await inspectionNRCED.save();

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -309,10 +308,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     orderLNG.read.push('public');
     orderLNG.datePublished = new Date();
     orderLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(orderLNG)) {
-      orderLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    orderLNG.issuedTo.read.push('public');
   }
 
   return await orderLNG.save();
@@ -434,10 +434,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     orderNRCED.read.push('public');
     orderNRCED.datePublished = new Date();
     orderNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(orderNRCED)) {
-      orderNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    orderNRCED.issuedTo.read.push('public');
   }
 
   return await orderNRCED.save();

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -321,10 +320,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     restorativeJusticeLNG.read.push('public');
     restorativeJusticeLNG.datePublished = new Date();
     restorativeJusticeLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(restorativeJusticeLNG)) {
-      restorativeJusticeLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    restorativeJusticeLNG.issuedTo.read.push('public');
   }
 
   return await restorativeJusticeLNG.save();
@@ -450,10 +450,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     restorativeJusticeNRCED.read.push('public');
     restorativeJusticeNRCED.datePublished = new Date();
     restorativeJusticeNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(restorativeJusticeNRCED)) {
-      restorativeJusticeNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    restorativeJusticeNRCED.issuedTo.read.push('public');
   }
 
   return await restorativeJusticeNRCED.save();

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -311,10 +310,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     ticketLNG.read.push('public');
     ticketLNG.datePublished = new Date();
     ticketLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(ticketLNG)) {
-      ticketLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    ticketLNG.issuedTo.read.push('public');
   }
 
   return await ticketLNG.save();
@@ -435,10 +435,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     ticketNRCED.read.push('public');
     ticketNRCED.datePublished = new Date();
     ticketNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(ticketNRCED)) {
-      ticketNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    ticketNRCED.issuedTo.read.push('public');
   }
 
   return await ticketNRCED.save();

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -1,6 +1,5 @@
 let mongoose = require('mongoose');
 let ObjectId = require('mongoose').Types.ObjectId;
-let queryUtils = require('../../utils/query-utils');
 let postUtils = require('../../utils/post-utils');
 
 /**
@@ -315,10 +314,11 @@ exports.createLNG = async function(args, res, next, incomingObj) {
     warningLNG.read.push('public');
     warningLNG.datePublished = new Date();
     warningLNG.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(warningLNG)) {
-      warningLNG.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    warningLNG.issuedTo.read.push('public');
   }
 
   return await warningLNG.save();
@@ -443,10 +443,11 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
     warningNRCED.read.push('public');
     warningNRCED.datePublished = new Date();
     warningNRCED.publishedBy = args.swagger.params.auth_payload.displayName;
+  }
 
-    if (!queryUtils.isRecordAnonymous(warningNRCED)) {
-      warningNRCED.issuedTo.read.push('public');
-    }
+  // set issuedTo sub-object read roles
+  if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    warningNRCED.issuedTo.read.push('public');
   }
 
   return await warningNRCED.save();

--- a/api/src/controllers/put/administrative-penalty.js
+++ b/api/src/controllers/put/administrative-penalty.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const AdministrativePenaltyPost = require('../post/administrative-penalty');
 
 /**
@@ -260,13 +259,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await AdministrativePenaltyLNG.findOneAndUpdate(
@@ -342,13 +338,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await AdministrativePenaltyNRCED.findOneAndUpdate(

--- a/api/src/controllers/put/administrative-sanction.js
+++ b/api/src/controllers/put/administrative-sanction.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const AdministrativeSanctionPost = require('../post/administrative-sanction');
 
 /**
@@ -260,13 +259,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await AdministrativeSanctionLNG.findOneAndUpdate(
@@ -342,13 +338,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await AdministrativeSanctionNRCED.findOneAndUpdate(

--- a/api/src/controllers/put/court-conviction.js
+++ b/api/src/controllers/put/court-conviction.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const CourtConvictionPost = require('../post/court-conviction');
 
 /**
@@ -256,15 +255,11 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
-
   return await CourtConvictionLNG.findOneAndUpdate({ _schemaName: 'CourtConvictionLNG', _id: _id }, updateObj, {
     new: true
   });
@@ -336,13 +331,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await CourtConvictionNRCED.findOneAndUpdate({ _schemaName: 'CourtConvictionNRCED', _id: _id }, updateObj, {

--- a/api/src/controllers/put/inspection.js
+++ b/api/src/controllers/put/inspection.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const InspectionPost = require('../post/inspection');
 
 /**
@@ -252,13 +251,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await InspectionLNG.findOneAndUpdate({ _schemaName: 'InspectionLNG', _id: _id }, updateObj, { new: true });
@@ -330,13 +326,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await InspectionNRCED.findOneAndUpdate({ _schemaName: 'InspectionNRCED', _id: _id }, updateObj, { new: true });

--- a/api/src/controllers/put/order.js
+++ b/api/src/controllers/put/order.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const OrderPost = require('../post/order');
 
 /**
@@ -248,13 +247,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await OrderLNG.findOneAndUpdate({ _schemaName: 'OrderLNG', _id: _id }, updateObj, { new: true });
@@ -326,13 +322,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await OrderNRCED.findOneAndUpdate({ _schemaName: 'OrderNRCED', _id: _id }, updateObj, { new: true });

--- a/api/src/controllers/put/restorative-justice.js
+++ b/api/src/controllers/put/restorative-justice.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const RestorativeJusticePost = require('../post/restorative-justice');
 
 /**
@@ -258,13 +257,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await RestorativeJusticeLNG.findOneAndUpdate({ _schemaName: 'RestorativeJusticeLNG', _id: _id }, updateObj, {
@@ -338,13 +334,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await RestorativeJusticeNRCED.findOneAndUpdate(

--- a/api/src/controllers/put/ticket.js
+++ b/api/src/controllers/put/ticket.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const TicketPost = require('../post/ticket');
 
 /**
@@ -248,13 +247,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await TicketLNG.findOneAndUpdate({ _schemaName: 'TicketLNG', _id: _id }, updateObj, { new: true });
@@ -326,13 +322,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await TicketNRCED.findOneAndUpdate({ _schemaName: 'TicketNRCED', _id: _id }, updateObj, { new: true });

--- a/api/src/controllers/put/warning.js
+++ b/api/src/controllers/put/warning.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const ObjectID = require('mongodb').ObjectID;
 const PutUtils = require('../../utils/put-utils');
 const PostUtils = require('../../utils/post-utils');
-const QueryUtils = require('../../utils/query-utils');
 const WarningPost = require('../post/warning');
 
 /**
@@ -247,13 +246,10 @@ exports.editLNG = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await WarningLNG.findOneAndUpdate({ _schemaName: 'WarningLNG', _id: _id }, updateObj, { new: true });
@@ -325,13 +321,10 @@ exports.editNRCED = async function(args, res, next, incomingObj) {
     updateObj.$set['publishedBy'] = '';
   }
 
-  if (sanitizedObj.issuedTo) {
-    // check if a condition changed that would cause the entity details to be anonymous, or not.
-    if (QueryUtils.isRecordAnonymous(sanitizedObj)) {
-      updateObj.$pull['issuedTo.read'] = 'public';
-    } else {
-      updateObj.$addToSet['issuedTo.read'] = 'public';
-    }
+  if (incomingObj.issuedTo && incomingObj.issuedTo.removeRole === 'public') {
+    updateObj.$pull['issuedTo.read'] = 'public';
+  } else if (incomingObj.issuedTo && incomingObj.issuedTo.addRole === 'public') {
+    updateObj.$addToSet['issuedTo.read'] = 'public';
   }
 
   return await WarningNRCED.findOneAndUpdate({ _schemaName: 'WarningNRCED', _id: _id }, updateObj, { new: true });

--- a/api/src/controllers/record-controller.js
+++ b/api/src/controllers/record-controller.js
@@ -252,7 +252,7 @@ exports.protectedDelete = function(args, res, next) {
 };
 
 /**
- * Publish a record.
+ * Publish a record.  Adds the `public` role to the records root read array.
  *
  * @param {*} args
  * @param {*} res
@@ -272,16 +272,6 @@ exports.protectedPublish = async function(args, res, next) {
       return queryActions.sendResponse(res, 404, {});
     }
 
-    defaultLog.debug(`protectedPublish - record: ${JSON.stringify(record)}`);
-
-    // add entity read role
-    if (!queryActions.isPublished(record.issuedTo)) {
-      if (!queryUtils.isRecordAnonymous(record)) {
-        // make entity information public
-        queryActions.addPublicReadRole(record.issuedTo);
-      }
-    }
-
     const published = await queryActions.publish(record, true);
 
     await queryUtils.recordAction('Publish', record, args.swagger.params.auth_payload.preferred_username, record._id);
@@ -293,7 +283,7 @@ exports.protectedPublish = async function(args, res, next) {
 };
 
 /**
- * Unpublish a record.
+ * Unpublish a record. Removes the `public` role from the records root read array.
  *
  * @param {*} args
  * @param {*} res
@@ -311,13 +301,6 @@ exports.protectedUnPublish = async function(args, res, next) {
     if (!record) {
       defaultLog.info(`protectedUnPublish - couldn't find record for recordId: ${record._id}`);
       return queryActions.sendResponse(res, 404, {});
-    }
-
-    defaultLog.debug(`protectedUnPublish - record: ${JSON.stringify(record)}`);
-
-    // remove entity read role
-    if (queryActions.isPublished(record.issuedTo)) {
-      queryActions.removePublicReadRole(record.issuedTo);
     }
 
     const unPublished = await queryActions.unPublish(record);

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -229,11 +229,15 @@ let searchCollection = async function(
   const db = mongodb.connection.db(process.env.MONGODB_DATABASE || 'nrpti-dev');
   const collection = db.collection('nrpti');
 
-  return await collection.aggregate(aggregation, { collation : {
-    locale: "en_US",
-    alternate: "shifted",
-    numericOrdering: true
-  }}).toArray();
+  return await collection
+    .aggregate(aggregation, {
+      collation: {
+        locale: 'en_US',
+        alternate: 'shifted',
+        numericOrdering: true
+      }
+    })
+    .toArray();
 };
 
 exports.publicGet = async function(args, res, next) {

--- a/api/src/integrations/epic/base-record-utils.js
+++ b/api/src/integrations/epic/base-record-utils.js
@@ -46,12 +46,13 @@ class BaseRecordUtils {
     const documents = [];
 
     if (epicRecord && epicRecord._id && epicRecord.documentFileName) {
-      const savedDocument = await DocumentController.createDocument(
+      const savedDocument = await DocumentController.createURLDocument(
         epicRecord.documentFileName,
         (this.auth_payload && this.auth_payload.displayName) || '',
         `${EPIC_PUBLIC_HOSTNAME}/api/document/${epicRecord._id}/fetch/${encodeURIComponent(
           epicRecord.documentFileName
-        )}`
+        )}`,
+        ['public']
       );
 
       documents.push(savedDocument._id);

--- a/api/src/integrations/epic/inspections-utils.js
+++ b/api/src/integrations/epic/inspections-utils.js
@@ -56,8 +56,9 @@ class Inspections extends BaseRecordUtils {
       legislation: legislation,
       legislationDescription: 'Inspection to verify compliance with regulatory requirement',
       issuedTo: {
-        // Epic doesn't support `Individual` proponents
-        type: 'Company',
+        write: ['sysadmin'],
+        read: ['sysadmin', 'public'],
+        type: 'Company', // Epic doesn't support `Individual` proponents
         companyName: epicRecord.project.proponent.company || '',
         fullName: epicRecord.project.proponent.company || ''
       }

--- a/api/src/integrations/epic/orders-utils.js
+++ b/api/src/integrations/epic/orders-utils.js
@@ -55,8 +55,9 @@ class Orders extends BaseRecordUtils {
       legislation: legislation,
       legislationDescription: 'Order to cease or remedy.',
       issuedTo: {
-        // Epic doesn't support `Individual` proponents
-        type: 'Company',
+        write: ['sysadmin'],
+        read: ['sysadmin', 'public'],
+        type: 'Company', // Epic doesn't support `Individual` proponents
         companyName: epicRecord.project.proponent.company || '',
         fullName: epicRecord.project.proponent.company || ''
       }

--- a/api/src/integrations/nris/datasource.js
+++ b/api/src/integrations/nris/datasource.js
@@ -10,17 +10,6 @@ const documentController = require('../../controllers/document-controller');
 const RecordController = require('./../../controllers/record-controller');
 const fs = require('fs');
 
-const AWS = require('aws-sdk');
-const OBJ_STORE_URL = process.env.OBJECT_STORE_endpoint_url || 'nrs.objectstore.gov.bc.ca';
-const ep = new AWS.Endpoint(OBJ_STORE_URL);
-const s3 = new AWS.S3({
-  endpoint: ep,
-  accessKeyId: process.env.OBJECT_STORE_user_account,
-  secretAccessKey: process.env.OBJECT_STORE_password,
-  signatureVersion: 'v4',
-  s3ForcePathStyle: true
-});
-
 const NRIS_TOKEN_ENDPOINT =
   process.env.NRIS_TOKEN_ENDPOINT ||
   'https://api.nrs.gov.bc.ca/oauth2/v1/oauth/token?disableDeveloperFilter=true&grant_type=client_credentials&scope=NRISWS.*';
@@ -292,13 +281,13 @@ class NrisDataSource {
     let s3Response = null;
 
     try {
-      [docResponse, s3Response] = await documentController.createS3Document(
+      ({ docResponse, s3Response } = await documentController.createS3Document(
         fileName,
         file,
         (this.auth_payload && this.auth_payload.displayName) || '',
         (!isAnIndividual && ['public']) || null,
         (!isAnIndividual && 'public-read') || 'authenticated-read'
-      );
+      ));
     } catch (e) {
       defaultLog.info(`Error creating S3 document - fileName: ${fileName}, Error ${e}`);
       return null;

--- a/api/src/models/document.js
+++ b/api/src/models/document.js
@@ -3,10 +3,14 @@ module.exports = require('../utils/model-schema-generator')(
   {
     _schemaName: { type: String, default: 'Document', index: true },
     fileName: { type: String, default: null },
-    addedBy: { type: String, default: null },
     url: { type: String, default: null },
     key: { type: 'string', default: null },
+
+    addedBy: { type: String, default: null },
     dateAdded: { type: Date, default: Date.now() },
+
+    updatedBy: { type: String, default: null },
+    dateUpdated: { type: Date, default: null },
 
     // Permissions
     write: [{ type: String, trim: true, default: 'sysadmin' }],

--- a/api/src/models/nrced/administrativePenalty-nrced.js
+++ b/api/src/models/nrced/administrativePenalty-nrced.js
@@ -59,7 +59,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/administrativeSanction-nrced.js
+++ b/api/src/models/nrced/administrativeSanction-nrced.js
@@ -62,7 +62,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/inspection-nrced.js
+++ b/api/src/models/nrced/inspection-nrced.js
@@ -56,7 +56,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/order-nrced.js
+++ b/api/src/models/nrced/order-nrced.js
@@ -56,7 +56,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/restorativeJustice-nrced.js
+++ b/api/src/models/nrced/restorativeJustice-nrced.js
@@ -62,7 +62,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/ticket-nrced.js
+++ b/api/src/models/nrced/ticket-nrced.js
@@ -62,7 +62,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/models/nrced/warning-nrced.js
+++ b/api/src/models/nrced/warning-nrced.js
@@ -56,7 +56,7 @@ module.exports = require('../../utils/model-schema-generator')(
 
     sourceDateAdded: { type: Date, default: null },
     sourceDateUpdated: { type: Date, default: null },
-    sourceSystemRef: { type: String, default: 'nrpti' },
+    sourceSystemRef: { type: String, default: 'nrpti' }
   },
   'nrpti'
 );

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -616,50 +616,24 @@ paths:
           type: string
         - name: upfile
           in: formData
-          description: "The file to upload. If this is present, the file will be uploaded to S3."
+          description: 'The file to upload. If this is present, the file will be uploaded to S3.'
           required: false
           type: file
         - name: fileName
           in: formData
-          description: "Filename for document/link (Only applies to links)"
+          description: 'Filename for document/link (Only applies to links)'
           required: true
           type: string
         - name: url
           in: formData
-          description: "Url for links. If this is present, a link will be created."
+          description: 'Url for links. If this is present, a link will be created.'
           required: false
           type: string
-      responses:
-        '200':
-          description: 'Success'
-          schema:
-            $ref: '#/definitions/DocumentResponseObject'
-        '403':
-          description: 'Access Denied'
-          schema:
-            $ref: '#/definitions/Error'
-    put:
-      tags:
-        - Document
-      summary: 'Create new Document'
-      operationId: protectedPut
-      description: 'Authenticated access to create a Document and get a signed put URL in return'
-      security:
-        - Bearer: []
-      x-security-scopes:
-        - sysadmin
-      parameters:
-        - name: recordId
-          in: path
-          description: '_id of record the document is associated with'
-          required: true
+        - name: addRole
+          in: formData
+          description: 'Read role to add to the document'
+          required: false
           type: string
-        - in: body
-          name: data
-          description: 'Data to create a document'
-          required: true
-          schema:
-            $ref: '#/definitions/DocumentRequestObject'
       responses:
         '200':
           description: 'Success'
@@ -714,6 +688,138 @@ paths:
         - name: docId
           in: path
           description: '_id of document we want to delete'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+  /document/{docId}/publish:
+    x-swagger-router-controller: document-controller
+    options:
+      tags:
+        - document
+      summary: 'Pre-flight request'
+      operationId: protectedOptions
+      description: 'Options on authenticated document route'
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to publish'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      tags:
+        - document
+      summary: 'Publish a document'
+      operationId: protectedPublish
+      description: "Adds the singular instance of the 'public' role to a document."
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - sysadmin
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to publish'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+  /document/{docId}/unpublish:
+    x-swagger-router-controller: document-controller
+    options:
+      tags:
+        - document
+      summary: 'Pre-flight request'
+      operationId: protectedOptions
+      description: 'Options on authenticated document route'
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to unpublish'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      tags:
+        - document
+      summary: 'Unpublish a document'
+      operationId: protectedUnpublish
+      description: "Adds the singular instance of the 'public' role to a document."
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - sysadmin
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to publish'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+  /document/{docId}/signedurl:
+    x-swagger-router-controller: document-controller
+    options:
+      tags:
+        - document
+      summary: 'Pre-flight request'
+      operationId: protectedGetS3SignedURL
+      description: 'Options on authenticated document route'
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to get an s3 signed url for'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      tags:
+        - document
+      summary: 'Get a signed s3 url for an uploaded document'
+      operationId: protectedGetS3SignedURL
+      description: 'Gets an s3 signed url for a document uploaded to s3.'
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - sysadmin
+      parameters:
+        - name: docId
+          in: path
+          description: '_id of document to get an s3 signed url for'
           required: true
           type: string
       responses:

--- a/api/src/utils/query-actions.js
+++ b/api/src/utils/query-actions.js
@@ -8,7 +8,7 @@ const defaultLog = require('./logger')('queryActions');
  * @param {*} obj
  * @returns
  */
-exports.publish = async function(obj) {
+exports.publish = async function(obj, auth_payload) {
   let self = this;
   return new Promise(async function(resolve, reject) {
     // Object was already published?
@@ -28,8 +28,14 @@ exports.publish = async function(obj) {
       obj.datePublished = date;
       obj.markModified('datePublished');
 
+      obj.publishedBy = auth_payload && auth_payload.idir_userid;
+      obj.markModified('publishedBy');
+
       obj.dateUpdated = date;
       obj.markModified('dateUpdated');
+
+      obj.updatedBy = auth_payload && auth_payload.idir_userid;
+      obj.markModified('updatedBy');
 
       // save and return
       let savedObj = await obj.save();
@@ -69,7 +75,7 @@ exports.addPublicReadRole = function(obj) {
  * @param {*} obj
  * @returns
  */
-exports.unPublish = async function(obj) {
+exports.unPublish = async function(obj, auth_payload) {
   let self = this;
   return new Promise(async function(resolve, reject) {
     // Object wasn't already published?
@@ -87,8 +93,14 @@ exports.unPublish = async function(obj) {
       obj.datePublished = null;
       obj.markModified('datePublished');
 
+      obj.publishedBy = null;
+      obj.markModified('publishedBy');
+
       obj.dateUpdated = new Date();
       obj.markModified('dateUpdated');
+
+      obj.updatedBy = auth_payload && auth_payload.idir_userid;
+      obj.markModified('updatedBy');
 
       // save and return
       let savedObj = await obj.save();

--- a/api/src/utils/query-utils.js
+++ b/api/src/utils/query-utils.js
@@ -5,7 +5,6 @@
  */
 
 let mongoose = require('mongoose');
-const moment = require('moment');
 let DEFAULT_PAGESIZE = 100;
 
 /**
@@ -101,36 +100,3 @@ exports.recordTypes = [
   'ManagementPlan',
   'CourtConviction'
 ];
-
-/**
- * Determine if the obj (record.issuedTo) meets the requirements to not be anonymous.
- *
- * Note: If insufficient information is provided, must assume anonymous.
- *
- * @param {*} obj
- * @returns true if the object is anonymous, false if it is not anonymous.
- */
-exports.isRecordAnonymous = function(record) {
-  if (!record || !record.issuedTo) {
-    // can't determine anonymity, must assume anonymous
-    return true;
-  }
-
-  if (record.issuedTo.type === 'Company') {
-    // companies are not anonymous
-    return false;
-  }
-
-  if (!record.issuedTo.dateOfBirth) {
-    // all types other than Company must have a birth date to have a chance at being not anonymous
-    return true;
-  }
-
-  if (moment().diff(moment(record.issuedTo.dateOfBirth), 'years') >= 19) {
-    // adults are not anonymous
-    return false;
-  }
-
-  // if no contradicting evidence, must assume anonymous
-  return true;
-};


### PR DESCRIPTION
Some of the note-worthy stuff:

### General
- All anonymous business logic/references have been removed from the API.
- All 'anonymous' type business logic is handled on the front-end, and triggered in the data via generic read/write roles and publish/unpublish actions.

### Documents
- Document creation methods, including s3, take in a roles param.
- Document creation, including s3, assumes non-public by default, unless specified otherwise in roles param.
- Link documents now no longer get a key, as that is only used by s3 documents.
- I've added publish/unpublish routes for documents.
  - The controller function for which, also calls publish/unpublish functions for s3 documents.

### S3 Signed URL
- Added a route to fetch an authenticated signed url for an s3 document.
  - Currently this gets called by the front-end when loading admin pages so that document links work, even when not published.

### Frontend
- Added some basic 'anonymous' business logic to the admin site. 
  - There are currently no user-controls to influence this logic, as that opens a whole can of other issues around both the business rules and the architecture.
- Added some code to the add-edit pages that updates document read roles according to the anonymous business logic.

### NRIS Importer
- Updated nris import to not add the 'public' role to issuedTo or documents if the type is an individual.