### PR TITLE
NRPT-252: Fixes Core Import Update

### DIFF
--- a/api/src/controllers/post/permit-amendment.js
+++ b/api/src/controllers/post/permit-amendment.js
@@ -57,7 +57,7 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
   incomingObj.issueDate && (permitAmendment.issueDate = incomingObj.issueDate);
   incomingObj.authorizedEndDate && (permitAmendment.authorizedEndDate = incomingObj.authorizedEndDate);
   incomingObj.description && (permitAmendment.description = incomingObj.description);
-  (incomingObj.documents && incomingObj.documents.length) && (permitAmendment.documents = incomingObj.documents);
+  (incomingObj.amendmentDocuments && incomingObj.amendmentDocuments.length) && (permitAmendment.amendmentDocuments = incomingObj.amendmentDocuments);
 
   // Set meta.
   permitAmendment.addedBy = args && args.swagger.params.auth_payload.displayName || incomingObj.addedBy;
@@ -106,8 +106,7 @@ exports.createBCMI = function (args, res, next, incomingObj) {
   incomingObj.issueDate && (permitAmendmentBCMI.issueDate = incomingObj.issueDate);
   incomingObj.authorizedEndDate && (permitAmendmentBCMI.authorizedEndDate = incomingObj.authorizedEndDate);
   incomingObj.description && (permitAmendmentBCMI.description = incomingObj.description);
-  (incomingObj.documents && incomingObj.documents.length) && (permitAmendmentBCMI.documents = incomingObj.documents);
-
+  (incomingObj.amendmentDocuments && incomingObj.amendmentDocuments.length) && (permitAmendmentBCMI.amendmentDocuments = incomingObj.amendmentDocuments);
   // Set meta.
   permitAmendmentBCMI.addedBy = args && args.swagger.params.auth_payload.displayName || incomingObj.addedBy;
   permitAmendmentBCMI.updatedBy = args && args.swagger.params.auth_payload.displayName || incomingObj.updatedBy;

--- a/api/src/integrations/core/mine-utils.js
+++ b/api/src/integrations/core/mine-utils.js
@@ -57,9 +57,6 @@ class Mines extends BaseRecordUtils {
       permittee: '',
       permitNumber: '',
       permit: null,
-      type: '',
-      summary: '',
-      description: '',
       links: []
     };
   }
@@ -163,6 +160,16 @@ class Mines extends BaseRecordUtils {
       permit: new ObjectId(permit._id),
       permittee: this.getParty(MINE_PARTY_PERMITTEE, permit, parties)
     }
+  }
+
+  updateRecord(nrptiRecord, existingRecord) {
+    // The permit information is updated separately and the NRPTI record will not contain it.
+    // Copy permit information over before updating to preserve it.
+    nrptiRecord.permittee = existingRecord.permittee;
+    nrptiRecord.permit = existingRecord.permit;
+    nrptiRecord.permitNumber = existingRecord.permitNumber;
+
+    return super.updateRecord(nrptiRecord, existingRecord);
   }
 }
 

--- a/api/src/integrations/core/mine-utils.test.js
+++ b/api/src/integrations/core/mine-utils.test.js
@@ -67,9 +67,6 @@ describe('MineUtils', () => {
         region: 'TE',
         location: { type: 'Point', coordinates: [ 123, 456 ]},
         permittee: '',
-        type: '',
-        summary: '',
-        description: '',
         links: []
       };
 

--- a/api/src/integrations/core/permit-amendment-utils.js
+++ b/api/src/integrations/core/permit-amendment-utils.js
@@ -48,7 +48,7 @@ class PermitAmendments extends BaseRecordUtils {
       issueDate: amendment.issue_date || null,
       authorizedEndDate: amendment.authorized_end_date || null,
       description: amendment.description,
-      documents: amendment.related_documents.map(document => ({
+      amendmentDocuments: amendment.related_documents.map(document => ({
         _sourceRefId: document.document_manager_guid,
         documentName: document.document_name,
         documentId: null

--- a/api/src/models/bcmi/permitAmendment-bcmi.js
+++ b/api/src/models/bcmi/permitAmendment-bcmi.js
@@ -15,7 +15,7 @@ module.exports = require('../../utils/model-schema-generator')(
     issueDate: { type: Date, default: null },
     authorizedEndDate: { type: Date, default: null },
     description: { type: String, default: '' },
-    documents: [{
+    amendmentDocuments: [{
       _sourceRefId: { type: String, default: null },
       documentName: { type: String, defualt: '' },
       documentId: { type: 'ObjectId', default: null }

--- a/api/src/models/master/permitAmendment.js
+++ b/api/src/models/master/permitAmendment.js
@@ -17,7 +17,7 @@ module.exports = require('../../utils/model-schema-generator')(
     issueDate: { type: Date, default: null },
     authorizedEndDate: { type: Date, default: null },
     description: { type: String, default: '' },
-    documents: [{
+    amendmentDocuments: [{
       _sourceRefId: { type: String, default: null },
       documentName: { type: String, defualt: '' },
       documentId: { type: 'ObjectId', default: null }


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-252

There were a couple issues that would occur when the Core import would run an update on a Mine record. One problem is that using the put-utils, anything named 'documents' goes through a role update, but they expect it to just be an array of object IDs. Permit Amendment documents are a different shape, so I update the property to reflect that and avoid the role update which should not happen on them.