### PR TITLE
NRPT-274: Extra valid test for ObjectID type

### DIFF
--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -149,7 +149,7 @@ exports.getConvertedValue = getConvertedValue;
 
 const convertValue = function (item) {
   if (isNaN(item) || item === null) {
-    if (mongoose.Types.ObjectId.isValid(item)) {
+    if (mongoose.Types.ObjectId.isValid(item) && mongoose.Types.ObjectId(item).toString() === item) {
       defaultLog.info('objectid', item);
       // ObjectID
       return mongoose.Types.ObjectId(item);


### PR DESCRIPTION
Strings that equal 12 chars will be detected as an ObjectID, even though they're not supposed to (ie. Wildlife Act). This will cause filters to fail as it will convert the valid string into an invalid objectID.

See ticket [NRPT-274](https://bcmines.atlassian.net/browse/NRPT-274)

Note: I believe the fix requested in the ticket is incorrect. These values should remain as strings. However as some are exactly 12 chars they fail on filters as they are converted to ObjectID's inadvertently.

If the decision is made that these should all be objectid values, this fix should still be put in place as it corrects a deficiency in the ObjectID.isValid() test.