### PR TITLE
NRPT-167: Fix for panel display on focus bug

### DIFF
--- a/angular/projects/common/src/app/autocomplete-multi-select/autocomplete-multi-select.component.html
+++ b/angular/projects/common/src/app/autocomplete-multi-select/autocomplete-multi-select.component.html
@@ -34,7 +34,7 @@
     [matAutocomplete]="multiAutocomplete"
   />
 <mat-autocomplete #multiAutocomplete="matAutocomplete">
-  <mat-option (click)="selectNone()" title="Select none">Clear Selected</mat-option>
+  <mat-option (click)="selectNone()" title="Select none" value="Clear Selected">Clear Selected</mat-option>
   <ng-container *ngFor="let option of options">
     <mat-option
       *ngIf="option.display"


### PR DESCRIPTION
There's an outstanding bug in the angular material autocomplete component that can cause the panel to not display in some circumstances if the component has the focus. This is mainly around mat-option click events and the "clear selected" functionality.

To get around this, I've added the MatAutocompleteTrigger to force an onChange event whenever the clear is selected, which will force the popup to display as expected.

Additionally, fixed a small bug where you couldn't hit the "clear selected" option via keyboard commands only.