### PR TITLE
NRPT-240: Adds collection search

### DIFF
--- a/angular/projects/admin-nrpti/src/app/app-routing.module.ts
+++ b/angular/projects/admin-nrpti/src/app/app-routing.module.ts
@@ -50,7 +50,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { relativeLinkResolution: 'corrected' })],
   exports: [RouterModule],
   providers: []
 })

--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-list-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-list-resolver.ts
@@ -39,6 +39,11 @@ export class MinesCollectionsListResolver implements Resolve<Observable<object>>
       or['hasRecords'] = params.hasRecords;
     }
 
+    // This should always be set.
+    if (params.mineId) {
+      and['project'] = params.mineId;
+    }
+
     // force-reload so we always have latest data
     return this.factoryService.getRecords(
       keywords,

--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-list-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-list-resolver.ts
@@ -9,22 +9,49 @@ export class MinesCollectionsListResolver implements Resolve<Observable<object>>
   constructor(private factoryService: FactoryService, private tableTemplateUtils: TableTemplateUtils) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<object> {
+    const params = { ...route.params };
+
     // Get params from route, shove into the tableTemplateUtils so that we get a new dataset to work with.
     const tableObject = this.tableTemplateUtils.updateTableObjectWithUrlParams(route.params, new TableObject());
 
+    let keywords = '';
+    if (params.keywords) {
+      keywords = params.keywords;
+    }
+
+    const and = {};
+    const or = {};
+    const nor = {};
+
+    if (params.isBcmiPublished) {
+      or['isBcmiPublished'] = params.isBcmiPublished;
+    }
+
+    if (params.dateRangeFromFilter) {
+      or['dateRangeFromFilterdate'] = params.dateRangeFromFilter;
+    }
+
+    if (params.dateRangeToFilter) {
+      or['dateRangeToFilterdate'] = params.dateRangeToFilter;
+    }
+
+    if (params.hasRecords) {
+      or['hasRecords'] = params.hasRecords;
+    }
+
     // force-reload so we always have latest data
     return this.factoryService.getRecords(
-      '',
+      keywords,
       ['CollectionBCMI'],
       [],
       tableObject.currentPage,
       tableObject.pageSize,
       tableObject.sortBy || '-dateAdded',
-      {},
+      and,
       false,
-      {},
+      or,
       [],
-      {}
+      nor
     );
   }
 }

--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.html
@@ -38,6 +38,19 @@
   </section>
 
   <section>
+    <search-filter-template
+      #explorePanel
+      (searchEvent)='executeSearch($event)'
+      title="Keyword Search"
+      tooltip="Search collection name"
+      [advancedFilters]="true"
+      [showAdvancedFilters]="showAdvancedFilters"
+      [searchOnFilterChange]="true"
+      [filters]="filters">
+    </search-filter-template>
+  </section>
+
+  <section>
     <div class="border-bottom">
       <div class="text-right mb-3">
         <button class="btn btn-primary" (click)="addCollection()" title="Create new collection">
@@ -59,4 +72,5 @@
       (messageOut)="onMessageOut($event)"
     ></lib-table-template>
   </section>
+
 </main>

--- a/angular/projects/common/src/app/search-filter-template/search-filter-template.component.ts
+++ b/angular/projects/common/src/app/search-filter-template/search-filter-template.component.ts
@@ -315,7 +315,9 @@ export class SearchFilterTemplateComponent implements OnInit, AfterViewInit, OnD
     // clear keywords
     this.keywordSearchWords = '';
     // reset the subset settings
-    this.changeSubset(this.subsets.defaultSubset);
+    if (this.subsets) {
+      this.changeSubset(this.subsets.defaultSubset);
+    }
     // emit to the host that the form was reset
     this.resetControls.emit();
     // rerun the search

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -49,6 +49,10 @@ let generateExpArray = async function (field, logicalOperator = '$or', compariso
         return getHasDocumentsExp(entry);
       }
 
+      if (item === 'hasRecords') {
+        return getHasDocumentsExp(entry);
+      }
+
       if (item === 'isNrcedPublished' && entry === 'true') {
         return { isNrcedPublished: true }
       } else if (item === 'isNrcedPublished' && entry === 'false') {
@@ -122,6 +126,19 @@ const getHasDocumentsExp = function (entry) {
   }
 };
 exports.getHasDocumentsExp = getHasDocumentsExp;
+
+const getHasRecordsExp = function (entry) {
+  // We're checking if there are docs in the record or not.
+  if (entry === 'true') {
+    return { $and: [{ records: { $exists: true } }, { records: { $not: { $size: 0 } } }] };
+  } else if (entry === 'false') {
+    return { $or: [{ records: { $exists: false } }, { records: { $size: 0 } }] };
+  } else {
+    // Invalid
+    return {};
+  }
+};
+exports.getHasRecordsExp = getHasRecordsExp;
 
 /**
  * Generate an expression for a basic parameter key/value

--- a/api/src/models/bcmi/collection-bcmi.js
+++ b/api/src/models/bcmi/collection-bcmi.js
@@ -42,7 +42,8 @@ module.exports = require('../../utils/model-schema-generator')(
     dateUpdated: { type: Date, default: null },
     updatedBy: { type: String, default: '' },
     datePublished: { type: Date, default: null },
-    publishedBy: { type: String, default: '' }
+    publishedBy: { type: String, default: '' },
+    isBcmiPublished: { type: Boolean, default: false, index: true },
   },
   'nrpti'
 );


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-200

Uses the new search component to add searching to the collections list of a mine.

Three of the ticket criteria are currently not implemented. Agency and Type have placeholders in the code and can be implemented once this is known from the create collection ticket. Searching on BCMI tab is currently not possible. Again, will have to wait to see how collection creation is implemented.