### PR TITLE
NOBUG: Re-implement common constants

### DIFF
--- a/angular/projects/admin-nrpti/src/app/services/factory.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/factory.service.ts
@@ -8,7 +8,7 @@ import { RecordService } from './record.service';
 import { catchError } from 'rxjs/operators';
 import { TaskService, ITaskParams } from './task.service';
 import { DocumentService } from './document.service';
-import { ApplicationRoles } from '../../../../../../api/src/utils/constants/misc';
+import { Constants } from '../utils/constants/misc';
 /**
  * Facade service for all admin-nrpti services.
  *
@@ -160,7 +160,7 @@ export class FactoryService {
         // to handle any case issues with role or the scopes, convert them
         // all to lower case first
         const userRoles = jwt.realm_access.roles.map((userRole: string) => userRole.toLowerCase());
-        return userRoles.includes(ApplicationRoles.ADMIN) || userRoles.includes(role.toLowerCase());
+        return userRoles.includes(Constants.ApplicationRoles.ADMIN) || userRoles.includes(role.toLowerCase());
       }
     }
 
@@ -168,15 +168,15 @@ export class FactoryService {
   }
 
   userInLngRole() {
-    return this.userInRole(ApplicationRoles.ADMIN_LNG);
+    return this.userInRole(Constants.ApplicationRoles.ADMIN_LNG);
   }
 
   userInBcmiRole() {
-    return this.userInRole(ApplicationRoles.ADMIN_BCMI);
+    return this.userInRole(Constants.ApplicationRoles.ADMIN_BCMI);
   }
 
   userInNrcedRole() {
-    return this.userInRole(ApplicationRoles.ADMIN_NRCED);
+    return this.userInRole(Constants.ApplicationRoles.ADMIN_NRCED);
   }
 
   /**

--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { JwtUtil } from '../utils/jwt-utils';
 import { Observable } from 'rxjs';
-import { ApplicationRoles } from '../../../../../../api/src/utils/constants/misc';
+import { Constants } from '../utils/constants/misc';
 
 declare let Keycloak: any;
 
@@ -115,8 +115,8 @@ export class KeycloakService {
     }
 
     // Make sure they have at least one instance of including a role in the ROLE array
-    return Object.keys(ApplicationRoles).some(role => {
-      return jwt.realm_access.roles.includes(ApplicationRoles[role]);
+    return Object.keys(Constants.ApplicationRoles).some(role => {
+      return jwt.realm_access.roles.includes(Constants.ApplicationRoles[role]);
     });
   }
 

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -1,0 +1,8 @@
+export class Constants {
+  public static readonly ApplicationRoles: any = {
+    ADMIN: 'sysadmin',
+    ADMIN_NRCED: 'admin:nrced',
+    ADMIN_LNG: 'admin:lng',
+    ADMIN_BCMI: 'admin:bcmi',
+  };
+}

--- a/angular/projects/admin-nrpti/src/typings.d.ts
+++ b/angular/projects/admin-nrpti/src/typings.d.ts
@@ -4,4 +4,7 @@ interface NodeModule {
   id: string;
 }
 
-declare module "*";
+declare module "ApplicationRoles" {
+  const ApplicationRoles: any;
+  export = ApplicationRoles;
+}

--- a/angular/projects/admin-nrpti/src/typings.d.ts
+++ b/angular/projects/admin-nrpti/src/typings.d.ts
@@ -3,3 +3,5 @@ declare var module: NodeModule;
 interface NodeModule {
   id: string;
 }
+
+declare module "*";


### PR DESCRIPTION
Nuclear option, just to get the builds working. Putting the constants back in place on the common lib and removing the failing reference to the API package.