### PR TITLE
NRPT-319: Document publish fixes

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -406,11 +406,18 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     if (!this.isEditing) {
       this.factoryService.writeRecord(administrativePenalty, 'administrativePenalties', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'AdministrativePenalty')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -411,11 +411,18 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     if (!this.isEditing) {
       this.factoryService.writeRecord(administrativeSanction, 'administrativeSanctions', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'AdministrativeSanction')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
@@ -168,11 +168,19 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(agreement, 'agreements', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Agreement')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
@@ -288,11 +288,18 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(annualReport, 'annualReports', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'AnnualReport')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
@@ -343,11 +343,18 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(certificateAmendment, 'certificateAmendments', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'CertificateAmendment')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -255,11 +255,18 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(certificate, 'certificates', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Certificate')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -194,11 +194,18 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(constructionPlan, 'constructionPlans', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'ConstructionPlan')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
@@ -341,11 +341,18 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(correspondence, 'correspondences', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Correspondence')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -393,11 +393,18 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(courtConviction, 'courtConvictions', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'CourtConviction')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
@@ -341,11 +341,18 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(damSafetyInspection, 'damSafetyInspections', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'DamSafetyInspection')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -349,11 +349,18 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(inspection, 'inspections', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Inspection')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -195,11 +195,18 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(managementPlan, 'managementPlans', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'ManagementPlan')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -351,11 +351,18 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(order, 'orders', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Order')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -251,11 +251,18 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(permit, 'permits', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Permit')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
@@ -341,11 +341,18 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(report, 'reports', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Report')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -405,11 +405,18 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(restorativeJustice, 'restorativeJustices', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'RestorativeJustice')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -259,11 +259,18 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(selfReport, 'selfReports', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'SelfReport')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -402,11 +402,18 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(ticket, 'tickets', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Ticket')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -342,11 +342,18 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     if (!this.isEditing) {
       this.factoryService.writeRecord(warning, 'warnings', true).subscribe(async res => {
         this.recordUtils.parseResForErrors(res);
+        let _id = null;
+        if (Array.isArray(res[0][0].object)) {
+          _id = res[0][0].object.find(r => r._schemaName === 'Warning')._id;
+        } else {
+          _id = res[0][0].object._id;
+        }
+
         const docResponse = await this.recordUtils.handleDocumentChanges(
           this.links,
           this.documents,
           this.documentsToDelete,
-          res[0][0].object._id,
+          _id,
           this.factoryService
         );
 

--- a/angular/projects/common/src/app/models/bcmi/index.ts
+++ b/angular/projects/common/src/app/models/bcmi/index.ts
@@ -5,3 +5,4 @@ export * from './dam-safety-inspection-bcmi';
 export * from './annual-report-bcmi';
 export * from './report-bcmi';
 export * from './correspondence-bcmi';
+export * from './permit-bcmi';

--- a/api/src/utils/business-logic-manager.test.js
+++ b/api/src/utils/business-logic-manager.test.js
@@ -53,15 +53,15 @@ describe('isDocumentConsideredAnonymous', () => {
     expect(result).toBe(true);
   });
 
-  it('returns true if masterRecord.documents is null', async () => {
+  it('returns false if masterRecord.documents is null', async () => {
     const result = await BusinessLogicManager.isDocumentConsideredAnonymous({ documents: null });
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
-  it('returns true if masterRecord.documents is empty', async () => {
+  it('returns false if masterRecord.documents is empty', async () => {
     const result = await BusinessLogicManager.isDocumentConsideredAnonymous({ documents: [] });
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
Changes to allow documents to be published on the creation of a new record, when a record is published, or when a document is updated. Additionally, a couple of other small fixes to issued identified while fixing the core issue.

Updated the businessLogicManager `isDocumentConsideredAnonymous` function so a new record without documents or a record that does not have an `issuedTo` attribute could be public. Previously the only documents that could ever be published had a very thin criteria that expected some values that would not be consistent with all record types.

Also added a step when publishing a record to go through and publish any associated docs. This will call the `isDocumentConsideredAnonymous` function as well, for consistency and to prevent publishing a document that should not be public.

Additionally, made a small fix in the document controllers `POST` method to check the supplied record ID was valid. It was possible to completely kill the service (or silently fail in some cases) by passing in an invalid ObjectID.

Finally, records were passing in an invalid objectID for the master when creating new records due to some parsing issues when fetching the result. This would allow the document to be saved, but ignored any permissions and always forced the documents to be anonymous.

See ticket [NRPT-319](https://bcmines.atlassian.net/browse/NRPT-319)