### PR TITLE
NOBUG: Declare type for ApplicationRoles

### DIFF
--- a/angular/projects/admin-nrpti/src/typings.d.ts
+++ b/angular/projects/admin-nrpti/src/typings.d.ts
@@ -4,4 +4,7 @@ interface NodeModule {
   id: string;
 }
 
-declare module "*";
+declare module "ApplicationRoles" {
+  const ApplicationRoles: any;
+  export = ApplicationRoles;
+}

--- a/angular/projects/admin-nrpti/src/typings.d.ts
+++ b/angular/projects/admin-nrpti/src/typings.d.ts
@@ -3,3 +3,5 @@ declare var module: NodeModule;
 interface NodeModule {
   id: string;
 }
+
+declare module "*";


### PR DESCRIPTION
Update to roles constants made the import come from the api JS package, which is causing typescript build errors in the common libraries due to missing type. Added a typedef to get our builds working.