### PR TITLE
NRPT-344: Setting published, search endpoint update

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-add-edit/mines-collections-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-add-edit/mines-collections-add-edit.component.ts
@@ -395,8 +395,10 @@ export class MinesCollectionsAddEditComponent implements OnInit, OnDestroy {
     if (this.myForm.get('collectionPublish').dirty) {
       if (this.myForm.get('collectionPublish').value) {
         collection['addRole'] = 'public';
+        collection['isBcmiPublished'] = true;
       } else {
         collection['removeRole'] = 'public';
+        collection['isBcmiPublished'] = false;
       }
     }
 

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-add-edit/mines-records-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-add-edit/mines-records-add-edit.component.ts
@@ -280,10 +280,10 @@ export class MinesRecordsAddEditComponent implements OnInit {
       record[schemaString]['typeCode'] = this.myForm.get('typeCode').value;
     }
     if (this.myForm.get('recordPublish').dirty && this.myForm.get('recordPublish').value) {
-      record['addRole'] = 'public';
+      record['isBcmiPublished'] = true;
       record[schemaString]['addRole'] = 'public';
     } else if (this.myForm.get('recordPublish').dirty && !this.myForm.get('recordPublish').value) {
-      record['removeRole'] = 'public';
+      record['isBcmiPublished'] = false;
       record[schemaString]['removeRole'] = 'public';
     }
 

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-add-edit/mines-records-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-add-edit/mines-records-add-edit.component.ts
@@ -280,8 +280,10 @@ export class MinesRecordsAddEditComponent implements OnInit {
       record[schemaString]['typeCode'] = this.myForm.get('typeCode').value;
     }
     if (this.myForm.get('recordPublish').dirty && this.myForm.get('recordPublish').value) {
+      record['addRole'] = 'public';
       record[schemaString]['addRole'] = 'public';
     } else if (this.myForm.get('recordPublish').dirty && !this.myForm.get('recordPublish').value) {
+      record['removeRole'] = 'public';
       record[schemaString]['removeRole'] = 'public';
     }
 

--- a/api/src/controllers/record-controller.js
+++ b/api/src/controllers/record-controller.js
@@ -298,7 +298,7 @@ exports.protectedPublish = async function (args, res, next) {
       const masterModel = require('mongoose').model(masterSchema);
       await masterModel.findOneAndUpdate({ _id: record._master, write: { $in: args.swagger.params.auth_payload.realm_access.roles } }, { isLngPublished: true });
     }
-    else if (recordData._schemaName.includes('BCMI')) {
+    else if (recordData._schemaName !== 'CollectionBCMI' && recordData._schemaName.includes('BCMI')) {
       const masterSchema = recordData._schemaName.substring(0, recordData._schemaName.length - 3);
       const masterModel = require('mongoose').model(masterSchema);
       await masterModel.findOneAndUpdate({ _id: record._master, write: { $in: args.swagger.params.auth_payload.realm_access.roles } }, { isBcmiPublished: true });


### PR DESCRIPTION
Update to ensure isBcmiPublished and read role is set when records/collections are updated.

Also added a new search datatype of CollectionDocuments as a public endpoint for BCMI to use to fetch collection documents without requiring a check on the master _id values.

Additionally (and unrelated), made a fix to the hasCollection aggregate section. The hasCollection filter could cause the search to fail (and the api to crash) if you included a text search component. This is because an `$addField` step was created before the `$match: {$text}}` which mongodb does not allow in an aggregate. I've updated the logic to create the addField and match check after the main match processing is done.

See ticket [NRPT-344](https://bcmines.atlassian.net/browse/NRPT-344)