### PR TITLE
NRPT-148: Reversing YX coordinate order

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -188,10 +188,10 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -361,7 +361,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
 
     this.myForm.controls.location.dirty && (administrativePenalty['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (administrativePenalty['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (administrativePenalty['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     this.myForm.get('penalties').dirty && (administrativePenalty['penalties'] = this.parsePenaltiesFormGroups());
 

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -77,7 +77,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -190,10 +190,10 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -364,8 +364,8 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     this.myForm.controls.location.dirty && (administrativeSanction['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
       (administrativeSanction['centroid'] = [
-        this.myForm.controls.latitude.value,
-        this.myForm.controls.longitude.value
+        this.myForm.controls.longitude.value,
+        this.myForm.controls.latitude.value
       ]);
 
     this.myForm.get('penalties').dirty && (administrativeSanction['penalties'] = this.parsePenaltiesFormGroups());

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -77,7 +77,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -148,10 +148,10 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
 
       // LNG
@@ -230,7 +230,7 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (certificate['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (certificate['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (certificate['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     // LNG flavour
     if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-detail/certificate-detail.component.html
@@ -62,7 +62,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -102,10 +102,10 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
 
       // LNG
@@ -161,7 +161,7 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (constructionPlan['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (constructionPlan['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (constructionPlan['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     // LNG flavour
     if (

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-detail/construction-plan-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-detail/construction-plan-detail.component.html
@@ -54,7 +54,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -188,10 +188,10 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -347,7 +347,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (courtConviction['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (courtConviction['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (courtConviction['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     this.myForm.get('penalties').dirty && (courtConviction['penalties'] = this.parsePenaltiesFormGroups());
 

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -72,7 +72,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -189,10 +189,10 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
       outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
@@ -306,7 +306,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (inspection['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (inspection['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (inspection['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
     this.myForm.controls.outcomeStatus.dirty &&
       (inspection['outcomeStatus'] = this.myForm.controls.outcomeStatus.value);
     this.myForm.controls.outcomeDescription.dirty &&

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -67,7 +67,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -102,10 +102,10 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
 
       // LNG
@@ -164,7 +164,7 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (managementPlan['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (managementPlan['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (managementPlan['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     // LNG flavour
     if (

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-detail/management-plan-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-detail/management-plan-detail.component.html
@@ -54,7 +54,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -191,10 +191,10 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
       outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
@@ -309,7 +309,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (order['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (order['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (order['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
     this.myForm.controls.outcomeStatus.dirty && (order['outcomeStatus'] = this.myForm.controls.outcomeStatus.value);
     this.myForm.controls.outcomeDescription.dirty &&
       (order['outcomeDescription'] = this.myForm.controls.outcomeDescription.value);

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -71,7 +71,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -149,10 +149,10 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
 
       // LNG
@@ -223,7 +223,7 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (permit['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (permit['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (permit['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     // LNG flavour
     if (this.myForm.controls.lngDescription.dirty || this.myForm.controls.publishLng.dirty) {

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-detail/permit-detail.component.html
@@ -61,7 +61,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -188,10 +188,10 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -360,7 +360,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (restorativeJustice['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (restorativeJustice['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (restorativeJustice['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     this.myForm.get('penalties').dirty && (restorativeJustice['penalties'] = this.parsePenaltiesFormGroups());
 

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -77,7 +77,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -149,10 +149,10 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
 
       // LNG
@@ -225,7 +225,7 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (selfReport['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (selfReport['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (selfReport['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     // LNG flavour
     if (

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-detail/self-report-detail.component.html
@@ -62,7 +62,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -188,10 +188,10 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -356,7 +356,7 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (ticket['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (ticket['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (ticket['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
 
     this.myForm.get('penalties').dirty && (ticket['penalties'] = this.parsePenaltiesFormGroups());
 

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -77,7 +77,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -189,10 +189,10 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
       location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
       latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
       ),
       longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
+        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
       ),
       outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
       outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
@@ -295,7 +295,7 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
 
     this.myForm.controls.location.dirty && (warning['location'] = this.myForm.controls.location.value);
     (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
-      (warning['centroid'] = [this.myForm.controls.latitude.value, this.myForm.controls.longitude.value]);
+      (warning['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
     this.myForm.controls.outcomeStatus.dirty && (warning['outcomeStatus'] = this.myForm.controls.outcomeStatus.value);
     this.myForm.controls.outcomeDescription.dirty &&
       (warning['outcomeDescription'] = this.myForm.controls.outcomeDescription.value);

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -67,7 +67,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value">{{ (data && data._master.centroid) || '-' }}</span>
+            <span class="grid-item-value">{{ data && data._master.centroid ? data._master.centroid[1] + '/' + data._master.centroid[0]: '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Location</label>

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -89,7 +89,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -85,7 +85,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -89,7 +89,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -86,7 +86,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -86,7 +86,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-4">

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -89,7 +89,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -89,7 +89,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-5">

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -88,7 +88,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>
-            <span class="grid-item-value__col">{{ (data && data.centroid) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.centroid ? data.centroid[1] + '/' + data.centroid[0]: '-' }}</span>
           </div>
         </div>
         <div class="grid-section section-4">


### PR DESCRIPTION
Lat/long values are reversed throughout the application(s). centroid[0], which is the longitude, is mapped to latitude columns, and centroid[1], which is latitude, is mapped to longitude columns. [GeoJSON uses x,y coordinate order](https://tools.ietf.org/html/rfc7946#appendix-A.1) (long/lat).

Fix was to swap the values where they're used in NRPTI and NRCED public. 

See ticket [NRPT-148](https://bcmines.atlassian.net/browse/NRPT-148)