### PR TITLE
PTI-599: update nris-epd anonymous rules

### DIFF
--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -62,13 +62,8 @@ function isRecordConsideredAnonymous(record) {
     isAnonymous = false;
   }
 
-  if (
-    record.sourceSystemRef &&
-    record.sourceSystemRef.toLowerCase() === 'nris-epd' &&
-    record.dateIssued &&
-    moment(record.dateIssued).isBefore('2020-01-01', 'YYYY-MM-DD')
-  ) {
-    // records imported from NRIS-EPD before January 1st 2020 are not anonymous
+  if (record.sourceSystemRef && record.sourceSystemRef.toLowerCase() === 'nris-epd') {
+    // records imported from NRIS-EPD are not anonymous
     isAnonymous = false;
   }
 


### PR DESCRIPTION
Remove date portion of the check, so all NRIS-EPD records are not anonymous, regardless of date issued.