### PR TITLE
NOBUG: FIxed checkbox handler

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.html
@@ -1,5 +1,5 @@
-<td scope="row" class="col-1" (click)="$event.stopPropagation(); toggleCheckbox();">
-  <mat-checkbox *ngIf="!rowData.collections || rowData.collections.length === 0" (click)="$event.stopPropagation();" [checked]="rowData.rowSelected"></mat-checkbox>
+<td scope="row" class="col-1" (click)="toggleCheckbox(); $event.stopPropagation();">
+  <mat-checkbox #rowCheckBox *ngIf="!rowData.collections || rowData.collections.length === 0" [checked]="rowData.rowSelected" (change)="toggleCheckbox($event)"></mat-checkbox>
 </td>
 <td scope="row" data-label="Name" class="col-2">
   {{ getAttributeValue('recordName') }}

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.html
@@ -1,4 +1,4 @@
-<td scope="row" class="col-1" (click)="toggleCheckbox(); $event.stopPropagation();">
+<td scope="row" class="col-1" (click)="toggleCheckbox(null); $event.stopPropagation();">
   <mat-checkbox #rowCheckBox *ngIf="!rowData.collections || rowData.collections.length === 0" [checked]="rowData.rowSelected" (change)="toggleCheckbox($event)"></mat-checkbox>
 </td>
 <td scope="row" data-label="Name" class="col-2">

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-rows/mines-records-table-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectorRef, HostListener } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, HostListener, ViewChild, ElementRef } from '@angular/core';
 import { FactoryService } from '../../services/factory.service';
 import { TableRowComponent } from 'nrpti-angular-components';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -11,6 +11,8 @@ import { Entity } from '../../../../../common/src/app/models/master/common-model
 })
 export class MinesRecordsTableRowComponent extends TableRowComponent implements OnInit {
   public entityString = '';
+
+  @ViewChild('rowCheckBox') rowCheckBox: ElementRef;
 
   constructor(
     public route: ActivatedRoute,
@@ -56,7 +58,13 @@ export class MinesRecordsTableRowComponent extends TableRowComponent implements 
     }
   }
 
-  public toggleCheckbox() {
+  public toggleCheckbox(event) {
+
+    if (!event) {
+      this.rowCheckBox['checked'] = true;
+      return;
+    }
+
     this.rowData.rowSelected = !this.rowData.rowSelected;
 
     if (this.rowData.rowSelected) {
@@ -64,9 +72,8 @@ export class MinesRecordsTableRowComponent extends TableRowComponent implements 
     } else {
       this.messageOut.emit({ label: 'rowUnselected', data: this.rowData });
     }
-
-    this.changeDetectionRef.detectChanges();
   }
+
   /**
    * Navigate to record details page.
    *


### PR DESCRIPTION
A fix to prevent the clicking of the table cell kill propogation to the checkbox (or the checkbox click causing the click event to trigger twice).

Affects a number of different bug tickets so pushing this in as a nobug to assist with debugging the other bug tickets.