### PR TITLE
NRPT-380, 326: Update Core importer and add manual import

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import.component.html
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.html
@@ -42,6 +42,26 @@
         </div>
       </div>
     </div>
+    <div class="label-pair mb-3">
+      <label>Import from CORE</label>
+      <div>
+        <button
+          type="button"
+          [disabled]="showAlert['core']"
+          class="btn btn-primary"
+          (click)="startJob('core')"
+          title="Start CORE import job"
+        >
+          Start Job
+        </button>
+      </div>
+      <div *ngIf="showAlert['core']" class="input-group mt-1">
+        <div class="alert alert-success" role="alert">
+          <h5 class="alert-heading">Job Started!</h5>
+          <span>Please refresh the page to see the updated status.</span>
+        </div>
+      </div>
+    </div>
   </section>
 
   <section class="mt-4.5 mb-3">

--- a/angular/projects/admin-nrpti/src/app/import/import.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.ts
@@ -21,7 +21,7 @@ export class ImportComponent implements OnInit {
   private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
 
   public loading = true;
-  public showAlert = { epic: false, 'nris-epd': false };
+  public showAlert = { epic: false, 'nris-epd': false, core: false };
   public tableData: TableObject = new TableObject({ component: ImportTableRowsComponent });
   public tableColumns: IColumnObject[] = [
     {

--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -412,7 +412,22 @@ class CoreDataSource {
         defaultLog.info(`Fetched page ${currentPage - 1} out of ${totalPages}`);
       } while (currentPage <= totalPages)
 
-      return mineRecords;
+      // Only want mines that are not abandoned.
+      const activeMines = mineRecords.filter(mine => {
+        // If the mine is missing a status we still want to include it.
+        if (!mine.mine_status || !mine.mine_status.length) {
+          return true;
+        }
+
+        // If the mine's most recent status does not include 'Abandoned' then include it.
+        if (mine.mine_status[0].status_values && !mine.mine_status[0].status_values.includes('ABN')) {
+          return true;
+        }
+
+        return false;
+      });
+
+      return activeMines;
     } catch (error) {
       defaultLog.error(`getVerifiedMines - unexpected error: ${error.message}`);
       throw(error);


### PR DESCRIPTION
Tickets: 

- https://bcmines.atlassian.net/browse/NRPT-380
- https://bcmines.atlassian.net/browse/NRPT-326

This PR updates the CORE importer to exclude any many that have a recent status of abandoned. If the mine is missing a status then we still want to include it. The PR also adds a manual import button to run the CORE importer.