### PR TITLE
NRPT-233: Updates Core importer for better error handling

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -135,8 +135,8 @@ swaggerTools.initializeMiddleware(swaggerConfig, async function (middleware) {
       app.listen(3000, '0.0.0.0', function () {
         defaultLog.info('Started server on port 3000');
       });
-      createTask('core')
-      //startCron(defaultLog);
+
+      startCron(defaultLog);
     },
     error => {
       defaultLog.info('Mongoose connect error:', error);

--- a/api/app.js
+++ b/api/app.js
@@ -135,8 +135,8 @@ swaggerTools.initializeMiddleware(swaggerConfig, async function (middleware) {
       app.listen(3000, '0.0.0.0', function () {
         defaultLog.info('Started server on port 3000');
       });
-
-      startCron(defaultLog);
+      createTask('core')
+      //startCron(defaultLog);
     },
     error => {
       defaultLog.info('Mongoose connect error:', error);

--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -417,8 +417,8 @@ class CoreDataSource {
           integrationUtils.getRecords(mineDetailsUrl, this.getAuthHeader())
         ]);
 
-        const latitude = mineDetails.mine_location && mineDetails.mine_location.latitude || 0.00;
-        const longitude = mineDetails.mine_location && mineDetails.mine_location.longitude || 0.00;
+        const latitude = mineDetails && mineDetails.mine_location && mineDetails.mine_location.latitude || 0.00;
+        const longitude = mineDetails && mineDetails.mine_location && mineDetails.mine_location.longitude || 0.00;
   
         completeRecords.push({
           ...coreRecords[i],

--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -321,7 +321,6 @@ class CoreDataSource {
         if (permit.permit_amendments.length && !permit.permit_amendments[0].authorization_end_date) {
           // There should only be a single record. If there is more then we do not want to continue processing.
           if (validPermit) {
-            //console.log(permit);
             throw new Error(`getMinePermit - more than one valid permit found for mine ${coreRecord.mine_guid}`);
           }
 

--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -348,6 +348,12 @@ class CoreDataSource {
     }
   }
 
+  /**
+   * Gets all verified mines from Core.
+   * 
+   * @returns {object[]} Verified Core mines.
+   * @memberof CoreDataSource
+   */
   async getVerifiedMines() {
     try{
       let currentPage = 1;
@@ -385,6 +391,13 @@ class CoreDataSource {
     }
   }
 
+  /**
+   * Adds party and lat/long details to each Core record.
+   * 
+   * @param {object[]} coreRecords Records from Core API that have not been transformed.
+   * @returns {obejct[]} Records with details added.
+   * @memberof CoreDataSource
+   */
   async addMinesDetails(coreRecords) {
     const completeRecords = [];
 


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-233

I made multiple changes to better import the Core records and better handle errors.

- New parameter to only import major mines (cuts down from 18,000 to ~110 records)
- Makes subsequent API calls to get more details about each record to only send 2 at a time (fixes 504 errors)
- If there are any API failures or if a record doesn't contain valid data the Mine ID is logged but the other records continue to process

When running against prod data there are 14 records that will throw errors. These are data related and are to be expected right now.