### PR TITLE
NOBUG: Fix missing 's'

### DIFF
--- a/api/src/controllers/post/collection-bcmi.js
+++ b/api/src/controllers/post/collection-bcmi.js
@@ -84,7 +84,7 @@ exports.createMaster = async function(args, res, next, incomingObj) {
   // if any values in the "records" attribute exist on any other collection, throw an error
   if (collection.records && collection.records.length > 0) {
     const model = require('mongoose').model(RECORD_TYPE.CollectionBCMI._schemaName);
-    for(const record of collection.record) {
+    for(const record of collection.records) {
       // does this record exit in any other collection?
       const collectionCount = await model.count({ _schemaName: RECORD_TYPE.CollectionBCMI._schemaName,  records: { $elemMatch: { $eq: new ObjectID(record) } } });
       if (collectionCount && collectionCount > 0) {


### PR DESCRIPTION
A literal One Character Fix.

A missing 's' on the call to loop through a collections records was causing a failure during POSTs for collections (`collection.record is not iterable`) which makes sense as the attribute doesn't exist (it's supposed to be `records`... likely the primary reason for a number of the bug tickets related to collections not saving properly... but rather than link each one as a partial fix, I'll nobug this up so we can merge it in asap and it should help with the others.