### PR TITLE
PTI-607: unhide agency filter

### DIFF
--- a/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.html
+++ b/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.html
@@ -62,8 +62,7 @@
           ></app-autocomplete-multi-select>
         </div>
       </div>
-      <!-- temporarily hidden as per https://bcmines.atlassian.net/browse/PTI-513 -->
-      <div [hidden]="true">
+      <div>
         <div class="label-pair">
           <label for="agencyFilter">Responsible Agency</label>
           <span *ngIf="agencyCount" class="grey-subtext ml-2">({{ agencyCount }} selected)</span>


### PR DESCRIPTION
Apparently the mockup that showed that the agency filter should be hidden was out of date, so unhiding it.