### PR TITLE
PTI-564: Move RecordName field from master/nrced/lng to lng

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -101,7 +101,6 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -173,6 +172,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -272,8 +272,6 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     // projectName
 
     const administrativePenalty = {};
-    this.myForm.controls.recordName.dirty &&
-      (administrativePenalty['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (administrativePenalty['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
@@ -349,9 +347,15 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       administrativePenalty['AdministrativePenaltyLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (administrativePenalty['AdministrativePenaltyLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (administrativePenalty['AdministrativePenaltyLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-lng-detail/administrative-penalty-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-lng-detail/administrative-penalty-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -101,7 +101,6 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -173,6 +172,7 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -272,8 +272,6 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     // projectName
 
     const administrativeSanction = {};
-    this.myForm.controls.recordName.dirty &&
-      (administrativeSanction['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (administrativeSanction['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
@@ -352,9 +350,15 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       administrativeSanction['AdministrativeSanctionLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (administrativeSanction['AdministrativeSanctionLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (administrativeSanction['AdministrativeSanctionLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-lng-detail/administrative-sanction-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-lng-detail/administrative-sanction-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
@@ -87,7 +87,6 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -98,6 +97,7 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -128,7 +128,6 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const agreement = {};
-    this.myForm.controls.recordName.dirty && (agreement['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (agreement['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.nationName.dirty && (agreement['nationName'] = this.myForm.controls.nationName.value);
@@ -143,9 +142,15 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       agreement['AgreementLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (agreement['AgreementLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (agreement['AgreementLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-detail/agreement-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-detail/agreement-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-lng-detail/agreement-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-lng-detail/agreement-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -91,7 +91,6 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
@@ -132,6 +131,7 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
           ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
           ''
       ),
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
       )
@@ -163,7 +163,6 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const certificate = {};
-    this.myForm.controls.recordName.dirty && (certificate['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.recordSubtype.dirty &&
       (certificate['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
@@ -204,9 +203,15 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       (certificate['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       certificate['CertificateLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (certificate['CertificateLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (certificate['CertificateLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-lng-detail/certificate-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-lng-detail/certificate-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -91,7 +91,6 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -110,6 +109,7 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
@@ -142,7 +142,6 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const constructionPlan = {};
-    this.myForm.controls.recordName.dirty && (constructionPlan['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (constructionPlan['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
@@ -166,12 +165,15 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
 
     // LNG flavour
     if (
+      this.myForm.controls.recordName.dirty ||
       this.myForm.controls.lngDescription.dirty ||
       this.myForm.controls.lngRelatedPhase.dirty ||
       this.myForm.controls.publishLng.dirty
     ) {
       constructionPlan['ConstructionPlanLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (constructionPlan['ConstructionPlanLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (constructionPlan['ConstructionPlanLNG']['description'] = this.myForm.controls.lngDescription.value);
     this.myForm.controls.lngRelatedPhase.dirty &&

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-detail/construction-plan-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-detail/construction-plan-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-lng-detail/construction-plan-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-lng-detail/construction-plan-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Related Phase</label>
             <span class="grid-item-value">{{ (data && data.relatedPhase) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -100,7 +100,6 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
@@ -173,6 +172,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -260,7 +260,6 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
 
   async submit() {
     const courtConviction = {};
-    this.myForm.controls.recordName.dirty && (courtConviction['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.recordSubtype.dirty &&
       (courtConviction['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
@@ -335,9 +334,15 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       courtConviction['CourtConvictionLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (courtConviction['CourtConvictionLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (courtConviction['CourtConvictionLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value__col">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value__col">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-lng-detail/court-conviction-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-lng-detail/court-conviction-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -102,7 +102,6 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -181,6 +180,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl(
         // default to using the master description if the flavour record does not exist
         (this.currentRecord &&
@@ -221,7 +221,6 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const inspection = {};
-    this.myForm.controls.recordName.dirty && (inspection['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (inspection['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.issuingAgency.dirty &&
@@ -296,9 +295,15 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       inspection['InspectionLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (inspection['InspectionLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (inspection['InspectionLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-lng-detail/inspection-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-lng-detail/inspection-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -91,7 +91,6 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -110,6 +109,7 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),
       lngDescription: new FormControl(
         // default to using the master description if the flavour record does not exist
@@ -148,7 +148,6 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
     // documentURL
 
     const managementPlan = {};
-    this.myForm.controls.recordName.dirty && (managementPlan['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (managementPlan['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.agency.dirty && (managementPlan['agency'] = this.myForm.controls.agency.value);
@@ -169,12 +168,15 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
 
     // LNG flavour
     if (
+      this.myForm.controls.recordName.dirty ||
       this.myForm.controls.lngDescription.dirty ||
       this.myForm.controls.lngRelatedPhase.dirty ||
       this.myForm.controls.publishLng.dirty
     ) {
       managementPlan['ManagementPlanLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (managementPlan['ManagementPlanLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (managementPlan['ManagementPlanLNG']['description'] = this.myForm.controls.lngDescription.value);
     this.myForm.controls.lngRelatedPhase.dirty &&

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-detail/management-plan-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-detail/management-plan-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-lng-detail/management-plan-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-lng-detail/management-plan-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Related Phase</label>
             <span class="grid-item-value">{{ (data && data.relatedPhase) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -103,7 +103,6 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
@@ -183,6 +182,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl(
         // default to using the master description if the flavour record does not exist
         (this.currentRecord &&
@@ -223,7 +223,6 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const order = {};
-    this.myForm.controls.recordName.dirty && (order['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.recordSubtype.dirty && (order['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
       (order['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
@@ -286,9 +285,15 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       (order['outcomeDescription'] = this.myForm.controls.outcomeDescription.value);
 
     // NRCED flavour
-    if (this.myForm.controls.nrcedSummary.dirty || this.myForm.controls.publishNrced.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.nrcedSummary.dirty ||
+      this.myForm.controls.publishNrced.dirty
+    ) {
       order['OrderNRCED'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (order['OrderNRCED']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.nrcedSummary.dirty &&
       (order['OrderNRCED']['summary'] = this.myForm.controls.nrcedSummary.value);
     if (this.myForm.controls.publishNrced.dirty && this.myForm.controls.publishNrced.value) {

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-lng-detail/order-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-lng-detail/order-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -92,7 +92,6 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
@@ -127,6 +126,7 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -159,7 +159,6 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const permit = {};
-    this.myForm.controls.recordName.dirty && (permit['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.recordSubtype.dirty && (permit['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
       (permit['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
@@ -197,9 +196,15 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       (permit['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       permit['PermitLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (permit['PermitLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (permit['PermitLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-lng-detail/permit-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-lng-detail/permit-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -101,7 +101,6 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -173,6 +172,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -272,7 +272,6 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const restorativeJustice = {};
-    this.myForm.controls.recordName.dirty && (restorativeJustice['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (restorativeJustice['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
@@ -336,9 +335,15 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     this.myForm.get('penalties').dirty && (restorativeJustice['penalties'] = this.parsePenaltiesFormGroups());
 
     // NRCED flavour
-    if (this.myForm.controls.nrcedSummary.dirty || this.myForm.controls.publishNrced.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.nrcedSummary.dirty ||
+      this.myForm.controls.publishNrced.dirty
+    ) {
       restorativeJustice['RestorativeJusticeNRCED'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (restorativeJustice['RestorativeJusticeNRCED']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.nrcedSummary.dirty &&
       (restorativeJustice['RestorativeJusticeNRCED']['summary'] = this.myForm.controls.nrcedSummary.value);
     if (this.myForm.controls.publishNrced.dirty && this.myForm.controls.publishNrced.value) {

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-lng-detail/restorative-justice-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-lng-detail/restorative-justice-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -91,8 +91,7 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
 
   private buildForm() {
     this.myForm = new FormGroup({
-      // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
+      // Maste
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -127,6 +126,7 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
@@ -160,7 +160,6 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const selfReport = {};
-    this.myForm.controls.recordName.dirty && (selfReport['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (selfReport['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.issuingAgency.dirty &&
@@ -200,12 +199,15 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
 
     // LNG flavour
     if (
+      this.myForm.controls.recordName.dirty ||
       this.myForm.controls.lngDescription.dirty ||
       this.myForm.controls.lngRelatedPhase.dirty ||
       this.myForm.controls.publishLng.dirty
     ) {
       selfReport['SelfReportLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (selfReport['SelfReportLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (selfReport['SelfReportLNG']['description'] = this.myForm.controls.lngDescription.value);
     this.myForm.controls.lngRelatedPhase.dirty &&

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-lng-detail/self-report-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-lng-detail/self-report-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Related Phase</label>
             <span class="grid-item-value">{{ (data && data.relatedPhase) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -101,7 +101,6 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -173,6 +172,7 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -272,7 +272,6 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const ticket = {};
-    this.myForm.controls.recordName.dirty && (ticket['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (ticket['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.issuingAgency.dirty && (ticket['issuingAgency'] = this.myForm.controls.issuingAgency.value);
@@ -344,9 +343,15 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       ticket['TicketLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (ticket['TicketLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (ticket['TicketLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-lng-detail/ticket-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-lng-detail/ticket-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -102,7 +102,6 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     this.myForm = new FormGroup({
       // Master
-      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       dateIssued: new FormControl(
         (this.currentRecord &&
           this.currentRecord.dateIssued &&
@@ -175,6 +174,7 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       ),
 
       // LNG
+      recordName: new FormControl((this.currentRecord && this.currentRecord.recordName) || ''),
       lngDescription: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.description) || ''),
       publishLng: new FormControl(
         (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false
@@ -210,7 +210,6 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     // projectName
 
     const warning = {};
-    this.myForm.controls.recordName.dirty && (warning['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (warning['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
     this.myForm.controls.issuingAgency.dirty && (warning['issuingAgency'] = this.myForm.controls.issuingAgency.value);
@@ -284,9 +283,15 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     }
 
     // LNG flavour
-    if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {
+    if (
+      this.myForm.controls.recordName.dirty ||
+      this.myForm.controls.lngDescription.dirty ||
+      this.myForm.controls.publishLng.dirty
+    ) {
       warning['WarningLNG'] = {};
     }
+    this.myForm.controls.recordName.dirty &&
+      (warning['WarningLNG']['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.lngDescription.dirty &&
       (warning['WarningLNG']['description'] = this.myForm.controls.lngDescription.value);
     if (this.myForm.controls.publishLng.dirty && this.myForm.controls.publishLng.value) {

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -21,10 +21,6 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
-            <label class="grid-item-name">Record Name</label>
-            <span class="grid-item-value">{{ (data && data._master.recordName) || '-' }}</span>
-          </div>
-          <div class="grid-item__row">
             <label class="grid-item-name">Record Type</label>
             <span class="grid-item-value">{{ (data && data._master.recordType) || '-' }}</span>
           </div>

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-lng-detail/warning-lng-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-lng-detail/warning-lng-detail.component.html
@@ -26,6 +26,10 @@
         </div>
         <div class="grid-section section-1">
           <div class="grid-item__row">
+            <label class="grid-item-name">Record Name</label>
+            <span class="grid-item-value">{{ (data && data.recordName) || '-' }}</span>
+          </div>
+          <div class="grid-item__row">
             <label class="grid-item-name">Description</label>
             <span class="grid-item-value">{{ (data && data.description) || '-' }}</span>
           </div>

--- a/angular/projects/common/src/app/models/master/administrative-penalty.ts
+++ b/angular/projects/common/src/app/models/master/administrative-penalty.ts
@@ -18,7 +18,6 @@ export class AdministrativePenalty {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -52,7 +51,6 @@ export class AdministrativePenalty {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/administrative-sanction.ts
+++ b/angular/projects/common/src/app/models/master/administrative-sanction.ts
@@ -18,7 +18,6 @@ export class AdministrativeSanction {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -52,7 +51,6 @@ export class AdministrativeSanction {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/agreement.ts
+++ b/angular/projects/common/src/app/models/master/agreement.ts
@@ -14,7 +14,6 @@ export class Agreement {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   nationName: string;
@@ -40,7 +39,6 @@ export class Agreement {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.nationName = (obj && obj.nationName) || null;

--- a/angular/projects/common/src/app/models/master/certificate.ts
+++ b/angular/projects/common/src/app/models/master/certificate.ts
@@ -17,7 +17,6 @@ export class Certificate {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   recordSubtype: string;
   dateIssued: Date;
@@ -52,7 +51,6 @@ export class Certificate {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/master/construction-plan.ts
+++ b/angular/projects/common/src/app/models/master/construction-plan.ts
@@ -14,7 +14,6 @@ export class ConstructionPlan {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   agency: string;
@@ -44,7 +43,6 @@ export class ConstructionPlan {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.agency = (obj && obj.agency) || null;

--- a/angular/projects/common/src/app/models/master/court-conviction.ts
+++ b/angular/projects/common/src/app/models/master/court-conviction.ts
@@ -18,7 +18,6 @@ export class CourtConviction {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   recordSubtype: string;
   dateIssued: Date;
@@ -53,7 +52,6 @@ export class CourtConviction {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/master/inspection.ts
+++ b/angular/projects/common/src/app/models/master/inspection.ts
@@ -17,7 +17,6 @@ export class Inspection {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -53,7 +52,6 @@ export class Inspection {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/management-plan.ts
+++ b/angular/projects/common/src/app/models/master/management-plan.ts
@@ -15,7 +15,6 @@ export class ManagementPlan {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   agency: string;
@@ -47,7 +46,6 @@ export class ManagementPlan {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.agency = (obj && obj.agency) || null;

--- a/angular/projects/common/src/app/models/master/order.ts
+++ b/angular/projects/common/src/app/models/master/order.ts
@@ -17,7 +17,6 @@ export class Order {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   recordSubtype: string;
   dateIssued: Date;
@@ -55,7 +54,6 @@ export class Order {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/master/permit.ts
+++ b/angular/projects/common/src/app/models/master/permit.ts
@@ -16,7 +16,6 @@ export class Permit {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   recordSubtype: string;
   dateIssued: Date;
@@ -48,7 +47,6 @@ export class Permit {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/master/restorative-justice.ts
+++ b/angular/projects/common/src/app/models/master/restorative-justice.ts
@@ -18,7 +18,6 @@ export class RestorativeJustice {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -52,7 +51,6 @@ export class RestorativeJustice {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/self-report.ts
+++ b/angular/projects/common/src/app/models/master/self-report.ts
@@ -16,7 +16,6 @@ export class SelfReport {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -48,7 +47,6 @@ export class SelfReport {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/ticket.ts
+++ b/angular/projects/common/src/app/models/master/ticket.ts
@@ -18,7 +18,6 @@ export class Ticket {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -52,7 +51,6 @@ export class Ticket {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/master/warning.ts
+++ b/angular/projects/common/src/app/models/master/warning.ts
@@ -17,7 +17,6 @@ export class Warning {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -52,7 +51,6 @@ export class Warning {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
     this.recordType = (obj && obj.recordType) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
@@ -19,7 +19,6 @@ export class AdministrativePenaltyNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class AdministrativePenaltyNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/administrative-sanction-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/administrative-sanction-nrced.ts
@@ -19,7 +19,6 @@ export class AdministrativeSanctionNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class AdministrativeSanctionNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/court-conviction-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/court-conviction-nrced.ts
@@ -19,8 +19,6 @@ export class CourtConvictionNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
-  recordType: string;
   recordSubtype: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -55,8 +53,6 @@ export class CourtConvictionNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || null;
-    this.recordType = (obj && obj.recordType) || null;
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || null;

--- a/angular/projects/common/src/app/models/nrced/inspection-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/inspection-nrced.ts
@@ -18,7 +18,6 @@ export class InspectionNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class InspectionNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/order-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/order-nrced.ts
@@ -18,7 +18,6 @@ export class OrderNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   recordSubtype: string;
   dateIssued: Date;
@@ -59,7 +58,6 @@ export class OrderNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.recordSubtype = (obj && obj.recordSubtype) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/nrced/restorative-justice-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/restorative-justice-nrced.ts
@@ -19,7 +19,6 @@ export class RestorativeJusticeNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class RestorativeJusticeNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/ticket-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/ticket-nrced.ts
@@ -19,7 +19,6 @@ export class TicketNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class TicketNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/warning-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/warning-nrced.ts
@@ -18,7 +18,6 @@ export class WarningNRCED {
   read: string[];
   write: string[];
 
-  recordName: string;
   recordType: string;
   dateIssued: Date;
   issuingAgency: string;
@@ -58,7 +57,6 @@ export class WarningNRCED {
     this.read = (obj && obj.read) || null;
     this.write = (obj && obj.write) || null;
 
-    this.recordName = (obj && obj.recordName) || '';
     this.recordType = (obj && obj.recordType) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/api/migrations/20200109220142-projectData.js
+++ b/api/migrations/20200109220142-projectData.js
@@ -267,7 +267,6 @@ let createAgreementRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Agreement',
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: item.date && moment(item.date, 'DD-MM-YYYY').toDate() || null,
@@ -342,7 +341,6 @@ let createManagementPlanRecord = async function (item, project, nrptiCollection)
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Management Plan',
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: item.date && moment(item.date, 'DD-MM-YYYY').toDate() || null,
@@ -417,7 +415,6 @@ let createConstructionPlanRecord = async function (item, project, nrptiCollectio
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Construction Plan',
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: item.date && moment(item.date, 'DD-MM-YYYY').toDate() || null,
@@ -492,7 +489,6 @@ let createWarningRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Warning',
     recordSubtype: item.complianceDocumentSubtype,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -570,7 +566,6 @@ let createComplianceSelfReportRecord = async function (item, project, nrptiColle
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Compliance Self-Report',
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: item.date && moment(item.date, 'DD-MM-YYYY').toDate() || null,
@@ -646,7 +641,6 @@ let createCertificateRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Certificate',
     recordSubtype: item.complianceDocumentSubtype,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -722,7 +716,6 @@ let createPermitRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Permit',
     recordSubtype: item.complianceDocumentSubtype,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -799,7 +792,6 @@ let createOrderRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Order',
     recordSubtype: item.complianceDocumentSubtype,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -875,7 +867,6 @@ let createInspectionRecord = async function (item, project, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: item.name,
     recordType: 'Inspection',
     // Prefer to store dates in the DB as ISO, not some random format.
     dateIssued: item.date && moment(item.date, 'DD-MM-YYYY').toDate() || null,

--- a/api/migrations/20200211065122-nrcedData.js
+++ b/api/migrations/20200211065122-nrcedData.js
@@ -116,7 +116,6 @@ const createAdministrativePenalty = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.AdministrativePenalty.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -164,7 +163,6 @@ const createAdministrativePenalty = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.AdministrativePenalty.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -208,7 +206,6 @@ const createAdministrativeSanction = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.AdministrativeSanction.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -256,7 +253,6 @@ const createAdministrativeSanction = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.AdministrativeSanction.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -300,7 +296,6 @@ const createCourtConviction = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     // recordSubtype: '',
     recordType: RECORD_TYPE.CourtConviction.displayName,
@@ -349,7 +344,6 @@ const createCourtConviction = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.CourtConviction.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -393,7 +387,6 @@ const createInspection = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Inspection.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -441,7 +434,6 @@ const createInspection = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Inspection.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -485,7 +477,6 @@ const createOrder = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Order.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -533,7 +524,6 @@ const createOrder = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Order.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -577,7 +567,6 @@ const createRestorativeJustice = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.RestorativeJustice.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -625,7 +614,6 @@ const createRestorativeJustice = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.RestorativeJustice.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -669,7 +657,6 @@ const createTicket = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.Ticket.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -717,7 +704,6 @@ const createTicket = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     offence: row[12],
     recordType: RECORD_TYPE.Ticket.displayName,
     // Prefer to store dates in the DB as ISO, not some random format.
@@ -761,7 +747,6 @@ const createWarning = async function (row, nrptiCollection) {
     read: ['sysadmin', 'public'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Warning.displayName,
     // recordSubtype: '',
@@ -809,7 +794,6 @@ const createWarning = async function (row, nrptiCollection) {
     read: ['sysadmin'],
     write: ['sysadmin'],
 
-    recordName: row[12],
     legislationDescription: row[12],
     recordType: RECORD_TYPE.Warning.displayName,
     // recordSubtype: '',

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -142,7 +142,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (administrativePenalty.recordName = incomingObj.recordName);
   administrativePenalty.recordType = 'Administrative Penalty';
   incomingObj.dateIssued && (administrativePenalty.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativePenalty.issuingAgency = incomingObj.issuingAgency);
@@ -390,7 +389,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   administrativePenaltyNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (administrativePenaltyNRCED.recordName = incomingObj.recordName);
   administrativePenaltyNRCED.recordType = 'Administrative Penalty';
   incomingObj.dateIssued && (administrativePenaltyNRCED.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativePenaltyNRCED.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -142,7 +142,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (administrativeSanction.recordName = incomingObj.recordName);
   administrativeSanction.recordType = 'Administrative Sanction';
   incomingObj.dateIssued && (administrativeSanction.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativeSanction.issuingAgency = incomingObj.issuingAgency);
@@ -386,7 +385,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   administrativeSanctionNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (administrativeSanctionNRCED.recordName = incomingObj.recordName);
   administrativeSanctionNRCED.recordType = 'Administrative Sanction';
   incomingObj.dateIssued && (administrativeSanctionNRCED.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (administrativeSanctionNRCED.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/agreement.js
+++ b/api/src/controllers/post/agreement.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (agreement.recordName = incomingObj.recordName);
   agreement.recordType = 'Agreement';
   incomingObj.dateIssued && (agreement.dateIssued = incomingObj.dateIssued);
   incomingObj.nationName && (agreement.nationName = incomingObj.nationName);

--- a/api/src/controllers/post/certificate.js
+++ b/api/src/controllers/post/certificate.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (certificate.recordName = incomingObj.recordName);
   certificate.recordType = 'Certificate';
   incomingObj.recordSubtype && (certificate.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (certificate.dateIssued = incomingObj.dateIssued);

--- a/api/src/controllers/post/construction-plan.js
+++ b/api/src/controllers/post/construction-plan.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (constructionPlan.recordName = incomingObj.recordName);
   constructionPlan.recordType = 'Construction Plan';
   incomingObj.dateIssued && (constructionPlan.dateIssued = incomingObj.dateIssued);
   incomingObj.agency && (constructionPlan.agency = incomingObj.agency);

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (courtConviction.recordName = incomingObj.recordName);
   courtConviction.recordType = 'Court Conviction';
   courtConviction.recordSubtype && (courtConviction.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (courtConviction.dateIssued = incomingObj.dateIssued);
@@ -384,7 +383,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   courtConvictionNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (courtConvictionNRCED.recordName = incomingObj.recordName);
   courtConvictionNRCED.recordType = 'Court Conviction';
   incomingObj.recordSubtype && (courtConvictionNRCED.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (courtConvictionNRCED.dateIssued = incomingObj.dateIssued);

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (inspection.recordName = incomingObj.recordName);
   inspection.recordType = 'Inspection';
   incomingObj.dateIssued && (inspection.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (inspection.issuingAgency = incomingObj.issuingAgency);
@@ -374,7 +373,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   inspectionNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (inspectionNRCED.recordName = incomingObj.recordName);
   inspectionNRCED.recordType = 'Inspection';
   incomingObj.dateIssued && (inspectionNRCED.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (inspectionNRCED.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/management-plan.js
+++ b/api/src/controllers/post/management-plan.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (managementPlan.recordName = incomingObj.recordName);
   managementPlan.recordType = 'Management Plan';
   incomingObj.dateIssued && (managementPlan.dateIssued = incomingObj.dateIssued);
   incomingObj.agency && (managementPlan.agency = incomingObj.agency);

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (order.recordName = incomingObj.recordName);
   order.recordType = 'Order';
   incomingObj.recordSubtype && (order.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (order.dateIssued = incomingObj.dateIssued);
@@ -372,7 +371,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   orderNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (orderNRCED.recordName = incomingObj.recordName);
   orderNRCED.recordType = 'Order';
   incomingObj.recordSubtype && (orderNRCED.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (orderNRCED.dateIssued = incomingObj.dateIssued);

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (permit.recordName = incomingObj.recordName);
   permit.recordType = 'Permit';
   incomingObj.recordSubtype && (permit.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (permit.dateIssued = incomingObj.dateIssued);

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (restorativeJustice.recordName = incomingObj.recordName);
   restorativeJustice.recordType = 'Restorative Justice';
   incomingObj.dateIssued && (restorativeJustice.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (restorativeJustice.issuingAgency = incomingObj.issuingAgency);
@@ -384,7 +383,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   restorativeJusticeNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (restorativeJusticeNRCED.recordName = incomingObj.recordName);
   restorativeJusticeNRCED.recordType = 'Restorative Justice';
   incomingObj.dateIssued && (restorativeJusticeNRCED.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (restorativeJusticeNRCED.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/self-report.js
+++ b/api/src/controllers/post/self-report.js
@@ -124,7 +124,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (selfReport.recordName = incomingObj.recordName);
   selfReport.recordType = 'Compliance Self-Report';
   incomingObj.dateIssued && (selfReport.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (selfReport.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (ticket.recordName = incomingObj.recordName);
   ticket.recordType = 'Ticket';
   incomingObj.dateIssued && (ticket.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (ticket.issuingAgency = incomingObj.issuingAgency);
@@ -374,7 +373,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   ticketNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (ticketNRCED.recordName = incomingObj.recordName);
   ticketNRCED.recordType = 'Ticket';
   incomingObj.dateIssued && (ticketNRCED.dateIssued = incomingObj.dateIssued);
   incomingObj.issuingAgency && (ticketNRCED.issuingAgency = incomingObj.issuingAgency);

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -138,7 +138,6 @@ exports.createMaster = async function(args, res, next, incomingObj, flavourIds) 
   }
 
   // set data
-  incomingObj.recordName && (warning.recordName = incomingObj.recordName);
   warning.recordType = 'Warning';
   incomingObj.recordSubtype && (warning.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (warning.dateIssued = incomingObj.dateIssued);
@@ -378,7 +377,6 @@ exports.createNRCED = async function(args, res, next, incomingObj) {
   warningNRCED.dateAdded = new Date();
 
   // set master data
-  incomingObj.recordName && (warningNRCED.recordName = incomingObj.recordName);
   warningNRCED.recordType = 'Warning';
   incomingObj.recordSubtype && (warningNRCED.recordSubtype = incomingObj.recordSubtype);
   incomingObj.dateIssued && (warningNRCED.dateIssued = incomingObj.dateIssued);

--- a/api/src/integrations/epic/base-record-utils.test.js
+++ b/api/src/integrations/epic/base-record-utils.test.js
@@ -37,7 +37,6 @@ describe('BaseRecordUtils', () => {
         _sourceRefId: expect.any(Object),
         _epicMilestoneId: '',
 
-        recordName: '',
         recordType: RECORD_TYPE.Order.displayName,
         dateIssued: null,
         description: '',
@@ -85,7 +84,6 @@ describe('BaseRecordUtils', () => {
         _sourceRefId: expect.any(Object),
         _epicMilestoneId: 'milestone',
 
-        recordName: 'docDisplay',
         recordType: RECORD_TYPE.Order.displayName,
         dateIssued: 'someDate',
         description: 'someDescription',

--- a/api/src/integrations/nris/datasource.js
+++ b/api/src/integrations/nris/datasource.js
@@ -173,7 +173,6 @@ class NrisDataSource {
     // We don't need this as we insert based on assessmentId
     delete newRecord._id;
 
-    newRecord.recordName = `Inspection - ${record.requirementSource} - ${record.assessmentId}`;
     newRecord.legislationDescription = 'Inspection to verify compliance with regulatory requirement.';
     newRecord.recordType = 'Inspection';
     newRecord._sourceRefNrisId = record.assessmentId;
@@ -258,6 +257,15 @@ class NrisDataSource {
     newRecord.read.push('sysadmin');
     newRecord.write.push('sysadmin');
 
+    newRecord[RECORD_TYPE.Inspection.flavours.lng._schemaName] = {
+      recordName: `Inspection - ${record.requirementSource} - ${record.assessmentId}`,
+      addRole: 'public'
+    };
+
+    newRecord[RECORD_TYPE.Inspection.flavours.nrced._schemaName] = {
+      addRole: 'public'
+    };
+
     defaultLog.info('Processed:', record.assessmentId);
     return newRecord;
   }
@@ -332,25 +340,12 @@ class NrisDataSource {
     }
 
     try {
-      // build create Obj, which should include the flavour record details
-      const createObj = { ...record };
-
-      createObj[RECORD_TYPE.Inspection.flavours.lng._schemaName] = {
-        description: record.description || '',
-        addRole: 'public'
-      };
-
-      createObj[RECORD_TYPE.Inspection.flavours.nrced._schemaName] = {
-        summary: record.description || '',
-        addRole: 'public'
-      };
-
       return await RecordController.processPostRequest(
         { swagger: { params: { auth_payload: this.auth_payload } } },
         null,
         null,
         RECORD_TYPE.Inspection.recordControllerName,
-        [createObj]
+        [record]
       );
     } catch (error) {
       defaultLog.error(`Failed to create Inspection record: ${error.message}`);

--- a/api/src/models/master/administrativePenalty.js
+++ b/api/src/models/master/administrativePenalty.js
@@ -15,7 +15,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/administrativeSanction.js
+++ b/api/src/models/master/administrativeSanction.js
@@ -15,7 +15,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/agreement.js
+++ b/api/src/models/master/agreement.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     nationName: { type: String, default: '' },

--- a/api/src/models/master/certificate.js
+++ b/api/src/models/master/certificate.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/master/constructionPlan.js
+++ b/api/src/models/master/constructionPlan.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     agency: { type: String, default: '' },

--- a/api/src/models/master/courtConviction.js
+++ b/api/src/models/master/courtConviction.js
@@ -15,7 +15,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/master/inspection.js
+++ b/api/src/models/master/inspection.js
@@ -14,7 +14,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/managementPlan.js
+++ b/api/src/models/master/managementPlan.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     agency: { type: String, default: '' },

--- a/api/src/models/master/order.js
+++ b/api/src/models/master/order.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/master/permit.js
+++ b/api/src/models/master/permit.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/master/restorativeJustice.js
+++ b/api/src/models/master/restorativeJustice.js
@@ -15,7 +15,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/selfReport.js
+++ b/api/src/models/master/selfReport.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/ticket.js
+++ b/api/src/models/master/ticket.js
@@ -15,7 +15,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/master/warning.js
+++ b/api/src/models/master/warning.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
 
     _flavourRecords: [{ type: 'ObjectId', default: [], index: true }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/nrced/administrativePenalty-nrced.js
+++ b/api/src/models/nrced/administrativePenalty-nrced.js
@@ -10,7 +10,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/nrced/administrativeSanction-nrced.js
+++ b/api/src/models/nrced/administrativeSanction-nrced.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/nrced/courtConviction-nrced.js
+++ b/api/src/models/nrced/courtConviction-nrced.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/nrced/inspection-nrced.js
+++ b/api/src/models/nrced/inspection-nrced.js
@@ -12,7 +12,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/nrced/order-nrced.js
+++ b/api/src/models/nrced/order-nrced.js
@@ -11,7 +11,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },

--- a/api/src/models/nrced/restorativeJustice-nrced.js
+++ b/api/src/models/nrced/restorativeJustice-nrced.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/nrced/ticket-nrced.js
+++ b/api/src/models/nrced/ticket-nrced.js
@@ -13,7 +13,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     dateIssued: { type: Date, default: null },
     issuingAgency: { type: String, default: '' },

--- a/api/src/models/nrced/warning-nrced.js
+++ b/api/src/models/nrced/warning-nrced.js
@@ -11,7 +11,6 @@ module.exports = require('../../utils/model-schema-generator')(
     read: [{ type: String, trim: true, default: 'sysadmin' }],
     write: [{ type: String, trim: true, default: 'sysadmin' }],
 
-    recordName: { type: String, default: '' },
     recordType: { type: String, default: '' },
     recordSubtype: { type: String, default: '' },
     dateIssued: { type: Date, default: null },


### PR DESCRIPTION
- update controllers
  - removed recordName from the master and nrced sections
- update add-edit components
  - moved recordName from root level of the form/save obj, and moved it to the lng section/sub-object
- update details components
  - removed recordName from master details component, and moved it to the lng flavour detail component
- update models
  - removed recordName from master and nrced models, for both api and angular models
- update migrations
  - removed recordName completely from nrced mirgration
  - removed recordName from master record in lng migration

