### PR TITLE
Adds Core ENVs to ReadMe

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -33,7 +33,7 @@ For Core
 
 - client_id
 - client_secret
-- rant_type
+- grant_type
 - oidc
 
 

--- a/api/README.md
+++ b/api/README.md
@@ -25,6 +25,18 @@ npm install -g yarn
 
 ## Install [MongoDB](https://docs.mongodb.com/v3.2/installation/)
 
+## Environment Variables
+
+The API requires a number of environment variables to be set. Some for the API and others to connection to external sources.
+
+For Core
+
+- client_id
+- client_secret
+- rant_type
+- oidc
+
+
 # Build and Run
 
 1. Download dependencies
@@ -235,3 +247,4 @@ Each record has an attribute called sourceSystemRef. We currently have the follo
 - nris-epd
 - ocers-csv
 - epic
+- core


### PR DESCRIPTION
This adds a section to the ReadMe where the envs can be added. I have only added the ones require for Core connection, but we should eventually update with all required ones.