### PR TITLE
NRPT-57: Allows multiple NRIS imports

### DIFF
--- a/api/migrations/20200807181534-fixMineGuidDefault.js
+++ b/api/migrations/20200807181534-fixMineGuidDefault.js
@@ -14,7 +14,7 @@ exports.setup = function(options, seedLink) {
   seed = seedLink;
 };
 
-exports.up = function(db) {
+exports.up = async function(db) {
   const mClient = await db.connection.connect(db.connectionString, { native_parser: true })
   try {
     console.log('Starting fix for mineGUID.');

--- a/api/migrations/20200810162152-fixNrisSourceRef.js
+++ b/api/migrations/20200810162152-fixNrisSourceRef.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const ObjectId = mongoose.Types.ObjectId;
+
+let dbm;
+let type;
+let seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+
+  try {
+    console.log('Starting fix for NRIS records...');
+
+    const nrpti = await mClient.collection('nrpti');
+
+    // Get all records that have been created from an NRIS import.
+    const records = await nrpti.find({ sourceSystemRef: 'nris-epd' }).toArray();
+
+    for (const record of records) {
+      if (!record.recordName){
+        console.log(`Record ${record._id} is missing recordName`);
+        continue;
+      }
+
+      // The record name contains the assessment ID at the end.
+      // It is in the format 'Inspection - {record name} - {assessment ID}'
+      const lastDash =  record.recordName.lastIndexOf('-');
+
+      if (!lastDash){
+        console.log(`Record ${record._id} has a different recordName format`);
+        continue;
+      }
+
+      // There is always a space after the last dash.
+      const assessmentId = record.recordName.substring(lastDash + 2);
+
+      if (!assessmentId){
+        console.log(`Cannot find assessment ID for record ${record._id}`);
+        continue;
+      }
+
+      await nrpti.update({ _id: new ObjectId(record._id) }, { $set: { _sourceRefNrisId: parseInt(assessmentId) }});
+    }
+
+  } catch (err) {
+    console.log('Error:', err);
+  }
+
+  console.log('Done.');
+  mClient.close()
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -93,6 +93,8 @@ exports.createMaster = function(args, res, next, incomingObj, flavourIds) {
     (inspection._sourceRefOgcInspectionId = incomingObj._sourceRefOgcInspectionId);
   incomingObj._sourceRefOgcDeficiencyId &&
     (inspection._sourceRefOgcDeficiencyId = incomingObj._sourceRefOgcDeficiencyId);
+  incomingObj._sourceRefNrisId &&
+    (inspection._sourceRefNrisId = incomingObj._sourceRefNrisId);
 
   // set permissions
   inspection.read = ROLES.ADMIN_ROLES;

--- a/api/src/models/bcmi/permit-bcmi.js
+++ b/api/src/models/bcmi/permit-bcmi.js
@@ -27,12 +27,8 @@ module.exports = require('../../utils/model-schema-generator')(
     dateIssued: { type: Date, default: null },
     authorizedEndDate: { type: Date, default: null },
     description: { type: String, default: '' },
-    // Document ref to meta record and physical document on the object store
-    amendmentDocument: {
-      _sourceRefId: { type: String, default: null },
-      documentName: { type: String, defualt: '' },
-      documentId: { type: 'ObjectId', default: null }
-    },
+    documents: [{ type: 'ObjectId', default: [], index: true }],
+
     // final Record boilerplate
     dateAdded: { type: Date, default: Date.now() },
     dateUpdated: { type: Date, default: null },


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-57

Stops duplication when the NRIS importer is run more than once. Also includes a migration to add the source reference ID for the NRIS records as there was an issue that was saving them as `null`.