### PR TITLE
NRPT-316: Remove mines tabs, update breadcrumbs

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.html
@@ -2,38 +2,8 @@
   <section>
     <div class="d-flex heading-bar">
       <div>
-        <h1 id="name" class="m-0">{{ (mine && mine.name) || '-' }}</h1>
+        <h1 id="name" class="m-0">{{ (mine && mine.name) || '-' }} Collections</h1>
       </div>
-    </div>
-  </section>
-
-  <section>
-    <!-- TAB HEADERS -->
-    <div role="navigation">
-      <ul class="nav nav-tabs nav-fill pl-2" role="tablist">
-        <li class="nav-item" role="presentation">
-          <a
-            class="nav-link"
-            role="tab"
-            routerLink="/mines/{{ mine && mine._id }}/records"
-            [class.active]="false"
-          >
-            Records
-          </a>
-        </li>
-        <li class="nav-item" role="presentation">
-          <a
-            class="nav-link"
-            role="tab"
-            routerLink="/mines/{{ mine && mine._id }}/collections"
-            routerLinkActive
-            #rla="routerLinkActive"
-            [class.active]="true"
-          >
-            Collections
-          </a>
-        </li>
-      </ul>
     </div>
   </section>
 

--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-list/mines-collections-list.component.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../../../common/src/app/search-filter-template/filter-object';
 import { Mine } from '../../../../../common/src/app/models/bcmi/mine';
 import { StateIDs, StateStatus, Picklists } from '../../../../../common/src/app/utils/record-constants';
