### PR TITLE
NRPT-190: Disable edit for imported records

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -136,73 +136,74 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       offence: new FormControl({
         value: (this.currentRecord && this.currentRecord.offence) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -210,28 +211,28 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -275,21 +276,21 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
         new FormGroup({
           type: new FormControl({
             value: penalty.type || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
           penalty: new FormGroup({
             type: new FormControl({
               value: penalty.penalty.type || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             }),
             value: new FormControl({
               value: penalty.penalty.value || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             })
           }),
           description: new FormControl({
             value: penalty.description || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           })
         })
       );

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -61,7 +61,13 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
           alert('Error: could not load edit administrative penalty.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -130,72 +136,103 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      offence: new FormControl((this.currentRecord && this.currentRecord.offence) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      offence: new FormControl({
+        value: (this.currentRecord && this.currentRecord.offence) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
       // NRCED
@@ -236,12 +273,24 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     this.currentRecord.penalties.forEach(penalty => {
       penalties.push(
         new FormGroup({
-          type: new FormControl(penalty.type || ''),
-          penalty: new FormGroup({
-            type: new FormControl(penalty.penalty.type || ''),
-            value: new FormControl(penalty.penalty.value || '')
+          type: new FormControl({
+            value: penalty.type || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
           }),
-          description: new FormControl(penalty.description || '')
+          penalty: new FormGroup({
+            type: new FormControl({
+              value: penalty.penalty.type || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            }),
+            value: new FormControl({
+              value: penalty.penalty.value || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            })
+          }),
+          description: new FormControl({
+            value: penalty.description || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          })
         })
       );
     });

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -61,7 +61,13 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
           alert('Error: could not load edit administrative sanction.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -132,72 +138,103 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-          ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-            ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
       // NRCED
@@ -238,12 +275,24 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     this.currentRecord.penalties.forEach(penalty => {
       penalties.push(
         new FormGroup({
-          type: new FormControl(penalty.type || ''),
-          penalty: new FormGroup({
-            type: new FormControl(penalty.penalty.type || ''),
-            value: new FormControl(penalty.penalty.value || '')
+          type: new FormControl({
+            value: penalty.type || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
           }),
-          description: new FormControl(penalty.description || '')
+          penalty: new FormGroup({
+            type: new FormControl({
+              value: penalty.penalty.type || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            }),
+            value: new FormControl({
+              value: penalty.penalty.value || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            })
+          }),
+          description: new FormControl({
+            value: penalty.description || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          })
         })
       );
     });

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -138,73 +138,74 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -212,28 +213,28 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -277,21 +278,21 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
         new FormGroup({
           type: new FormControl({
             value: penalty.type || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
           penalty: new FormGroup({
             type: new FormControl({
               value: penalty.penalty.type || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             }),
             value: new FormControl({
               value: penalty.penalty.value || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             })
           }),
           description: new FormControl({
             value: penalty.description || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           })
         })
       );

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
@@ -54,7 +54,13 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit agreement.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
       this.loading = false;
       this._changeDetectionRef.detectChanges();
@@ -89,16 +95,23 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-          ''
-      ),
-      nationName: new FormControl((this.currentRecord && this.currentRecord.nationName) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+      nationName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.nationName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngDescription: new FormControl({

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
@@ -95,22 +95,23 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
       nationName: new FormControl({
         value: (this.currentRecord && this.currentRecord.nationName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
@@ -122,69 +122,70 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInBcmiRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInBcmiRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -192,28 +193,28 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // BCMI

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
@@ -57,7 +57,13 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit annual report.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -116,71 +122,99 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInBcmiRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInBcmiRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // BCMI
       bcmiDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
@@ -135,74 +135,74 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
         (!this.factoryService.userInLngRole() || !this.factoryService.userInBcmiRole())
       }),
       recordSubtype: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -210,28 +210,28 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
@@ -60,7 +60,13 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit certificate amendment.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -129,72 +135,104 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole() || !this.factoryService.userInBcmiRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        (!this.factoryService.userInLngRole() || !this.factoryService.userInBcmiRole())
       }),
-      recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      recordSubtype: new FormControl({
+        value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -126,7 +126,8 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
       dateIssued: new FormControl({
@@ -134,53 +135,53 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -58,7 +58,13 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit certificate.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -120,42 +126,62 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
       recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -98,38 +98,39 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
       agency: new FormControl({
         value: (this.currentRecord && this.currentRecord.agency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -57,7 +57,13 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit construction plan.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
       this.loading = false;
       this._changeDetectionRef.detectChanges();
@@ -92,24 +98,39 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      agency: new FormControl((this.currentRecord && this.currentRecord.agency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+      agency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.agency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
@@ -135,7 +135,7 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
         (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
       dateIssued: new FormControl({
@@ -143,62 +143,62 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -206,28 +206,28 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // NRCED

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
@@ -59,7 +59,13 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit correspondence.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -129,71 +135,100 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // NRCED
       nrcedDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -60,7 +60,13 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit court conviction.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -129,73 +135,107 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      recordSubtype: new FormControl({
+        value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      offence: new FormControl((this.currentRecord && this.currentRecord.offence) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      offence: new FormControl({
+        value: (this.currentRecord && this.currentRecord.offence) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
       // NRCED

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -135,77 +135,78 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       recordSubtype: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       offence: new FormControl({
         value: (this.currentRecord && this.currentRecord.offence) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -213,28 +214,28 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
@@ -135,7 +135,7 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
         (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
       dateIssued: new FormControl({
@@ -143,62 +143,62 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -206,28 +206,28 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // nrced

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
@@ -59,7 +59,13 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit dam safety inspection.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -129,71 +135,100 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // nrced
       nrcedDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -137,73 +137,74 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -211,36 +212,36 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeStatus: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // NRCED

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -62,7 +62,13 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit inspection.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -131,74 +137,111 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
-      outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
-      outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeStatus: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // NRCED
       nrcedSummary: new FormControl({

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -57,7 +57,13 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit management plan.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
       this.loading = false;
       this._changeDetectionRef.detectChanges();
@@ -92,24 +98,39 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      agency: new FormControl((this.currentRecord && this.currentRecord.agency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      agency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.agency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -98,38 +98,39 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       agency: new FormControl({
         value: (this.currentRecord && this.currentRecord.agency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -63,7 +63,13 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit order.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -132,75 +138,115 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      recordSubtype: new FormControl({
+        value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
-      outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
-      outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeStatus: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // NRCED
       nrcedSummary: new FormControl({

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -138,77 +138,78 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       recordSubtype: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -216,36 +217,36 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeStatus: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // NRCED

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -127,64 +127,65 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       recordSubtype: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -59,7 +59,13 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit permit.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -121,42 +127,65 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      recordSubtype: new FormControl((this.currentRecord && this.currentRecord.recordSubtype) || ''),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      recordSubtype: new FormControl({
+        value: (this.currentRecord && this.currentRecord.recordSubtype) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngDescription: new FormControl({

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
@@ -135,7 +135,7 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
           (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
       dateIssued: new FormControl({
@@ -143,62 +143,62 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -206,28 +206,28 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // nrced

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
@@ -59,7 +59,13 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit report.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -129,71 +135,100 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' &&
+          (!this.factoryService.userInNrcedRole() || !this.factoryService.userInBcmiRole())
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // nrced
       nrcedDescription: new FormControl(

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -136,73 +136,74 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       offence: new FormControl({
         value: (this.currentRecord && this.currentRecord.offence) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -210,28 +211,28 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -275,21 +276,21 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
         new FormGroup({
           type: new FormControl({
             value: penalty.type || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
           penalty: new FormGroup({
             type: new FormControl({
               value: penalty.penalty.type || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             }),
             value: new FormControl({
               value: penalty.penalty.value || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             })
           }),
           description: new FormControl({
             value: penalty.description || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           })
         })
       );

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -61,7 +61,13 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit restorative justice.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -130,72 +136,103 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      offence: new FormControl((this.currentRecord && this.currentRecord.offence) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      offence: new FormControl({
+        value: (this.currentRecord && this.currentRecord.offence) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
       // NRCED
@@ -236,12 +273,24 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     this.currentRecord.penalties.forEach(penalty => {
       penalties.push(
         new FormGroup({
-          type: new FormControl(penalty.type || ''),
-          penalty: new FormGroup({
-            type: new FormControl(penalty.penalty.type || ''),
-            value: new FormControl(penalty.penalty.value || '')
+          type: new FormControl({
+            value: penalty.type || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
           }),
-          description: new FormControl(penalty.description || '')
+          penalty: new FormGroup({
+            type: new FormControl({
+              value: penalty.penalty.type || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            }),
+            value: new FormControl({
+              value: penalty.penalty.value || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            })
+          }),
+          description: new FormControl({
+            value: penalty.description || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          })
         })
       );
     });

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -127,64 +127,65 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // LNG

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -59,7 +59,13 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit selfReport.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -121,42 +127,65 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // LNG
       lngRelatedPhase: new FormControl((this.currentRecord && this.lngFlavour && this.lngFlavour.relatedPhase) || ''),

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -61,7 +61,13 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit ticket.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -130,72 +136,103 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      offence: new FormControl((this.currentRecord && this.currentRecord.offence) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      offence: new FormControl({
+        value: (this.currentRecord && this.currentRecord.offence) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
       // NRCED
@@ -236,12 +273,24 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     this.currentRecord.penalties.forEach(penalty => {
       penalties.push(
         new FormGroup({
-          type: new FormControl(penalty.type || ''),
-          penalty: new FormGroup({
-            type: new FormControl(penalty.penalty.type || ''),
-            value: new FormControl(penalty.penalty.value || '')
+          type: new FormControl({
+            value: penalty.type || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
           }),
-          description: new FormControl(penalty.description || '')
+          penalty: new FormGroup({
+            type: new FormControl({
+              value: penalty.penalty.type || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            }),
+            value: new FormControl({
+              value: penalty.penalty.value || '',
+              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            })
+          }),
+          description: new FormControl({
+            value: penalty.description || '',
+            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          })
         })
       );
     });

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -136,73 +136,74 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       offence: new FormControl({
         value: (this.currentRecord && this.currentRecord.offence) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -210,28 +211,28 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       penalties: new FormArray(this.getPenaltiesFormGroups()),
 
@@ -275,21 +276,21 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
         new FormGroup({
           type: new FormControl({
             value: penalty.type || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
           penalty: new FormGroup({
             type: new FormControl({
               value: penalty.penalty.type || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             }),
             value: new FormControl({
               value: penalty.penalty.value || '',
-              disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+              disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
             })
           }),
           description: new FormControl({
             value: penalty.description || '',
-            disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+            disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           })
         })
       );

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -137,73 +137,74 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti') &&
+          !this.factoryService.userInLngRole()
       }),
       dateIssued: new FormControl({
         value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
         '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
         value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
         value: (this.currentRecord && this.currentRecord.author) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       legislation: new FormGroup({
         act: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         regulation: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         section: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         subSection: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         paragraph: new FormControl({
           value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       legislationDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuedTo: new FormGroup({
         type: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         companyName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         firstName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         middleName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         lastName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         fullName: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         }),
         dateOfBirth: new FormControl({
           value: (this.currentRecord &&
@@ -211,36 +212,36 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
           '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
           }),
         anonymous: new FormControl({
           value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
-          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
         })
       }),
       projectName: new FormControl({
         value: (this.currentRecord && this.currentRecord.projectName) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       location: new FormControl({
         value: (this.currentRecord && this.currentRecord.location) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       latitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       longitude: new FormControl({
         value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeStatus: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       outcomeDescription: new FormControl({
         value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
-        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
 
       // NRCED

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -62,7 +62,13 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
           alert('Error: could not load edit warning.');
           this.router.navigate(['/']);
         }
+      } else {
+        this.currentRecord = {
+          sourceSystemRef: 'nrpti',
+          documents: []
+        };
       }
+
       this.buildForm();
 
       this.subscribeToFormControlChanges();
@@ -131,74 +137,111 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
       // Master
       recordName: new FormControl({
         value: (this.currentRecord && this.currentRecord.recordName) || '',
-        disabled: !this.factoryService.userInLngRole()
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti' && !this.factoryService.userInLngRole()
       }),
-      dateIssued: new FormControl(
-        (this.currentRecord &&
+      dateIssued: new FormControl({
+        value: (this.currentRecord &&
           this.currentRecord.dateIssued &&
           this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.dateIssued))) ||
-        ''
-      ),
-      issuingAgency: new FormControl((this.currentRecord && this.currentRecord.issuingAgency) || ''),
-      author: new FormControl((this.currentRecord && this.currentRecord.author) || ''),
-      legislation: new FormGroup({
-        act: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || ''
-        ),
-        regulation: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || ''
-        ),
-        section: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || ''
-        ),
-        subSection: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || ''
-        ),
-        paragraph: new FormControl(
-          (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || ''
-        )
+        '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
       }),
-      legislationDescription: new FormControl((this.currentRecord && this.currentRecord.legislationDescription) || ''),
+      issuingAgency: new FormControl({
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      author: new FormControl({
+        value: (this.currentRecord && this.currentRecord.author) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      legislation: new FormGroup({
+        act: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.act) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        regulation: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.regulation) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        section: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.section) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        subSection: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.subSection) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        paragraph: new FormControl({
+          value: (this.currentRecord && this.currentRecord.legislation && this.currentRecord.legislation.paragraph) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
+      }),
+      legislationDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.legislationDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
       issuedTo: new FormGroup({
-        type: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || ''
-        ),
-        companyName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || ''
-        ),
-        firstName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || ''
-        ),
-        middleName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || ''
-        ),
-        lastName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || ''
-        ),
-        fullName: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || ''
-        ),
-        dateOfBirth: new FormControl(
-          (this.currentRecord &&
+        type: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.type) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        companyName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.companyName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        firstName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.firstName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        middleName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.middleName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        lastName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.lastName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        fullName: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.fullName) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        }),
+        dateOfBirth: new FormControl({
+          value: (this.currentRecord &&
             this.currentRecord.issuedTo &&
             this.currentRecord.issuedTo.dateOfBirth &&
             this.utils.convertJSDateToNGBDate(new Date(this.currentRecord.issuedTo.dateOfBirth))) ||
-          ''
-        ),
-        anonymous: new FormControl(
-          (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || ''
-        )
+          '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+          }),
+        anonymous: new FormControl({
+          value: (this.currentRecord && this.currentRecord.issuedTo && this.currentRecord.issuedTo.anonymous) || '',
+          disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+        })
       }),
-      projectName: new FormControl((this.currentRecord && this.currentRecord.projectName) || ''),
-      location: new FormControl((this.currentRecord && this.currentRecord.location) || ''),
-      latitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || ''
-      ),
-      longitude: new FormControl(
-        (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || ''
-      ),
-      outcomeStatus: new FormControl((this.currentRecord && this.currentRecord.outcomeStatus) || ''),
-      outcomeDescription: new FormControl((this.currentRecord && this.currentRecord.outcomeDescription) || ''),
+      projectName: new FormControl({
+        value: (this.currentRecord && this.currentRecord.projectName) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      location: new FormControl({
+        value: (this.currentRecord && this.currentRecord.location) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      latitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[1]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      longitude: new FormControl({
+        value: (this.currentRecord && this.currentRecord.centroid && this.currentRecord.centroid[0]) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeStatus: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeStatus) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
+      outcomeDescription: new FormControl({
+        value: (this.currentRecord && this.currentRecord.outcomeDescription) || '',
+        disabled: this.currentRecord.sourceSystemRef !== 'nrpti'
+      }),
 
       // NRCED
       nrcedSummary: new FormControl({


### PR DESCRIPTION
Disables the edit form controls on record editing for all imported record (any record where the sourceSystemRef is not "nrpti"). Flavours are not affected. Many record edit screens also allowed editing the record name if you had appropriate NRCED, LNG, and BCMI admin access, so those follow the same rules.

See ticket [NRPT-190](https://bcmines.atlassian.net/browse/NRPT-190)