### PR TITLE
NRPT-249: Update mine map for populating summary with Intro content.

### DIFF
--- a/api/migrations/20200724171605-bcmiDataLoad.js
+++ b/api/migrations/20200724171605-bcmiDataLoad.js
@@ -95,11 +95,14 @@ async function updateMine(mineData, nrpti) {
     }
 
     console.log("Updating:", mineData.name);
+    const summary = mineData.content.filter(content => {
+      return content.type === 'Intro' && content.page === 'Mines';
+    })[0].html;
 
     return nrpti.update({ _id: new ObjectID(nrptiMines[0]._id) }, {
       $set: {
         type:            mineData.type,
-        summary:         mineData.description, // BCMI doesn't have a "summary" attribute
+        summary:         summary,
         description:     mineData.description,
         links:           externalLinks,
         updatedBy:       'NRPTI BCMI Data Migration',


### PR DESCRIPTION
We will need to delete the bcmiDataLoad migration from the DBs before re-running this.  It's safe to do so as this script can be run as many times as necessary.