### PR TITLE
NRPT-42: Max width on link, fix tooltip

### DIFF
--- a/angular/projects/admin-nrpti/src/assets/styles/components/doc-list.scss
+++ b/angular/projects/admin-nrpti/src/assets/styles/components/doc-list.scss
@@ -21,11 +21,25 @@ $doc-list-link-color: #007bff;
     overflow: hidden;
     text-overflow: ellipsis;
 
+    @media (max-width: 767px) {
+      &__txt-content {
+        max-width: calc(100vw - 110px);
+      }
+    }
+
+    @media (min-width: 767px) {
+      &__txt-content {
+        max-width: calc(100vw - 375px);
+      }
+    }
+
     // Text Content
     &__txt-content {
       margin-top: 0.5rem;
-      display: inline-block;
+      display: block;
+      overflow: hidden;
       white-space: nowrap;
+      text-overflow: ellipsis;
 
       a {
         color: $doc-list-link-color;

--- a/angular/projects/common/src/app/document-edit/document-edit.component.html
+++ b/angular/projects/common/src/app/document-edit/document-edit.component.html
@@ -3,7 +3,7 @@
     <span class="cell icon">
       <i class="material-icons">insert_drive_file</i>
     </span>
-    <span class="cell name" [title]="document || ''">
+    <span class="cell name" [title]="document.fileName || ''">
       <span *ngIf="!document.toDelete" class="cell__txt-content">{{ document.fileName }}</span>
       <span *ngIf="document.toDelete" class="cell__txt-content">
         <i>{{ document.fileName }} marked for deletion</i>


### PR DESCRIPTION
Long document names could stretch the screen and hide content and buttons. Added a max-width calc and overflow/ellipsis to prevent display of excessive text. As an added bonus, fixed the tooltip to show the document name, rather then `[object, object]`

See ticket [NRPT-42](https://bcmines.atlassian.net/browse/NRPT-42)