### PR TITLE
NRPT-102: BCMI data update script

### DIFF
--- a/api/migrations/20200603153526-bcmiDataLoad.js
+++ b/api/migrations/20200603153526-bcmiDataLoad.js
@@ -1,0 +1,146 @@
+'use strict';
+
+let dbm;
+let type;
+let seed;
+
+const https = require('https');
+// register the mine schema/model
+const ObjectID = require('mongodb').ObjectID;
+const bcmiUrl = 'https://mines.empr.gov.bc.ca'; // prod api url
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  let mClient;
+
+  try {
+    mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+    const nrpti = mClient.collection('nrpti');
+
+    // API call to pull data from BCMI
+    // could also fetch from NRPTI first: require('../src/models/bcmi/mine').find().then(...);
+    // then match to BCMI, just doing it this way so we can match on name, rather then code
+    console.log('Fetching all major mines in BCMI...');
+    // 30 results for major, 74 for published. Note, published does not return links so if we're supposed to use
+    // published, we'll need to do a follow up call to /api/project/bycode/<mineData.code> to get the links
+    const publishedMines = await getRequest(bcmiUrl + '/api/projects/published');
+    console.log('Located ' + publishedMines.length + ' mines. Batching updates...');
+
+    const promises = [];
+    // build up a collection of all requests
+    for (let i = 0; i < publishedMines.length; i++) {
+      try {
+        // The published endpoint doesn't have links, refresh the mineData object
+        let mineData = await getRequest(bcmiUrl + '/api/project/bycode/' + publishedMines[i].code);
+        promises.push(updateMine(mineData, nrpti));
+      } catch(err) {
+        console.error('Could not find ' + publishedMines[i]._id + ' : ' + publishedMines[i].name);
+        // dont rethrow, we'll just ignore this one as a failure and check the rest
+      }
+    }
+
+    // fire off the requests and wait
+    let results = await Promise.all(promises);
+
+    let updatedCount = 0;
+    let notFoundCount = 0;
+    results.forEach(result => {
+      if (Object.prototype.hasOwnProperty.call(result, 'notfound')) {
+        notFoundCount++;
+        console.log('Could not find ' + result.data._id + ' : ' + result.data.name);
+      } else {
+        updatedCount++;
+      }
+    });
+
+    // we're done
+    console.log('BCMI migration complete.');
+    console.log('Of ' + publishedMines.length + ' mines in BCMI, ' + notFoundCount + ' could not be found in NRPTI, and ' + updatedCount + ' were updated.');
+  } catch(err) {
+    console.error('Error on BCMI dataload: ' + err);
+  }
+
+  mClient.close();
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};
+
+async function updateMine(mineData, nrpti) {
+  let nrptiMines = await nrpti.find({ _schemaName: 'MineBCMI', name: mineData.name}).toArray();
+  // should have 1 result returned. Any more or less, just ignore this update
+  if (nrptiMines.length === 1) {
+    let externalLinks = [];
+    // format the links from the data
+    for(const idx in mineData.externalLinks) {
+      const link = mineData.externalLinks[idx];
+      externalLinks.push(link.link);
+    }
+
+    return nrpti.update({ _id: new ObjectID(nrptiMines[0]._id) }, {
+      $set: {
+        type:            mineData.type,
+        summary:         mineData.description, // BCMI doesn't have a "summary" attribute
+        description:     mineData.description,
+        links:           externalLinks,
+        updatedBy:       'NRPTI BCMI Data Migration',
+        sourceSystemRef: 'mem-admin'
+      }
+    });
+
+    // Alternatively...
+    /* let nrptiMine = await require('../src/models/bcmi/mine').findById(nrptiMines[0]._id);
+
+    nrptiMine.type        = mineData.type;
+    nrptiMine.summary     = mineData.description;
+    nrptiMine.description = mineData.description;
+    nrptiMine.links       = externalLinks;
+    nrptiMine.updatedBy   = 'NRPTI BCMI Data Migration';
+
+    return nrptiMine.save(); */
+  }
+
+  return { notfound: true, data: mineData };
+}
+
+function getRequest(url) {
+  return new Promise(function(resolve, reject) {
+      let req = https.get(url, function(res) {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+              return reject(new Error('statusCode=' + res.statusCode));
+          }
+          let body = [];
+          res.on('data', function(chunk) {
+              body.push(chunk);
+          });
+          res.on('end', function() {
+              try {
+                  body = JSON.parse(Buffer.concat(body).toString());
+              } catch(e) {
+                  reject(e);
+              }
+              resolve(body);
+          });
+      });
+
+      req.on('error', function(err) {
+          reject(err);
+      });
+
+      req.end();
+  });
+}

--- a/api/migrations/20200603153526-bcmiDataLoad.js
+++ b/api/migrations/20200603153526-bcmiDataLoad.js
@@ -81,7 +81,7 @@ exports._meta = {
 };
 
 async function updateMine(mineData, nrpti) {
-  let nrptiMines = await nrpti.find({ _schemaName: 'MineBCMI', name: mineData.name}).toArray();
+  let nrptiMines = await nrpti.find({ _schemaName: 'Mine', name: mineData.name}).toArray();
   // should have 1 result returned. Any more or less, just ignore this update
   if (nrptiMines.length === 1) {
     let externalLinks = [];

--- a/api/migrations/20200603153526-bcmiDataLoad.js
+++ b/api/migrations/20200603153526-bcmiDataLoad.js
@@ -101,17 +101,6 @@ async function updateMine(mineData, nrpti) {
         sourceSystemRef: 'mem-admin'
       }
     });
-
-    // Alternatively...
-    /* let nrptiMine = await require('../src/models/bcmi/mine').findById(nrptiMines[0]._id);
-
-    nrptiMine.type        = mineData.type;
-    nrptiMine.summary     = mineData.description;
-    nrptiMine.description = mineData.description;
-    nrptiMine.links       = externalLinks;
-    nrptiMine.updatedBy   = 'NRPTI BCMI Data Migration';
-
-    return nrptiMine.save(); */
   }
 
   return { notfound: true, data: mineData };


### PR DESCRIPTION
Migration script to fetch data from the BCMI api and update matching records in NRPTI. 

We don't currently have any data from Core, so testing was done by creating some mock data with matching names (basically just copied some data in from BCMI directly and matched the schema)

Schema name is `MineBCMI` in the script, matching with [PR 338](https://github.com/bcgov/NRPTI/pull/388). This can be updated as needed! sourceSystemRef for all updated records will be set to `mem-admin` so it should be easy to wipe and rerun the migration as needed.

See ticket [NRPT-102](https://bcmines.atlassian.net/browse/NRPT-102)