### PR TITLE
NRPT-350: Update coordinate order for NRIS import

### DIFF
--- a/api/src/integrations/nris-epd/datasource.js
+++ b/api/src/integrations/nris-epd/datasource.js
@@ -232,7 +232,7 @@ class NrisDataSource {
     newRecord.location = record.location.locationDescription;
 
     if (record.location && Number(record.location.latitude) && Number(record.location.longitude)) {
-      newRecord.centroid = [Number(record.location.latitude), Number(record.location.longitude)];
+      newRecord.centroid = [Number(record.location.longitude), Number(record.location.latitude)];
     }
 
     if (record.complianceStatus) {


### PR DESCRIPTION
Coordinates are swapped for some records in NRPTI/NRCED. A look at the data seemed to indicate that NRIS imported docs had the wrong coordinate order. A look in the code confirmed that indeed they did!

Optional: The values from NRIS should update with a re-import. As a safety-net though we could add a migration that runs through all records `centroid` attribute and swaps if `centroid[1] < -100` (basically, if any latitudes are less than 100, its a longitude and the order is wrong).

See ticket [NRPT-350](https://bcmines.atlassian.net/browse/NRPT-350)