### PR TITLE
NRPT-282: Adding mineGuid to 'and' in list resolver

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.spec.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.spec.ts
@@ -89,13 +89,17 @@ describe('MinesRecordsListResolver', () => {
             'Warning',
             'ConstructionPlan',
             'ManagementPlan',
-            'CourtConviction'
+            'CourtConviction',
+            'PermitBCMI',
+            'PermitAmendmentBCMI'
           ],
           [],
           1,
           25,
           '-dateAdded',
-          {},
+          {
+            mineGuid: ''
+          },
           false,
           {},
           [],
@@ -160,13 +164,17 @@ describe('MinesRecordsListResolver', () => {
             'Warning',
             'ConstructionPlan',
             'ManagementPlan',
-            'CourtConviction'
+            'CourtConviction',
+            'PermitBCMI',
+            'PermitAmendmentBCMI'
           ],
           [],
           1,
           25,
           '-dateAdded',
-          {},
+          {
+            mineGuid: ''
+          },
           false,
           {},
           [],

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list-resolver.ts
@@ -14,7 +14,7 @@ export class MinesRecordsListResolver implements Resolve<Observable<object>> {
     // Get params from route, shove into the tableTemplateUtils so that we get a new dataset to work with.
     const tableObject = this.tableTemplateUtils.updateTableObjectWithUrlParams(route.params, new TableObject());
 
-    let schemaList = SchemaLists.allBasicRecordTypes;
+    let schemaList = SchemaLists.bcmiRecordTypes;
 
     if (params.activityType) {
       schemaList = params.activityType.split(',');
@@ -29,9 +29,18 @@ export class MinesRecordsListResolver implements Resolve<Observable<object>> {
       subset = params.subset.split(',');
     }
 
-    const and = {};
+    const and = {
+      mineGuid: ''
+    };
     const or = {};
     const nor = {};
+
+    // fetch the mine from the parent resolver so we can get the sourceRefId
+
+    if (route.parent && route.parent.data && route.parent.data.mine) {
+      const mineResult = route.parent.data.mine;
+      and.mineGuid = mineResult[0].data._sourceRefId;
+    }
 
     if (params.dateRangeFromFilter) {
       or['dateRangeFromFilterdateIssued'] = params.dateRangeFromFilter;

--- a/angular/projects/admin-nrpti/src/app/mines/mines-routing.module.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-routing.module.ts
@@ -79,8 +79,7 @@ const routes: Routes = [
               breadcrumb: 'Mine Records'
             },
             resolve: {
-              records: MinesRecordsListResolver,
-              mine: MinesResolver
+              records: MinesRecordsListResolver
             }
           },
           {
@@ -146,7 +145,10 @@ const routes: Routes = [
               }
             ]
           }
-        ]
+        ],
+        resolve: {
+          mine: MinesResolver
+        }
       }
     ]
   }

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -51,6 +51,11 @@ export class SchemaLists {
     'CourtConviction'
   ];
 
+  public static readonly bcmiRecordTypes = SchemaLists.allBasicRecordTypes.concat([
+    'PermitBCMI',
+    'PermitAmendmentBCMI'
+  ]);
+
   // set schema filters
   public static readonly nrcedPublicBasicRecordTypes = [
     'OrderNRCED',


### PR DESCRIPTION
Adding filter to resolver to return only records asssociated with a mine via their mineGuid

See ticket [NRPT-282](https://bcmines.atlassian.net/browse/NRPT-282)