### PR TITLE
NRPT-199: Add in Mine Record List filter set

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.ts
@@ -3,7 +3,7 @@ import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { TableTemplateUtils, TableObject } from 'nrpti-angular-components';
 import { FactoryService } from '../services/factory.service';
-import { EpicProjectIds, SchemaLists } from '../../../../common/src/app/utils/record-constants';
+import { SchemaLists } from '../../../../common/src/app/utils/record-constants';
 
 @Injectable()
 export class MinesRecordsListResolver implements Resolve<Observable<object>> {
@@ -41,68 +41,20 @@ export class MinesRecordsListResolver implements Resolve<Observable<object>> {
       or['dateRangeToFilterdateIssued'] = params.dateRangeToFilter;
     }
 
-    if (params.issuedToCompany && params.issuedToIndividual) {
-      or['issuedTo.type'] = 'Company,Individual,IndividualCombined';
-    } else if (params.issuedToCompany) {
-      or['issuedTo.type'] = 'Company';
-    } else if (params.issuedToIndividual) {
-      or['issuedTo.type'] = 'Individual,IndividualCombined';
-    }
-
     if (params.agency) {
       or['issuingAgency'] = params.agency;
-    }
-
-    if (params.act) {
-      or['legislation.act'] = params.act;
-    }
-
-    if (params.regulation) {
-      or['legislation.regulation'] = params.regulation;
     }
 
     if (params.sourceSystemRef) {
       or['sourceSystemRef'] = params.sourceSystemRef;
     }
 
-    if (params.hasDocuments) {
-      or['hasDocuments'] = params.hasDocuments;
+    if (params.isBcmiPublished) {
+      or['isBcmiPublished'] = params.isBcmiPublished;
     }
 
-    if (params.projects) {
-      const projectIds = [];
-
-      if (params.projects.includes('lngCanada')) {
-        projectIds.push(EpicProjectIds.lngCanadaId);
-      }
-
-      if (params.projects.includes('coastalGaslink')) {
-        projectIds.push(EpicProjectIds.coastalGaslinkId);
-      }
-
-      if (params.projects.includes('otherProjects')) {
-        if (projectIds.length === 0) {
-          // Selecting only Other should return all projects EXCEPT for LNG Canada and Coastal Gaslink
-          nor['_epicProjectId'] = `${EpicProjectIds.lngCanadaId},${EpicProjectIds.coastalGaslinkId}`;
-        } else if (projectIds.length === 1) {
-          if (projectIds[0] === EpicProjectIds.lngCanadaId) {
-            // Other + LNG Canada is equivalent to NOT Coastal Gaslink
-            nor['_epicProjectId'] = EpicProjectIds.coastalGaslinkId;
-          } else {
-            // Other + Coastal Gaslink is equivalent to NOT LNG Canada
-            nor['_epicProjectId'] = EpicProjectIds.lngCanadaId;
-          }
-        }
-      } else if (projectIds.length) {
-        or['_epicProjectId'] = projectIds.join(',');
-      }
-    }
-
-    if (params.isNrcedPublished) {
-      or['isNrcedPublished'] = params.isNrcedPublished;
-    }
-    if (params.isLngPublished) {
-      or['isLngPublished'] = params.isLngPublished;
+    if (params.hasCollection) {
+      or['hasCollection'] = params.hasCollection;
     }
 
     // force-reload so we always have latest data

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.html
@@ -46,6 +46,7 @@
       [advancedFilters]="true"
       [showAdvancedFilters]="showAdvancedFilters"
       [searchOnFilterChange]="true"
+      filterItemPanelSize="3"
       [filters]="filters">
     </search-filter-template>
   </section>
@@ -53,7 +54,7 @@
     <div *ngIf="!tableData.totalListItems">
       No Mines found.
     </div>
-  
+
     <lib-table-template
       *ngIf="tableData.totalListItems > 0"
       [data]="tableData"

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.ts
@@ -14,7 +14,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MinesRecordsTableRowComponent } from '../mines-records-rows/mines-records-table-row.component';
 import { SearchSubsets, Picklists } from '../../../../../common/src/app/utils/record-constants';
-import { FilterObject, FilterType, DateFilterDefinition, CheckOrRadioFilterDefinition, OptionItem, RadioOptionItem, MultiSelectDefinition, DropdownDefinition } from '../../../../../common/src/app/search-filter-template/filter-object';
+import { FilterObject, FilterType, DateFilterDefinition, CheckOrRadioFilterDefinition, RadioOptionItem, MultiSelectDefinition, DropdownDefinition } from '../../../../../common/src/app/search-filter-template/filter-object';
 import { SubsetsObject, SubsetOption } from '../../../../../common/src/app/search-filter-template/subset-object';
 import { Mine } from '../../../../../common/src/app/models/bcmi/mine';
 
@@ -83,6 +83,7 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
     },
     {
       name: 'Published',
+      value: 'isBcmiPubished',
       width: 'col-1'
     },
     {
@@ -119,29 +120,12 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
     ];
     this.subsets = new SubsetsObject(subsetOptions);
 
-    // setup the advanced filters
     const issuedDateFilter = new FilterObject(
       'issuedDate',
       FilterType.DateRange,
       '', // if you include a name, it will add a label to the date range filter.
-      new DateFilterDefinition('dateRangeFromFilter', 'Start Issued Date', 'dateRangeToFilter', 'End Issued Date')
-    );
-
-    const entityTypeFilter = new FilterObject(
-      'entityType',
-      FilterType.Checkbox,
-      'Entity Type',
-      new CheckOrRadioFilterDefinition([new OptionItem('issuedToCompany', 'Company'), new OptionItem('issuedToIndividual', 'Individual')])
-    );
-
-    const publishedStatefilter = new FilterObject(
-      'isNrcedPublished',
-      FilterType.RadioPicker,
-      'NRCED Published State',
-      new CheckOrRadioFilterDefinition([
-        new RadioOptionItem('publishedState', 'Published', 'true'),
-        new RadioOptionItem('unpubState', 'Unpublished', 'false')
-      ])
+      new DateFilterDefinition('dateRangeFromFilter', 'Start Issued Date', 'dateRangeToFilter', 'End Issued Date'),
+      6
     );
 
     const activityTypeFilter = new FilterObject(
@@ -150,26 +134,8 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
       'Activity Type',
       new MultiSelectDefinition(Object.values(Picklists.activityTypePicklist).map(item => {
         return { value: item._schemaName, displayValue: item.displayName, selected: false, display: true };
-      }), 'Begin typing to filter activities...', 'Select all that apply...', true)
-    );
-
-    const issuedUnderActFilter = new FilterObject(
-      'act',
-      FilterType.MultiSelect,
-      'Issued Under which Act',
-      new MultiSelectDefinition(Picklists.getAllActs().map(value => {
-        return { value: value, displayValue: value, selected: false, display: true };
-      }), 'Begin typing to filter acts...', '', true)
-    );
-
-    const lngPublishedStatefilter = new FilterObject(
-      'isLngPublished',
-      FilterType.RadioPicker,
-      'LNG Published State',
-      new CheckOrRadioFilterDefinition([
-        new RadioOptionItem('lngPublishedState', 'Published', 'true'),
-        new RadioOptionItem('lngUnpubState', 'Unpublished', 'false')
-      ])
+      }), 'Begin typing to filter activities...', 'Select all that apply...'),
+      6
     );
 
     const responsibleAgencyFilter = new FilterObject(
@@ -178,16 +144,7 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
       'Responsible Agency',
       new MultiSelectDefinition(Picklists.agencyPicklist.map(value => {
         return { value: value, displayValue: value, selected: false, display: true };
-      }), 'Begin typing to filter agencies...', '', true)
-    );
-
-    const issuedUnderRegFilter = new FilterObject(
-      'regulation',
-      FilterType.MultiSelect,
-      'Issued Under which Regulation',
-      new MultiSelectDefinition(Picklists.getAllRegulations().map(value => {
-        return { value: value, displayValue: value, selected: false, display: true };
-      }), 'Begin typing to filter regulations...', '', true)
+      }), 'Begin typing to filter agencies...', '')
     );
 
     const sourceSystemFilter = new FilterObject(
@@ -197,40 +154,33 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
       new DropdownDefinition(Picklists.sourceSystemRefPicklist)
     );
 
