### PR TITLE
NRPT-366: Convert ancronyms

### DIFF
--- a/angular/projects/global/src/lib/utils/utils.ts
+++ b/angular/projects/global/src/lib/utils/utils.ts
@@ -105,4 +105,14 @@ export class Utils {
       return fn(...args);
     };
   }
+
+  static convertAcronyms(acronym): string {
+    if (acronym && acronym === 'EAO') {
+      return 'Environmental Assessment Office';
+    } else if (acronym && acronym === 'EMPR') {
+      return 'Ministry of Energy, Mines and Petroleum Resources';
+    } else {
+      return acronym;
+    }
+  }
 }

--- a/angular/projects/public-lng/src/app/project/authorizations/authorizations-rows/authorizations-table-rows.component.html
+++ b/angular/projects/public-lng/src/app/project/authorizations/authorizations-rows/authorizations-table-rows.component.html
@@ -1,5 +1,5 @@
 <td scope="row" data-label="Name" class="col-2">{{ rowData.recordName }}</td>
-<td scope="row" data-label="Government Agency" class="col-2">{{ rowData.issuingAgency }}</td>
+<td scope="row" data-label="Government Agency" class="col-2">{{ convertAcronyms(rowData.issuingAgency) }}</td>
 <td scope="row" data-label="Type" class="col-2">{{ rowData.recordType }}</td>
 <td scope="row" data-label="Subtype" class="col-1">{{ rowData.recordSubtype }}</td>
 <td scope="row" data-label="Date" class="col-2">{{ rowData.dateIssued | date: 'LLLL d, y' }}</td>

