### PR TITLE
PTI-584: Update entity type select event to work in Chrome

### DIFF
--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
@@ -3,8 +3,8 @@
   <div class="flex-container">
     <div class="label-pair">
       <label for="type">Entity Type</label>
-      <select name="type" id="type" formControlName="type" class="form-control">
-        <option (click)="updateUI()" *ngFor="let entityType of entityTypes" [ngValue]="entityType">
+      <select name="type" id="type" formControlName="type" class="form-control" (change)="updateUI()">
+        <option *ngFor="let entityType of entityTypes" [ngValue]="entityType">
           {{ entityType }}
         </option>
       </select>


### PR DESCRIPTION
`<option (click)="stuff()">` works in firefox but is never triggered in chrome.

`<select (change)="stuff()">` works in both.

:/