-    const projectFilter = new FilterObject(
-      'projects',
-      FilterType.Checkbox,
-      'Project',
+    const bcmiPublishedStatefilter = new FilterObject(
+      'isBcmiPublished',
+      FilterType.RadioPicker,
+      'BCMI Published State',
       new CheckOrRadioFilterDefinition([
-        new OptionItem('lngCanada', 'LNG Canada'),
-        new OptionItem('coastalGaslink', 'Coastal Gaslink'),
-        new OptionItem('otherProjects', 'Other')],
-        true)
+        new RadioOptionItem('bcmiPublishedState', 'Published', 'true'),
+        new RadioOptionItem('bcmiUnpubState', 'Unpublished', 'false')
+      ])
     );
 
-    const documentsfilter = new FilterObject(
-      'hasDocuments',
+    const hasCollectionsStatefilter = new FilterObject(
+      'hasCollection',
       FilterType.RadioPicker,
-      'Documents',
+      'Has Associated Collection',
       new CheckOrRadioFilterDefinition([
-        new RadioOptionItem('yesDoc', 'Yes', 'true'),
-        new RadioOptionItem('noDoc', 'No', 'false')
+        new RadioOptionItem('hasCollection', 'Yes', 'true'),
+        new RadioOptionItem('doesNotHaveCollection', 'No', 'false')
       ])
     );
 
     this.filters = [
       issuedDateFilter,
-      entityTypeFilter,
-      publishedStatefilter,
       activityTypeFilter,
-      issuedUnderActFilter,
-      lngPublishedStatefilter,
       responsibleAgencyFilter,
-      issuedUnderRegFilter,
       sourceSystemFilter,
-      projectFilter,
-      documentsfilter
-    ];
+      bcmiPublishedStatefilter,
+      hasCollectionsStatefilter];
   }
 
   executeSearch(searchPackage) {
@@ -260,21 +210,13 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
 
   private clearQueryParamsFilters() {
     delete this.queryParams['keywords'];
-    delete this.queryParams['subset'];
-    delete this.queryParams['activityType'];
     delete this.queryParams['dateRangeFromFilter'];
     delete this.queryParams['dateRangeToFilter'];
-    delete this.queryParams['issuedToCompany'];
-    delete this.queryParams['issuedToIndividual'];
     delete this.queryParams['activityType'];
     delete this.queryParams['agency'];
-    delete this.queryParams['act'];
-    delete this.queryParams['regulation'];
     delete this.queryParams['sourceSystemRef'];
-    delete this.queryParams['hasDocuments'];
-    delete this.queryParams['projects'];
-    delete this.queryParams['isNrcedPublished'];
-    delete this.queryParams['isLngPublished'];
+    delete this.queryParams['isBcmiPublished'];
+    delete this.queryParams['hasCollection'];
   }
 
   /**


### PR DESCRIPTION
Adding the mines records list filters, updating resolver. Note that some filters are not yet implementable: BCMI Published and Has Collection. These will have to be implemented once their requisite components are in place in the system.

Second part of ticket [NRPT-199](https://bcmines.atlassian.net/browse/NRPT-199)