### PR TITLE
NOBUG: Fix dependency import

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,6 +46,7 @@
     "biguint-format": "1.0.1",
     "body-parser": "1.19.0",
     "clamav.js": "0.12.0",
+    "csvtojson": "2.0.10",
     "db-migrate": "0.11.6",
     "db-migrate-mongodb": "1.5.0",
     "epsg": "0.5.0",
@@ -68,7 +69,6 @@
   "devDependencies": {
     "babel-eslint": "10.0.3",
     "csv-parse": "4.8.5",
-    "csvtojson": "2.0.10",
     "database-cleaner": "1.3.0",
     "eslint": "~6.8.0",
     "eslint-config-prettier": "~6.10.0",


### PR DESCRIPTION
dependency that is used in some more recent API code was in the devDependencies section, when it should have been in dependencies.