+import { MiscUtils } from '../../utils/constants/misc';
 
 
 /**
@@ -194,6 +195,8 @@ export class MinesCollectionsListComponent implements OnInit, OnDestroy {
         }
 
         this.mine = res.mine[0] && res.mine[0].data && new Mine(res.mine[0].data);
+
+        MiscUtils.updateBreadcrumbLabel(this.mine, this.route.root);
 
         const collections =
           (res.collections[0] && res.collections[0].data && res.collections[0].data.searchResults) || [];

--- a/angular/projects/admin-nrpti/src/app/mines/mines-detail/mines-detail.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-detail/mines-detail.component.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FactoryService } from '../../services/factory.service';
 import { LoadingScreenService } from 'nrpti-angular-components';
 import moment from 'moment';
+import { MiscUtils } from '../../utils/constants/misc';
 
 @Component({
   selector: 'app-mines-detail',
@@ -39,6 +40,8 @@ export class MinesDetailComponent implements OnInit, OnDestroy {
       }
 
       this.mine = res.mine[0] && res.mine[0].data && new Mine(res.mine[0].data);
+
+      MiscUtils.updateBreadcrumbLabel(this.mine, this.route.root);
 
       this.isPublished = this.isRecordPublished();
       this.canPublish = this.checkCanPublish();

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.html
@@ -2,38 +2,8 @@
   <section>
     <div class="d-flex heading-bar">
       <div>
-        <h1 id="name" class="m-0">{{ (mine && mine.name) || '-' }}</h1>
+        <h1 id="name" class="m-0">{{ (mine && mine.name) || '-' }} Records</h1>
       </div>
-    </div>
-  </section>
-
-  <section>
-    <!-- TAB HEADERS -->
-    <div role="navigation">
-      <ul class="nav nav-tabs nav-fill pl-2" role="tablist">
-        <li class="nav-item" role="presentation">
-          <a
-            class="nav-link"
-            role="tab"
-            routerLink="/mines/{{ mine && mine._id }}/records"
-            routerLinkActive
-            #rla="routerLinkActive"
-            [class.active]="true"
-          >
-            Records
-          </a>
-        </li>
-        <li class="nav-item" role="presentation">
-          <a
-            class="nav-link"
-            role="tab"
-            routerLink="/mines/{{ mine && mine._id }}/collections"
-            [class.active]="false"
-          >
-            Collections
-          </a>
-        </li>
-      </ul>
     </div>
   </section>
 

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-list/mines-records-list.component.ts
@@ -18,6 +18,7 @@ import { SearchSubsets, Picklists, StateIDs, StateStatus } from '../../../../../
 import { FilterObject, FilterType, DateFilterDefinition, CheckOrRadioFilterDefinition, RadioOptionItem, MultiSelectDefinition, DropdownDefinition } from '../../../../../common/src/app/search-filter-template/filter-object';
 import { SubsetsObject, SubsetOption } from '../../../../../common/src/app/search-filter-template/subset-object';
 import { Mine } from '../../../../../common/src/app/models/bcmi/mine';
+import { MiscUtils } from '../../utils/constants/misc';
 
 /**
  * Mine list page component.
@@ -246,6 +247,8 @@ export class MinesRecordsListComponent implements OnInit, OnDestroy {
         }
 
         this.mine = res.mine[0] && res.mine[0].data && new Mine(res.mine[0].data);
+
+        MiscUtils.updateBreadcrumbLabel(this.mine, this.route.root);
 
         const records = (res.records[0] && res.records[0].data && res.records[0].data.searchResults) || [];
 

--- a/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
+++ b/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
@@ -28,7 +28,7 @@
       id="mines-content"
       [routerLink]="['mines', currentMineId, 'records']"
     >
-      <i class="material-icons mr-3 mines-menu-icon">description</i>
+      <em class="material-icons mr-3 mines-menu-icon">description</em>
       Mine Records
     </a>
     <a
@@ -37,7 +37,7 @@
       id="mines-content"
       [routerLink]="['mines', currentMineId, 'collections']"
     >
-      <i class="material-icons mr-3 mines-menu-icon">collections_bookmark</i>
+      <em class="material-icons mr-3 mines-menu-icon">collections_bookmark</em>
       Mine Collections
     </a>
   </section>

--- a/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
+++ b/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
@@ -17,19 +17,28 @@
   <section class="mine-nav" *ngIf="showMineDetails">
     <a
       [ngClass]="{ active: mainRoute === 'mines' && currentMenu === 'detail' }"
-      class="dropdown-btn "
+      class="dropdown-btn"
       [routerLink]="['mines', currentMineId, 'detail']"
     >
       Mine Details
     </a>
     <a
-      [ngClass]="{ active: showMineDetails && (currentMenu === 'records' || currentMenu === 'collections') }"
+      [ngClass]="{ active: showMineDetails && currentMenu === 'records' }"
       class="mines-menu"
       id="mines-content"
       [routerLink]="['mines', currentMineId, 'records']"
     >
-      <i class="material-icons mr-3">description</i>
-      Mine Content
+      <i class="material-icons mr-3 mines-menu-icon">description</i>
+      Mine Records
+    </a>
+    <a
+      [ngClass]="{ active: showMineDetails && currentMenu === 'collections' }"
+      class="mines-menu"
+      id="mines-content"
+      [routerLink]="['mines', currentMineId, 'collections']"
+    >
+      <i class="material-icons mr-3 mines-menu-icon">collections_bookmark</i>
+      Mine Collections
     </a>
   </section>
   <section class="full-nav">

--- a/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.scss
+++ b/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.scss
@@ -38,11 +38,16 @@
 
 .sidebar .mines-menu {
   padding: 6px 16px 8px;
-  padding-left: 0.8rem;
+  padding-left: 0.4rem;
+  font-size: 14px;
 
   .material-icons {
     top: 2px;
   }
+}
+
+.sidebar .mines-menu-icon {
+  margin-right: 0.2rem !important;
 }
 
 /* Active/current link */

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -9,7 +9,7 @@ export class Constants {
   };
 }
 export class MiscUtils {
-  public static updateBreadcrumbLabel(mine: any, route: ActivatedRoute, url: string = '') {
+  public static updateBreadcrumbLabel(mine: any, route: ActivatedRoute) {
     const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
     // get the child routes
     const children: ActivatedRoute[] = route.children;
@@ -28,19 +28,13 @@ export class MiscUtils {
 
       // verify the custom data property "breadcrumb" is specified on the route
       if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
-        return this.updateBreadcrumbLabel(mine, child, url);
+        return this.updateBreadcrumbLabel(mine, child);
       }
 
       // skip if breadcrumb data is null
       if (!child.snapshot.data[ROUTE_DATA_BREADCRUMB]) {
-        return this.updateBreadcrumbLabel(mine, child, url);
+        return this.updateBreadcrumbLabel(mine, child);
       }
-
-      // get the route's URL segment
-      const routeURL: string = child.snapshot.url.map(segment => segment.path).join('/');
-
-      // append route URL to URL
-      url += `/${routeURL}`;
 
       // If this is the Mine Details breadcrumb, replace the name with the current
       // mine name, otherwise ignore and continue the recursive check
@@ -49,7 +43,7 @@ export class MiscUtils {
       }
 
       // recursive
-      return this.updateBreadcrumbLabel(mine, child, url);
+      return this.updateBreadcrumbLabel(mine, child);
     }
   }
 }

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -1,3 +1,6 @@
+import { ActivatedRoute } from '@angular/router';
+import { IBreadcrumb } from '../../../../../global/src/lib/components/breadcrumb/breadcrumb.component';
+
 export class Constants {
   public static readonly ApplicationRoles: any = {
     ADMIN: 'sysadmin',
@@ -5,4 +8,58 @@ export class Constants {
     ADMIN_LNG: 'admin:lng',
     ADMIN_BCMI: 'admin:bcmi',
   };
+}
+export class MiscUtils {
+  public static updateBreadcrumbLabel(mine: any, route: ActivatedRoute, url: string = '',
+    breadcrumbs: IBreadcrumb[] = []): IBreadcrumb[] {
+    const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
+    // get the child routes
+    const children: ActivatedRoute[] = route.children;
+
+    // return if there are no more children
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+
+    // iterate over each children
+    for (const child of children) {
+      // verify primary route
+      if (child.outlet !== 'primary') {
+        continue;
+      }
+
+      // verify the custom data property "breadcrumb" is specified on the route
+      if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
+        return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+      }
+
+      // skip if breadcrumb data is null
+      if (!child.snapshot.data[ROUTE_DATA_BREADCRUMB]) {
+        return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+      }
+
+      // get the route's URL segment
+      const routeURL: string = child.snapshot.url.map(segment => segment.path).join('/');
+
+      // append route URL to URL
+      url += `/${routeURL}`;
+
+      // add breadcrumb
+      const breadcrumb: IBreadcrumb = {
+        label: child.snapshot.data[ROUTE_DATA_BREADCRUMB],
+        params: child.snapshot.params,
+        url: url
+      };
+      breadcrumbs.push(breadcrumb);
+
+      // If this is the Mine Details breadcrumb, replace the name with the current
+      // mine name, otherwise ignore and continue the recursive check
+      if (child.snapshot.data[ROUTE_DATA_BREADCRUMB] === 'Mine Details') {
+        child.snapshot.data[ROUTE_DATA_BREADCRUMB] = mine.name;
+      }
+
+      // recursive
+      return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+    }
+  }
 }

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -1,5 +1,4 @@
 import { ActivatedRoute } from '@angular/router';
