### PR TITLE
NRPT-387: API and screen for communication package popup

### DIFF
--- a/angular/projects/admin-nrpti/src/app/app-routing.module.ts
+++ b/angular/projects/admin-nrpti/src/app/app-routing.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-
 import { NotAuthorizedComponent } from './not-authorized/not-authorized.component';
 import { HomeComponent } from './home/home.component';
 import { ImportComponent } from './import/import.component';
 import { ImportListResolver } from './import/import-list-resolver';
 import { NewsResolver } from './news/news-resolver';
 import { NewsListComponent } from './news/news-list.component';
+import { CommunicationsComponent } from './communications/communications.component';
+import { CommunicationsResolver } from './communications/communications.resolver';
 
 const routes: Routes = [
   {
@@ -40,6 +41,24 @@ const routes: Routes = [
     data: {
       breadcrumb: 'News'
     }
+  },
+  {
+    path: 'communications',
+    data: {
+      breadcrumb: 'Communications'
+    },
+    children: [
+      {
+        path: ':application',
+        data: {
+          breadcrumb: null
+        },
+        component: CommunicationsComponent,
+        resolve: {
+          communicationsPackage: CommunicationsResolver
+        }
+      },
+    ]
   },
   {
     // wildcard default route

--- a/angular/projects/admin-nrpti/src/app/app.module.ts
+++ b/angular/projects/admin-nrpti/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { RecordsModule } from './records/records.module';
 import { NewsModule } from './news/news.module';
 import { MinesModule } from './mines/mines.module';
+import { CommunicationsModule } from './communications/communications.module';
 
 // components
 import { AppComponent } from './app.component';
@@ -46,6 +47,7 @@ import { NewsService } from './services/news.service';
 import { ImportListResolver } from './import/import-list-resolver';
 import { NewsResolver } from './news/news-resolver';
 import { NewsListResolver } from './news/news-list.resolver';
+import { CommunicationsResolver } from './communications/communications.resolver';
 
 // guards
 import { CanActivateGuard } from './guards/can-activate-guard.service';
@@ -96,6 +98,7 @@ export function overlayScrollFactory(overlay: Overlay): () => CloseScrollStrateg
     RecordsModule,
     NewsModule,
     MinesModule,
+    CommunicationsModule,
     AppRoutingModule, // <-- module import order matters - https://angular.io/guide/router#module-import-order-matters
     NgbModule.forRoot(),
     NgxPaginationModule,
@@ -136,6 +139,7 @@ export function overlayScrollFactory(overlay: Overlay): () => CloseScrollStrateg
     ImportListResolver,
     NewsResolver,
     NewsListResolver,
+    CommunicationsResolver,
     CanActivateGuard,
     CanDeactivateGuard,
     RecordUtils

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.html
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.html
@@ -1,0 +1,79 @@
+<main class="container-fluid-padding">
+  <section class="mb-3">
+    <h4>Application Communication Popup</h4>
+    <!-- Tab headers for selecting application -->
+    <section>
+      <div role="navigation">
+        <ul class="nav nav-tabs nav-fill pl-2" role="tablist">
+          <li class="nav-item" role="presentation">
+            <a class="nav-link" role="tab" routerLink="/communications/BCMI" [class.active]="selectedApplication === 'BCMI'">
+              BCMI
+            </a>
+          </li>
+          <li class="nav-item" role="presentation">
+            <a class="nav-link" role="tab" routerLink="/communications/NRCED" [class.active]="selectedApplication === 'NRCED'">
+              NRCED
+            </a>
+          </li>
+          <li class="nav-item" role="presentation">
+            <a class="nav-link" role="tab" routerLink="/communications/LNG" routerLinkActive [class.active]="selectedApplication === 'LNG'">
+              LNG
+            </a>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- popup edit section-->
+    <!-- Should include some instructions here -->
+    <p>With this form you can supply details for a popup message that will be displayed to users of BCMI, LNG or NRCED.
+       Enter a popup title and description, and supply a date range when the popup will display. You can only have one
+       popup active at a time, so any edits here will replace the existing popup.
+    </p>
+    <section class="my-3 py-3 border-bottom">
+      <form [formGroup]="myForm" novalidate>
+        <div class="flex-container">
+          <div class="label-pair">
+            <label for="popupTitle">Title</label>
+            <input name="popupTitle" id="popupTitle" type="text" formControlName="popupTitle" class="form-control" />
+          </div>
+        </div>
+        <div class="flex-container">
+          <div class="label-pair lrg">
+            <label for="description">Description</label>
+            <textarea
+              name="description"
+              id="description"
+              type="text"
+              formControlName="description"
+              class="form-control"
+              rows="5"
+            ></textarea>
+          </div>
+        </div>
+        <div class="flex-container">
+          <div class="label-pair">
+            <label for="startDate">Start Date</label>
+            <lib-date-picker
+              [control]="myForm.controls.startDate"
+              [isValidate]="true">
+            </lib-date-picker>
+          </div>
+          <div class="label-pair">
+            <label for="endDate">End Date</label>
+            <lib-date-picker
+              [control]="myForm.controls.endDate"
+              [isValidate]="true">
+            </lib-date-picker>
+          </div>
+        </div>
+        <!-- Add an advanced section for updating the communication package additional info json blob? -->
+      </form>
+    </section>
+    <div class="d-flex justify-content-end mb-1">
+      <button class="btn btn-primary" type="submit" (click)="submit()" title="Save Popup">
+        Save Popup
+      </button>
+    </div>
+  </section>
+</main>

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.html
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.html
@@ -25,7 +25,6 @@
     </section>
 
     <!-- popup edit section-->
-    <!-- Should include some instructions here -->
     <p>With this form you can supply details for a popup message that will be displayed to users of BCMI, LNG or NRCED.
        Enter a popup title and description, and supply a date range when the popup will display. You can only have one
        popup active at a time, so any edits here will replace the existing popup.

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.scss
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.scss
@@ -1,0 +1,2 @@
+@import "assets/styles/base/base.scss";
+@import "assets/styles/components/add-edit.scss";

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
@@ -1,0 +1,113 @@
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs/Subject';
+import { FormGroup, FormControl } from '@angular/forms';
+import { CommunicationsPackage } from '../../../../common/src/app/models/master/common-models/communications-package';
+import { FactoryService } from '../services/factory.service';
+import { DatePickerComponent, LoadingScreenService, Utils } from 'nrpti-angular-components';
+
+@Component({
+  selector: 'communications-add',
+  templateUrl: './communications.component.html',
+  styleUrls: ['./communications.component.scss']
+})
+export class CommunicationsComponent implements OnInit, OnDestroy {
+  @ViewChild(DatePickerComponent) DatePicker: DatePickerComponent;
+
+  private ngUnsubscribe: Subject<boolean> = new Subject<boolean>();
+
+  public myForm: FormGroup;
+
+  public commPackage: CommunicationsPackage;
+  public selectedApplication: string;
+
+  constructor(
+    public route: ActivatedRoute,
+    public router: Router,
+    private factoryService: FactoryService,
+    private utils: Utils,
+    private loadingScreenService: LoadingScreenService
+  ) {}
+
+  ngOnInit() {
+    this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
+      this.commPackage = res.communicationsPackage.COMMUNICATIONS;
+      const urlSegments = this.router.url.split('/');
+      this.selectedApplication = urlSegments[urlSegments.length - 1].toUpperCase();
+
+      this.buildForm();
+    });
+  }
+
+  private buildForm() {
+    this.myForm = new FormGroup({
+      popupTitle: new FormControl({
+        value: (this.commPackage && this.commPackage.title) || '',
+        disabled: !this.checkRoles()
+      }),
+      description: new FormControl({
+        value: (this.commPackage && this.commPackage.description) || '',
+        disabled: !this.checkRoles()
+      }),
+      startDate: new FormControl({
+        value: (this.commPackage &&
+          this.commPackage.startDate &&
+          this.utils.convertJSDateToNGBDate(new Date(this.commPackage.startDate))) ||
+        '',
+        disabled: !this.checkRoles()
+      }),
+      endDate: new FormControl({
+        value: (this.commPackage &&
+          this.commPackage.endDate &&
+          this.utils.convertJSDateToNGBDate(new Date(this.commPackage.endDate))) ||
+        '',
+        disabled: !this.checkRoles()
+      })
+    });
+  }
+
+  async submit() {
+    // save the popup
+    this.loadingScreenService.setLoadingState(true, 'main');
+
+    if (
+      !this.myForm.get('popupTitle').value ||
+      !this.myForm.get('description').value
+    ) {
+      alert('Please ensure your Communication Package includes a title and a description.');
+      return;
+    }
+
+    const popup = {};
+
+    popup['title'] = this.myForm.get('popupTitle').value;
+    popup['description'] = this.myForm.get('description').value;
+    popup['startDate'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('startDate').value);
+    popup['endDate'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('endDate').value);
+    popup['application'] = this.selectedApplication;
+
+    this.factoryService.createCommunicationPackage(popup).subscribe(async (res: any) => {
+      this.loadingScreenService.setLoadingState(false, 'main');
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
+  }
+
+  checkRoles() {
+    if (this.factoryService.userInRole('sysadmin')) {
+      return true;
+    } else if (this.factoryService.userInLngRole() && this.selectedApplication === 'LNG') {
+      return true;
+    } else if (this.factoryService.userInNrcedRole() && this.selectedApplication === 'NRCED') {
+      return true;
+    } else if (this.factoryService.userInBcmiRole() && this.selectedApplication === 'BCMI') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
@@ -33,8 +33,7 @@ export class CommunicationsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
       this.commPackage = res.communicationsPackage.COMMUNICATIONS;
-      const urlSegments = this.router.url.split('/');
-      this.selectedApplication = urlSegments[urlSegments.length - 1].toUpperCase();
+      this.selectedApplication = this.route.snapshot.params.application.toUpperCase();
 
       this.buildForm();
     });

--- a/angular/projects/admin-nrpti/src/app/communications/communications.module.ts
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.module.ts
@@ -1,0 +1,37 @@
+// modules
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+// modules
+import { GlobalModule } from 'nrpti-angular-components';
+import { CommonModule as NrptiCommonModule } from '../../../../common/src/app/common.module';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { CommunicationsComponent } from './communications.component';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    FormsModule,
+    ReactiveFormsModule,
+    FormsModule,
+    CommonModule,
+    GlobalModule,
+    ReactiveFormsModule,
+    NrptiCommonModule,
+    RouterModule,
+    NgbModule.forRoot(),
+  ],
+  declarations: [
+    CommunicationsComponent
+  ],
+  providers: [],
+  entryComponents: [
+    CommunicationsComponent
+  ],
+  exports: []
+})
+export class CommunicationsModule {}

