### PR TITLE
NRPT-350: Fix record add order, coord update migration

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-record-add/mines-record-add.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-record-add/mines-record-add.component.ts
@@ -116,7 +116,7 @@ export class MinesRecordAddComponent implements OnInit, OnDestroy {
     };
     record['sourceSystemRef'] = 'nrpti';
     record['centroid'] = this.mine.location ?
-      [this.mine.location.coordinates[1], this.mine.location.coordinates[0]] : [0, 0];
+      [this.mine.location.coordinates[0], this.mine.location.coordinates[1]] : [0, 0];
 
     // If we are editing a collection, we add right away.
     if (this.collectionId) {

--- a/api/migrations/20200902195621-correctLatLong.js
+++ b/api/migrations/20200902195621-correctLatLong.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const RecordTypeEnum = require('../src/utils/constants/misc');
+const ObjectId =  require('mongoose').Types.ObjectId;
+
+let dbm;
+let type;
+let seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+}
+
+exports.up = async function(db) {
+  console.log('#############################################################');
+  console.log('## Updating records with flipped latitude/longitude values ##');
+  console.log('#############################################################');
+
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+
+  const schemas = [...RecordTypeEnum.MASTER_SCHEMA_NAMES,
+                   ...RecordTypeEnum.LNG_SCHEMA_NAMES,
+                   ...RecordTypeEnum.NRCED_SCHEMA_NAMES,
+                   ...RecordTypeEnum.BCMI_SCHEMA_NAMES];
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    let flippedCount = 0;
+    const records = await nrpti.find({ _schemaName: { $in: schemas } }).toArray();
+
+    for(const record of records) {
+      if(Object.prototype.hasOwnProperty.call(record, 'centroid') &&
+         record.centroid &&
+         record.centroid.length === 2 &&
+         record.centroid[1] < -90) {
+        record.centroid.reverse();
+        nrpti.update({ _id: new ObjectId(record._id) }, { $set: { centroid: record.centroid }});
+        flippedCount++;
+      }
+    }
+
+    console.log(`Processed ${records.length} records and flipped coords for ${flippedCount}`);
+  } catch (err) {
+    console.error(' Error updating centroids: ', err);
+  }
+
+  console.log('####################################');
+  console.log('##       Updates complete!        ##');
+  console.log('####################################');
+
+  mClient.close();
+}
+
+exports.down = function(db) {
+  return null;
+}
+
+exports._meta = {
+  "version": 1
+}

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -27,3 +27,72 @@ exports.EpicProjectIds = {
   lngCanadaId: '588511d0aaecd9001b826192',
   coastalGaslinkId: '588511c4aaecd9001b825604'
 };
+
+exports.MASTER_SCHEMA_NAMES = [
+  'AdministrativePenalty',
+  'AdministrativeSanction',
+  'Agreement',
+  'AnnualReport',
+  'Certificate',
+  'CertificateAmendment',
+  'ConstructionPlan',
+  'Correspondence',
+  'CourtConviction',
+  'DamSafetyInspection',
+  'Inspection',
+  'ManagementPlan',
+  'Order',
+  'Permit',
+  'Report',
+  'RestorativeJustice',
+  'SelfReport',
+  'Ticket',
+  'Warning'
+];
+
+exports.LNG_SCHEMA_NAMES = [
+  'ActivityLNG',
+  'AdministrativePenaltyLNG',
+  'AdministrativeSanctionLNG',
+  'AgreementLNG',
+  'CertificateLNG',
+  'CertificateAmendmentLNG',
+  'ConstructionPlanLNG',
+  'CourtConvictionLNG',
+  'InspectionLNG',
+  'ManagementPlanLNG',
+  'OrderLNG',
+  'PermitLNG',
+  'RestorativeJusticeLNG',
+  'SelfReportLNG',
+  'TicketLNG',
+  'WarningLNG'
+];
+
+exports.NRCED_SCHEMA_NAMES = [
+  'AdministrativePenaltyNRCED',
+  'AdministrativeSanctionNRCED',
+  'CorrespondenceNRCED',
+  'CourtConvictionNRCED',
+  'DamSafetyInspectionNRCED',
+  'InspectionNRCED',
+  'OrderNRCED',
+  'ReportNRCED',
+  'RestorativeJusticeNRCED',
+  'TicketNRCED',
+  'WarningNRCED'
+];
+
+exports.BCMI_SCHEMA_NAMES = [
+  'AnnualReportBCMI',
+  'CertificateAmendmentBCMI',
+  'CollectionBCMI',
+  'CorrespondenceBCMI',
+  'DamSafetyInspectionBCMI',
+  'InspectionBCMI',
+  'ManagementPlanBCMI',
+  'MineBCMI',
+  'OrderBCMI',
+  'PermitBCMI',
+  'ReportBCMI'
+];


### PR DESCRIPTION
Update for the lat long fixe with [NRPT-350](https://bcmines.atlassian.net/browse/NRPT-350). Fixed a flipped order in the mines record add screen, and added a migration to cycle through all of our records and flip the centroid values where the latitude is in [0] and the longitude is in [1] ( basicalluy`if record.centroid[1] < -90`). Not a perfect check, but should be sufficient for our data.