### PR TITLE
NOBUG: Remove recordName field from LNG flavour section

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
@@ -179,12 +179,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
@@ -191,12 +191,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.html
@@ -181,12 +181,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
@@ -201,12 +201,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
@@ -208,12 +208,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
@@ -179,12 +179,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
@@ -173,12 +173,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
@@ -201,12 +201,6 @@
         </div>
       </div>
       <div class="flex-container">
-        <div class="label-pair">
-          <label for="recordName">Record Name</label>
-          <input name="recordName" id="recordName" type="text" formControlName="recordName" class="form-control" />
-        </div>
-      </div>
-      <div class="flex-container">
         <div class="label-pair med">
           <label for="lngDescription">Description</label>
           <textarea
@@ -219,7 +213,7 @@
         </div>
       </div>
     </section>
-    
+
     <section>
       <div class="row mb-4">
         <div class="col-2">


### PR DESCRIPTION
Kit and I both submitted PRs recently that touched the add-edit components for the same record types.  My PR moved the recordName field from the lng flavour section into the master section, and Kits re-organized the lng and nrced flavour sections.

No major issues or anything resulted, we just accidentally ended up with 2 copies of the recordName field in the HTML of some of the record components.

This PR removes the duplicate recordName field from the lng section.