### PR TITLE
NRPT-62: Remove fullRecord, redact after doc/flavour import

### DIFF
--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -575,7 +575,7 @@ const executeQuery = async function (args, res, next) {
         }
       });
 
-    aggregation.push(      {
+    aggregation.push({
       $redact: {
         $cond: {
           if: {

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -548,29 +548,6 @@ const executeQuery = async function (args, res, next) {
     let aggregation = [
       {
         $match: { _id: mongoose.Types.ObjectId(args.swagger.params._id.value) }
-      },
-      {
-        $redact: {
-          $cond: {
-            if: {
-              $cond: {
-                if: '$read',
-                then: {
-                  $anyElementTrue: {
-                    $map: {
-                      input: '$read',
-                      as: 'fieldTag',
-                      in: { $setIsSubset: [['$$fieldTag'], roles] }
-                    }
-                  }
-                },
-                else: true
-              }
-            },
-            then: '$$DESCEND',
-            else: '$$PRUNE'
-          }
-        }
       }
     ];
 
@@ -597,6 +574,30 @@ const executeQuery = async function (args, res, next) {
           as: 'documents'
         }
       });
+
+    aggregation.push(      {
+      $redact: {
+        $cond: {
+          if: {
+            $cond: {
+              if: '$read',
+              then: {
+                $anyElementTrue: {
+                  $map: {
+                    input: '$read',
+                    as: 'fieldTag',
+                    in: { $setIsSubset: [['$$fieldTag'], roles] }
+                  }
+                }
+              },
+              else: true
+            }
+          },
+          then: '$$DESCEND',
+          else: '$$PRUNE'
+        }
+      }
+    });
 
     const data = await collectionObj.aggregate(aggregation);
 


### PR DESCRIPTION
It was possible to float documents/flavours out of the API when a user lacked the required roles due to the redaction occurring before the population of documents. An additional redaction step has been added to the document and flavour populate to re-redact these if the user does not have the roles.

I've left the original redaction pipe in place where it is, just to preemptively strip out records we don't need to process, and keep behaviour consistent when populate=false.

See ticket [NRPT-62](https://bcmines.atlassian.net/browse/NRPT-62)