### PR TITLE
NRPT-247: Swap around LatLong on Core mine import

### DIFF
--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -528,9 +528,10 @@ class CoreDataSource {
         const latitude = mineDetails.mine_location && mineDetails.mine_location.latitude || 0.00;
         const longitude = mineDetails.mine_location && mineDetails.mine_location.longitude || 0.00;
   
+
         completeRecords.push({
           ...coreRecords[i],
-          coordinates: [latitude, longitude],
+          coordinates: [longitude, latitude],
           parties
         });
       } catch (error) {


### PR DESCRIPTION
Swap reversed Latitude and Longitude values in our Core mine importer

See ticket [NRPT-247](https://bcmines.atlassian.net/browse/NRPT-247)