--- a/angular/projects/admin-nrpti/src/app/communications/communications.resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.resolver.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import { FactoryService } from '../services/factory.service';
+
+@Injectable()
+export class CommunicationsResolver implements Resolve<Observable<object>> {
+  constructor(private factoryService: FactoryService) {}
+
+  resolve(route: ActivatedRouteSnapshot): Observable<object> {
+    const application = route.params && route.params.application ? route.params.application : 'BCMI';
+    return this.factoryService.getCommunicationPackage(application);
+  }
+}

--- a/angular/projects/admin-nrpti/src/app/services/factory.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/factory.service.ts
@@ -3,7 +3,7 @@ import { KeycloakService } from './keycloak.service';
 import { JwtUtil } from '../utils/jwt-utils';
 import { Observable, of } from 'rxjs';
 import { ApiService } from './api.service';
-import { SearchService, SearchResults } from 'nrpti-angular-components';
+import { SearchService, SearchResults, ConfigService } from 'nrpti-angular-components';
 import { RecordService } from './record.service';
 import { catchError } from 'rxjs/operators';
 import { TaskService, ITaskParams } from './task.service';
@@ -29,6 +29,7 @@ export class FactoryService {
   private _collectionService: CollectionService;
   private _taskService: TaskService;
   private _documentService: DocumentService;
+  private _configService: ConfigService;
 
   constructor(private injector: Injector) {
     // The following items are loaded by a file that is only present on cluster builds.
@@ -131,6 +132,12 @@ export class FactoryService {
     return this._documentService;
   }
 
+  public get configService(): ConfigService {
+    if (!this._configService) {
+      this._configService = this.injector.get(ConfigService);
+    }
+    return this._configService;
+  }
   /**
    * True if the user is authenticated, false otherwise.
    *
@@ -560,5 +567,13 @@ export class FactoryService {
       : this.recordService
         .editRecord(dataPackage)
         .pipe(catchError(error => this.apiService.handleError(error)));
+  }
+
+  public getCommunicationPackage(application): Observable<object> {
+    return this.configService.getCommunicationPackage(application, this.apiService.pathAPI);
+  }
+
+  public createCommunicationPackage(communicationPackage): Observable<object> {
+    return this.configService.createCommunicationPackage(communicationPackage, this.apiService.pathAPI);
   }
 }

--- a/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
+++ b/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
@@ -71,5 +71,9 @@
       <i class="material-icons mr-3">import_export</i>
       Imports
     </a>
+    <a [ngClass]="{ active: mainRoute === 'communications' }" id="communications" [routerLink]="['/communications', 'BCMI']">
+      <i class="material-icons mr-3">chat</i>
+      Communications
+    </a>
   </section>
 </div>

--- a/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
+++ b/angular/projects/admin-nrpti/src/app/sidebar/sidebar.component.html
@@ -72,7 +72,7 @@
       Imports
     </a>
     <a [ngClass]="{ active: mainRoute === 'communications' }" id="communications" [routerLink]="['/communications', 'BCMI']">
-      <i class="material-icons mr-3">chat</i>
+      <em class="material-icons mr-3">chat</em>
       Communications
     </a>
   </section>

--- a/angular/projects/common/src/app/models/master/common-models/communications-package.ts
+++ b/angular/projects/common/src/app/models/master/common-models/communications-package.ts
@@ -1,0 +1,30 @@
+export class CommunicationsPackage {
+  write: string[];
+  read: string[];
+  _id: string;
+  _schemaName: string;
+  application: string;
+  title: string;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  additionalInfo: any;
+  addedBy: string;
+  dateAdded: Date;
+
+  constructor(obj?: any) {
+    this.read   = (obj && obj.read)   || null;
+    this.write  = (obj && obj.write)  || null;
+
+    this._id             = (obj && obj._id)            || null;
+    this._schemaName     = (obj && obj._schemaName)    || null;
+    this.application     = (obj && obj.application)    || null;
+    this.title           = (obj && obj.title)          || null;
+    this.description     = (obj && obj.description)    || null;
+    this.startDate       = (obj && obj.startDate)      || null;
+    this.endDate         = (obj && obj.endDate)        || null;
+    this.additionalInfo  = (obj && obj.additionalInfo) || null;
+    this.addedBy         = (obj && obj.addedBy)        || null;
+    this.dateAdded       = (obj && obj.dateAdded)      || null;
+  }
+}

--- a/angular/projects/global/src/lib/services/config.service.ts
+++ b/angular/projects/global/src/lib/services/config.service.ts
@@ -34,4 +34,16 @@ export class ConfigService {
   get config(): any {
     return this.configuration;
   }
+
+  public getCommunicationPackage(application, pathAPI: string) {
+    return this.httpClient.get(`${pathAPI}/config/${application}`, {});
+  }
+
+  public createCommunicationPackage(communicationPackage, pathAPI: string) {
+    if (!communicationPackage) {
+      throw new Error('Invalid communication pakage!');
+    }
+
+    return this.httpClient.post(`${pathAPI}/config/${communicationPackage.application}`, communicationPackage, {});
+  }
 }

--- a/angular/projects/global/src/lib/services/config.service.ts
+++ b/angular/projects/global/src/lib/services/config.service.ts
@@ -40,7 +40,8 @@ export class ConfigService {
   }
 
   public createCommunicationPackage(communicationPackage, pathAPI: string) {
-    if (!communicationPackage) {
+    if (!communicationPackage ||
+        (communicationPackage && !Object.prototype.hasOwnProperty.call(communicationPackage, 'application'))) {
       throw new Error('Invalid communication pakage!');
     }
 

--- a/api/src/controllers/config.js
+++ b/api/src/controllers/config.js
@@ -1,4 +1,7 @@
-let QueryActions = require('../utils/query-actions');
+const QueryActions = require('../utils/query-actions');
+const defaultLog   = require('../utils/logger')('record');
+const utils        = require('../utils/constants/misc');
+const { communicationPackage: CommunicationPackage }  = require('../models/index');
 
 exports.protectedOptions = function (args, res, next) {
   res.status(200).send();
@@ -9,7 +12,7 @@ exports.protectedOptions = function (args, res, next) {
  *
  * @returns {object}
  */
-exports.protectedGetConfig = function (args, res, next) {
+exports.protectedGetConfig = async function (args, res, next) {
   console.log("Got configuration data");
   let configurationData = {};
 
@@ -20,6 +23,69 @@ exports.protectedGetConfig = function (args, res, next) {
   configurationData['ENVIRONMENT'] = process.env.ENVIRONMENT;
   configurationData['debugMode'] = process.env.DEBUG_MODE;
 
+  // get project specific confguration
+  if (args.swagger.params.app && args.swagger.params.app.value) {
+    // fetch the latest business area specific CommunicationPackage
+    // attach it to the configuration data under "COMMUNICATIONS"
+    const commPackage = await CommunicationPackage.findOne({ _schemaName: 'CommunicationPackage', application: args.swagger.params.app.value });
+    configurationData['COMMUNICATIONS'] = commPackage;
+  }
+
   QueryActions.sendResponse(res, 200, configurationData);
 };
+
+exports.communicationPackageCreate = async function (args, res, next) {
+  defaultLog.debug(' >> communicationPackageCreate');
+  let communicationPackage = null;
+
+  try {
+    if (args.swagger.params.communicationPackage && args.swagger.params.communicationPackage.value) {
+      communicationPackage = args.swagger.params.communicationPackage.value
+    } else {
+      throw new Error('Invalid body');
+    }
+
+    // check roles. User must have the admin role for the application
+    if (!args.swagger.params.auth_payload.realm_access.roles.includes('sysadmin') &&
+        args.swagger.params.app.value === 'BCMI' &&
+        !args.swagger.params.auth_payload.realm_access.roles.includes('admin:bcmi')) {
+      throw new Error('Permission Denied. You are not an administrator for BCMI');
+    } else if (!args.swagger.params.auth_payload.realm_access.roles.includes('sysadmin') &&
+                args.swagger.params.app.value === 'NRCED' &&
+                !args.swagger.params.auth_payload.realm_access.roles.includes('admin:nrced')) {
+      throw new Error('Permission Denied. You are not an administrator for NRCED');
+    } else if (!args.swagger.params.auth_payload.realm_access.roles.includes('sysadmin') &&
+                args.swagger.params.app.value === 'LNG' &&
+                !args.swagger.params.auth_payload.realm_access.roles.includes('admin:lng')) {
+      throw new Error('Permission Denied. You are not an administrator for LNG');
+    }
+
+    let newCommPackage = new CommunicationPackage(communicationPackage);
+
+    newCommPackage._schemaName = 'CommunicationPackage';
+    newCommPackage.application = args.swagger.params.app.value;
+    newCommPackage.addedBy = args.swagger.params.auth_payload.displayName;
+    newCommPackage.dateAdded = new Date();
+    newCommPackage.write = utils.ApplicationAdminRoles;
+    newCommPackage.read = utils.ApplicationAdminRoles;
+    newCommPackage.read.push('public');
+
+    // remove any existing communication pacakges for this business area
+    // Future Enhancement: Don't do this. Allow users to create multiples so they can
+    // queue up a series of messages. Support for multiple messages, etc.
+    await CommunicationPackage.deleteMany({ _schemaName: 'CommunicationPackage', application: args.swagger.params.app.value });
+
+    // write the communication package to the DB
+    communicationPackage = await newCommPackage.save();
+  } catch (error) {
+    defaultLog.info(`error creating Communication Package: ${communicationPackage}`);
+    defaultLog.debug(error);
+    return QueryActions.sendResponse(res, 400, {});
+  }
+
+  QueryActions.sendResponse(res, 201, communicationPackage);
+  next();
+
+  defaultLog.debug(' << communicationPackageCreate');
+}
 

--- a/api/src/models/communicationPackage.js
+++ b/api/src/models/communicationPackage.js
@@ -1,0 +1,24 @@
+module.exports = require('../utils/model-schema-generator')(
+  'CommunicationPackage',
+  {
+    _schemaName: { type: String, default: 'CommunicationPackage', index: true },
+    // specific business area / application this comm package relates to
+    // should only be BCMI, LNG, NRCED for now
+    application: { type: String, default: 'BCMI', required: true },
+    // data
+    title: { type: String, default: null, required: true },
+    description: { type: String, default: null, required: true },
+    startDate: { type: Date, default: Date.now(), required: true },
+    endDate: { type: Date, default: null, required: true },
+    // Additional Info is a freeform json object that can be populated to send
+    // special instructions to the front ends
+    additionalInfo: { type: Object, default: null },
+    // meta
+    addedBy: { type: String, default: null },
+    dateAdded: { type: Date, default: Date.now() },
+    // Permissions
+    write: [{ type: String, trim: true, default: 'sysadmin' }],
+    read: [{ type: String, trim: true, default: 'public' }]
+  },
+  'nrpti'
+);

--- a/api/src/models/index.js
+++ b/api/src/models/index.js
@@ -5,6 +5,7 @@ exports.audit = require('./audit');
 exports.task = require('./task');
 exports.document = require('./document');
 exports.epicProject = require('./epicProject');
+exports.communicationPackage = require('./communicationPackage');
 
 // master
 require('./master');

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -170,6 +170,10 @@ definitions:
       - +documentType
       - -documentType
 
+  ### Communication Package Definition
+  CommunicationPackage:
+    type: object
+
   ### Task Definitions
   TaskObject:
     type: object
@@ -246,6 +250,82 @@ paths:
           description: 'Success'
           schema:
             $ref: '#/definitions/ConfigObject'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+  /config/{app}:
+    x-swagger-router-controller: config
+    options:
+      tags:
+        - config
+      summary: 'Pre-flight request'
+      operationId: protectedOptions
+      description: 'Options on config Route'
+      parameters:
+        - name: app
+          in: path
+          description: 'Specific application/business area you want to fetch configurations for'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/ConfigObject'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      tags:
+        - config
+      summary: 'Get the app configuration'
+      operationId: protectedGetConfig
+      description: 'Retrieves configuration data.'
+      parameters:
+        - name: app
+          in: path
+          description: 'Specific application/business area you want to fetch configurations for'
+          required: true
+          type: string
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/ConfigObject'
+        '403':
+          description: 'Access Denied'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      tags:
+        - config
+      summary: 'Create an app communication package (note: this will remove any existing package)'
+      operationId: communicationPackageCreate
+      description: 'Authenticated access to create a communication package'
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - sysadmin
+        - admin:lng
+        - admin:nrced
+        - admin:bcmi
+      parameters:
+        - name: app
+          in: path
+          description: 'Specific application/business area you want to fetch configurations for'
+          required: true
+          type: string
+        - name: communicationPackage
+          in: body
+          description: 'Create comm package body'
+          required: true
+          schema:
+            $ref: '#/definitions/CommunicationPackage'
+      responses:
+        '201':
+          description: 'Success'
         '403':
           description: 'Access Denied'
           schema:


### PR DESCRIPTION
Addition of a new model called "CommunicationPackage" that contains details for consuming applications to display a popup or other information.

The model contains the following attributes
```
{
    title: string,
    description: string,
    startDate: date,
    endDate: date,
    additionalInfo: object
}
```
Consuming applications can use title, description for the popup, start/end date for when to display. Additional Info is a future-proofing open object that should allow us to include any additional attribute information we need to pass back and forth to the application. Currently not editable by the admin screen, but it should be easy to add an ad-hoc attribute creator for that.

Updates to the config service to add `/api/config/{Application}` get and post endpoints. When calling `/api/config/BCMI` for example, it will append a `COMMUNICATIONS` attribute to the returned package that includes the model. There is only a post included as any changes to the popup will delete the previous and create a new one, which allows us to use the GUID as an indicator for changes.

Added a new tab called Communications to NRPTI admin, and a form that allows you to create these packages for BCMI, LNG and NRCED.

Still requires some cleanup and unit tests, additional debugging. Getting it up here asap so I'm not blocking Kit on his work with the popup on BCMI!

See ticket [NRPT-387](https://bcmines.atlassian.net/browse/NRPT-387)