### PR TITLE
NRPT-366: Update agency picklist constants

### DIFF
--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -138,11 +138,11 @@ export class Picklists {
     'BC Wildfire Service',
     'Climate Action Secretariat',
     'Conservation Officer Service (COS)',
-    'Environmental Assessment Office',
+    'EAO',
     'Environmental Protection Division',
     'LNG Secretariat',
     'Ministry of Agriculture',
-    'Ministry of Energy, Mines and Petroleum Resources',
+    'EMPR',
     'Ministry of Forests, Lands, Natural Resource Operations and Rural Development',
     'Natural Resource Officers (NRO)'
   ];


### PR DESCRIPTION
Update to constants for agency values (EMPR, EAO) to match with database changes to use acronyms

See ticket [NRPT-366](https://bcmines.atlassian.net/browse/NRPT-366)