-import { IBreadcrumb } from '../../../../../global/src/lib/components/breadcrumb/breadcrumb.component';
 
 export class Constants {
   public static readonly ApplicationRoles: any = {
@@ -10,15 +9,14 @@ export class Constants {
   };
 }
 export class MiscUtils {
-  public static updateBreadcrumbLabel(mine: any, route: ActivatedRoute, url: string = '',
-    breadcrumbs: IBreadcrumb[] = []): IBreadcrumb[] {
+  public static updateBreadcrumbLabel(mine: any, route: ActivatedRoute, url: string = '') {
     const ROUTE_DATA_BREADCRUMB = 'breadcrumb';
     // get the child routes
     const children: ActivatedRoute[] = route.children;
 
     // return if there are no more children
     if (children.length === 0) {
-      return breadcrumbs;
+      return;
     }
 
     // iterate over each children
@@ -30,12 +28,12 @@ export class MiscUtils {
 
       // verify the custom data property "breadcrumb" is specified on the route
       if (!child.snapshot.data.hasOwnProperty(ROUTE_DATA_BREADCRUMB)) {
-        return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+        return this.updateBreadcrumbLabel(mine, child, url);
       }
 
       // skip if breadcrumb data is null
       if (!child.snapshot.data[ROUTE_DATA_BREADCRUMB]) {
-        return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+        return this.updateBreadcrumbLabel(mine, child, url);
       }
 
       // get the route's URL segment
@@ -44,14 +42,6 @@ export class MiscUtils {
       // append route URL to URL
       url += `/${routeURL}`;
 
-      // add breadcrumb
-      const breadcrumb: IBreadcrumb = {
-        label: child.snapshot.data[ROUTE_DATA_BREADCRUMB],
-        params: child.snapshot.params,
-        url: url
-      };
-      breadcrumbs.push(breadcrumb);
-
       // If this is the Mine Details breadcrumb, replace the name with the current
       // mine name, otherwise ignore and continue the recursive check
       if (child.snapshot.data[ROUTE_DATA_BREADCRUMB] === 'Mine Details') {
@@ -59,7 +49,7 @@ export class MiscUtils {
       }
 
       // recursive
-      return this.updateBreadcrumbLabel(mine, child, url, breadcrumbs);
+      return this.updateBreadcrumbLabel(mine, child, url);
     }
   }
 }


### PR DESCRIPTION
Updates to split the Mines left-nav into a "Records" and "Collections" menu. Removed tabs from components. Updated the styling of the left-nav to make it more obvious it's a menu. Also, small update to replace the "Mines Details" Label of the breadcrumbs with the currently selected mine name. Note that if finding the mine name fails for whatever reason the breadcrumb will fall back to "Mine Details".

See tickets [NRPT-316](https://bcmines.atlassian.net/browse/NRPT-316), [NRPT-320](https://bcmines.atlassian.net/browse/NRPT-320) and [NRPT-321](https://bcmines.atlassian.net/browse/NRPT-321)