### PR TITLE
NRPT-169: Memory limit on MongoDB queries

### DIFF
--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -243,19 +243,19 @@ let searchCollection = async function (
     }
   ];
 
-  aggregation.push({
+  let projection = {
     $project: {
       _id: 1,
       _flavourRecords: 1,
-      documents: 1,
       read: 1,
-      recordName: 1,
-      location: 1,
-      recordType: 1,
-      'issuedTo.fullName': 1,
-      dateIssued: 1
     }
-  });
+  };
+
+  if (sortField && sortDirection) {
+    projection.$project[sortField] = 1;
+  }
+
+  aggregation.push(projection);
 
   aggregation.push({
     $redact: {

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -236,34 +236,20 @@ let searchCollection = async function (
       $limit: pageSize
     }
   );
-  // populate refs
-  if (populate) {
-    // populate flavours
-    searchResultAggregation.push({
-      $lookup: {
-        from: 'nrpti',
-        localField: '_flavourRecords',
-        foreignField: '_id',
-        as: 'flavours'
-      }
-    });
-
-    // populate documents
-    searchResultAggregation.push({
-      $lookup: {
-        from: 'nrpti',
-        localField: 'documents',
-        foreignField: '_id',
-        as: 'documents'
-      }
-    });
-  }
 
   let aggregation = [
     {
       $match: match
     }
   ];
+
+  aggregation.push({
+    $project: {
+      _id: 1,
+      _flavourRecords: 1,
+      read: 1
+    }
+  });
 
   aggregation.push({
     $redact: {
@@ -305,6 +291,38 @@ let searchCollection = async function (
       ]
     }
   });
+
+  aggregation.push({
+    $lookup: {
+      from: 'nrpti',
+      localField: 'searchResults._id',
+      foreignField: '_id',
+      as: 'searchResults'
+    }
+  });
+
+  // populate refs
+  if (populate) {
+    // populate flavours
+    searchResultAggregation.push({
+      $lookup: {
+        from: 'nrpti',
+        localField: 'searchResults._flavourRecords',
+        foreignField: '_id',
+        as: 'searchResults.flavours'
+      }
+    });
+
+    // populate documents
+    searchResultAggregation.push({
+      $lookup: {
+        from: 'nrpti',
+        localField: 'searchResults.documents',
+        foreignField: '_id',
+        as: 'searchResults.documents'
+      }
+    });
+  }
 
   defaultLog.info('Executing searching on schema(s):', schemaName);
 

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -247,7 +247,13 @@ let searchCollection = async function (
     $project: {
       _id: 1,
       _flavourRecords: 1,
-      read: 1
+      documents: 1,
+      read: 1,
+      recordName: 1,
+      location: 1,
+      recordType: 1,
+      'issuedTo.fullName': 1,
+      dateIssued: 1
     }
   });
 
@@ -291,6 +297,7 @@ let searchCollection = async function (
       as: 'fullRecord'
     }
   });
+
   searchResultAggregation.push({
     $replaceRoot: {
       newRoot: {


### PR DESCRIPTION
Some restructuring to the search aggregation to prevent exceeding mongo memory limits.

Adding a `$project` stage after the `$match` stage to remove unecessary query data:

```
$project: {
      _id: 1,
      _flavourRecords: 1,
      read: 1
}
```

Then repopulating with `$lookup` and `$replaceRoot` in the `$facet` stage. If populate is true, those lookups will also merge into the facet stage.

Note that `allowDiskUse` is still set to true as a safetly net for when we do exceed the size limits, but all queries should now run as expected if it is disabled.

See ticket [NRPT-169](https://bcmines.atlassian.net/browse/NRPT-169)