### PR TITLE
NRPT-219: Fixes EPIC importer for company name

### DIFF
--- a/api/src/integrations/epic/inspections-utils.js
+++ b/api/src/integrations/epic/inspections-utils.js
@@ -58,10 +58,14 @@ class Inspections extends BaseRecordUtils {
       issuedTo: {
         // Epic doesn't support `Individual` proponents
         type: 'Company',
-        companyName: epicRecord.project.proponent && epicRecord.project.proponent.company || '',
-        fullName: epicRecord.project.proponent && epicRecord.project.proponent.company || ''
+        companyName: epicRecord.project.proponent && this.getCompanyName(epicRecord.project.proponent) || '',
+        fullName: epicRecord.project.proponent && this.getCompanyName(epicRecord.project.proponent) || ''
       }
     };
+  }
+
+  getCompanyName(proponent) {
+    return proponent.company ? proponent.company : proponent.name;
   }
 }
 

--- a/api/src/integrations/epic/orders-utils.js
+++ b/api/src/integrations/epic/orders-utils.js
@@ -57,10 +57,14 @@ class Orders extends BaseRecordUtils {
       issuedTo: {
         // Epic doesn't support `Individual` proponents
         type: 'Company',
-        companyName: epicRecord.project.proponent && epicRecord.project.proponent.company || '',
-        fullName: epicRecord.project.proponent && epicRecord.project.proponent.company || ''
+        companyName: epicRecord.project.proponent && this.getCompanyName(epicRecord.project.proponent) || '',
+        fullName: epicRecord.project.proponent && this.getCompanyName(epicRecord.project.proponent) || ''
       }
     };
+  }
+
+  getCompanyName(proponent) {
+    return proponent.company ? proponent.company : proponent.name;
   }
 }
 


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-219

Changes: Updates the EPIC importer to address a data discrepancy in EPIC where the `company` field might not be filled in.  If the field is missing it will now fall back to the organization's name which is required.