--- a/angular/projects/public-lng/src/app/project/authorizations/authorizations-rows/authorizations-table-rows.component.ts
+++ b/angular/projects/public-lng/src/app/project/authorizations/authorizations-rows/authorizations-table-rows.component.ts
@@ -3,6 +3,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { TableRowComponent } from 'nrpti-angular-components';
 import { Subject } from 'rxjs';
 
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
+
 @Component({
   selector: 'tr[app-authorizations-table-rows]',
   templateUrl: './authorizations-table-rows.component.html',
@@ -22,5 +24,9 @@ export class AuthorizationsTableRowsComponent extends TableRowComponent implemen
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-lng/src/app/project/compliance/compliance-rows/compliance-table-rows.component.html
+++ b/angular/projects/public-lng/src/app/project/compliance/compliance-rows/compliance-table-rows.component.html
@@ -1,5 +1,5 @@
 <td scope="row" data-label="Name" class="col-2">{{ rowData.recordName }}</td>
-<td scope="row" data-label="Government Agency" class="col-2">{{ rowData.issuingAgency }}</td>
+<td scope="row" data-label="Government Agency" class="col-2">{{ convertAcronyms(rowData.issuingAgency) }}</td>
 <td scope="row" data-label="Author" class="col-2">{{ rowData.author }}</td>
 <td scope="row" data-label="Type" class="col-1">{{ rowData.recordType }}</td>
 <td scope="row" data-label="Date" class="col-2">{{ rowData.dateIssued | date: 'LLLL d, y' }}</td>

--- a/angular/projects/public-lng/src/app/project/compliance/compliance-rows/compliance-table-rows.component.ts
+++ b/angular/projects/public-lng/src/app/project/compliance/compliance-rows/compliance-table-rows.component.ts
@@ -3,6 +3,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { TableRowComponent } from 'nrpti-angular-components';
 import { Subject } from 'rxjs';
 
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
+
 @Component({
   selector: 'tr[app-compliance-table-rows]',
   templateUrl: './compliance-table-rows.component.html',
@@ -22,5 +24,9 @@ export class ComplianceTableRowsComponent extends TableRowComponent implements O
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-lng/src/app/project/plans/plans-rows/plans-table-rows.component.html
+++ b/angular/projects/public-lng/src/app/project/plans/plans-rows/plans-table-rows.component.html
@@ -1,5 +1,5 @@
 <td scope="row" data-label="Name" class="col-2">{{ rowData.recordName }}</td>
-<td scope="row" data-label="Government Agency" class="col-2">{{ rowData.issuingAgency || rowData.agency }}</td>
+<td scope="row" data-label="Government Agency" class="col-2">{{ convertAcronyms(rowData.issuingAgency) || rowData.agency }}</td>
 <td scope="row" data-label="Phase" class="col-2">{{ rowData.relatedPhase }}</td>
 <td scope="row" data-label="Type" class="col-2">{{ rowData.recordType }}</td>
 <td scope="row" data-label="Date" class="col-3">{{ rowData.dateIssued | date: 'LLLL d, y' }}</td>

--- a/angular/projects/public-lng/src/app/project/plans/plans-rows/plans-table-rows.component.ts
+++ b/angular/projects/public-lng/src/app/project/plans/plans-rows/plans-table-rows.component.ts
@@ -3,6 +3,8 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { TableRowComponent } from 'nrpti-angular-components';
 import { Subject } from 'rxjs';
 
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
+
 @Component({
   selector: 'tr[app-plans-table-rows]',
   templateUrl: './plans-table-rows.component.html',
@@ -22,5 +24,9 @@ export class PlansTableRowsComponent extends TableRowComponent implements OnInit
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { AdministrativePenaltyNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-administrative-penalty-detail',
@@ -91,5 +92,9 @@ export class AdministrativePenaltyDetailComponent implements OnInit, OnChanges, 
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/administrative-sanctions/administrative-sanction-detail/administrative-sanction-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { AdministrativeSanctionNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-administrative-sanction-detail',
@@ -91,5 +92,9 @@ export class AdministrativeSanctionDetailComponent implements OnInit, OnChanges,
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { CourtConvictionNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-court-conviction-detail',
@@ -93,5 +94,9 @@ export class CourtConvictionDetailComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/inspections/inspection-detail/inspection-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { InspectionNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-inspection-detail',
@@ -91,5 +92,9 @@ export class InspectionDetailComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/orders/order-detail/order-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { OrderNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-order-detail',
@@ -91,5 +92,9 @@ export class OrderDetailComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/restorative-justices/restorative-justice-detail/restorative-justice-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { RestorativeJusticeNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-restorative-justice-detail',
@@ -91,5 +92,9 @@ export class RestorativeJusticeDetailComponent implements OnInit, OnChanges, OnD
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/tickets/ticket-detail/ticket-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { TicketNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-ticket-detail',
@@ -91,5 +92,9 @@ export class TicketDetailComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.html
@@ -42,7 +42,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Issuing Agency</label>
-            <span class="grid-item-value__col">{{ (data && data.issuingAgency) || '-' }}</span>
+            <span class="grid-item-value__col">{{ data && data.issuingAgency ? convertAcronyms(data.issuingAgency) : '-' }}</span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Legislation</label>

--- a/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/warnings/warning-detail/warning-detail.component.ts
@@ -5,6 +5,7 @@ import { takeUntil } from 'rxjs/operators';
 import { WarningNRCED, Document } from '../../../../../../common/src/app/models';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils as CommonUtils } from '../../../../../../common/src/app/utils/utils';
+import { Utils as GlobalUtils } from 'nrpti-angular-components';
 
 @Component({
   selector: 'app-warning-detail',
@@ -91,5 +92,9 @@ export class WarningDetailComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy() {
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
+  }
+
+  convertAcronyms(acronym) {
+    return GlobalUtils.convertAcronyms(acronym);
   }
 }

--- a/api/migrations/20200904205029-updateAcronyms.js
+++ b/api/migrations/20200904205029-updateAcronyms.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const RecordTypeEnum = require('../src/utils/constants/misc');
+
+let dbm;
+let type;
+let seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  let failed = false;
+  console.log('##########################################');
+  console.log('##  Starting collection backref update  ##');
+  console.log('##########################################\n');
+
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+
+  console.log(' >> Updating Agency to Ancronyms for all records...');
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    console.log('    Changing "Environmental Assessment Office" to "EAO"');
+    await updateAcronym(nrpti, 'Environmental Assessment Office', 'EAO');
+
+    console.log('    Changing "Ministry of Energy, Mines and Petroleum Resources" to "EMPR"');
+    await updateAcronym(nrpti, 'Ministry of Energy, Mines and Petroleum Resources', 'EMPR');
+
+  } catch (err) {
+    console.error('    //////////////////////////////////////////');
+    console.error('    //  Error during agency assignment: ');
+    console.error('    //  Error:', err);
+    console.error('    //////////////////////////////////////////');
+    failed = true;
+  }
+  console.log(' << Finished agency updates.\n');
+
+  console.log(failed ? '\n##  Process Failed. Please review your errors' : '\n##  All done! Agency updated successfuly.');
+  console.log('#############################################');
+
+  mClient.close()
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};
+
+async function updateAcronym(nrpti, issuingAgencyString, issuingAgencyReplacement) {
+  const schemas = [...RecordTypeEnum.MASTER_SCHEMA_NAMES,
+                   ...RecordTypeEnum.LNG_SCHEMA_NAMES,
+                   ...RecordTypeEnum.NRCED_SCHEMA_NAMES,
+                   ...RecordTypeEnum.BCMI_SCHEMA_NAMES];
+
+  const result = await nrpti.updateMany(
+    { $and: [ { _schemaName: { $in: schemas } }, { issuingAgency: issuingAgencyString } ] },
+    { $set: { issuingAgency: issuingAgencyReplacement } }
+  );
+
+  console.log(`     - ${result.result.ok === 1 ? 'Success!' : 'Failed!'}`);
+  console.log(`     - Updated ${result.result.nModified} records`);
+}

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -27,3 +27,72 @@ exports.EpicProjectIds = {
   lngCanadaId: '588511d0aaecd9001b826192',
   coastalGaslinkId: '588511c4aaecd9001b825604'
 };
+
+exports.MASTER_SCHEMA_NAMES = [
+  'AdministrativePenalty',
+  'AdministrativeSanction',
+  'Agreement',
+  'AnnualReport',
+  'Certificate',
+  'CertificateAmendment',
+  'ConstructionPlan',
+  'Correspondence',
+  'CourtConviction',
+  'DamSafetyInspection',
+  'Inspection',
+  'ManagementPlan',
+  'Order',
+  'Permit',
+  'Report',
+  'RestorativeJustice',
+  'SelfReport',
+  'Ticket',
+  'Warning'
+];
+
+exports.LNG_SCHEMA_NAMES = [
+  'ActivityLNG',
+  'AdministrativePenaltyLNG',
+  'AdministrativeSanctionLNG',
+  'AgreementLNG',
+  'CertificateLNG',
+  'CertificateAmendmentLNG',
+  'ConstructionPlanLNG',
+  'CourtConvictionLNG',
+  'InspectionLNG',
+  'ManagementPlanLNG',
+  'OrderLNG',
+  'PermitLNG',
+  'RestorativeJusticeLNG',
+  'SelfReportLNG',
+  'TicketLNG',
+  'WarningLNG'
+];
+
+exports.NRCED_SCHEMA_NAMES = [
+  'AdministrativePenaltyNRCED',
+  'AdministrativeSanctionNRCED',
+  'CorrespondenceNRCED',
+  'CourtConvictionNRCED',
+  'DamSafetyInspectionNRCED',
+  'InspectionNRCED',
+  'OrderNRCED',
+  'ReportNRCED',
+  'RestorativeJusticeNRCED',
+  'TicketNRCED',
+  'WarningNRCED'
+];
+
+exports.BCMI_SCHEMA_NAMES = [
+  'AnnualReportBCMI',
+  'CertificateAmendmentBCMI',
+  'CollectionBCMI',
+  'CorrespondenceBCMI',
+  'DamSafetyInspectionBCMI',
+  'InspectionBCMI',
+  'ManagementPlanBCMI',
+  'MineBCMI',
+  'OrderBCMI',
+  'PermitBCMI',
+  'ReportBCMI'
+];


### PR DESCRIPTION
Adding a migration to replace all instances of "Environmental Assessment Office" with EAO and "Ministry of Energy, Mines and Petroleum Resources" with EMPR in the database.

Adding a function in Global Utils to convert the acronyms back to full strings.

Adding functions in NRCED and LNG public to use the global util to display acronyms as the full text (BCMI and NRPTI show acronyms instead).

See ticket [NRPT-366](https://bcmines.atlassian.net/browse/NRPT-366)