### PR TITLE
NPRT-42: Explicit ellipsis for public doc rows

### DIFF
--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -96,7 +96,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -92,7 +92,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -96,7 +96,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -93,7 +93,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -93,7 +93,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -96,7 +96,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -96,7 +96,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text"  *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -95,7 +95,7 @@
           <div class="grid-item__row">
             <label class="grid-item-name">Documents</label>
             <span class="grid-item-value__col" *ngIf="data && data.documents && data.documents.length > 0">
-              <span *ngFor="let document of data && data.documents">
+              <span class="trim-document-text" *ngFor="let document of data && data.documents">
                 <a href="{{ document.url }}" target=" _blank">{{ document.fileName }}</a>
               </span>
             </span>

--- a/angular/projects/public-nrpti/src/assets/styles/components/record-details.scss
+++ b/angular/projects/public-nrpti/src/assets/styles/components/record-details.scss
@@ -143,3 +143,9 @@ label {
   font-size: inherit;
   margin: 0;
 }
+
+.trim-document-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Small update to NRPT-42 for the NRCED public site to inline all document rows instead of wrapping text, add ellipsis on overflows.