### PR TITLE
NRPT-417 Remove Publish/Unpublish from ellipsis on Mines Collection page

### DIFF
--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-rows/mines-collections-table-row.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-rows/mines-collections-table-row.component.html
@@ -27,24 +27,6 @@
     <button mat-menu-item [disabled]="isEditingCollection" (click)="goToDetails()" title="View collection details">
       View Collection Details
     </button>
-    <button
-      mat-menu-item
-      *ngIf="rowData.read && !rowData.read.includes('public')"
-      [disabled]="isEditingCollection"
-      (click)="publishCollection()"
-      title="Publish collection"
-    >
-      Publish Collection
-    </button>
-    <button
-      mat-menu-item
-      *ngIf="rowData.read && rowData.read.includes('public')"
-      [disabled]="isEditingCollection"
-      (click)="unpublishCollection()"
-      title="Unpublish collection"
-    >
-      Unpublish Collection
-    </button>
     <button mat-menu-item [disabled]="isEditingCollection" (click)="deleteCollection()" title="Delete collection">
       Delete Collection
     </button>

--- a/angular/projects/admin-nrpti/src/app/mines/mines-collections-rows/mines-collections-table-row.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-collections-rows/mines-collections-table-row.component.ts
@@ -69,68 +69,6 @@ export class MinesCollectionsTableRowComponent extends TableRowComponent impleme
   }
 
   /**
-   * Publish the collection, adding the `public` role to the read array.
-   *
-   * @memberof MinesCollectionsTableRowComponent
-   */
-  publishCollection(): void {
-    this.factoryService
-      .publishRecord(this.rowData)
-      .pipe(
-        takeUntil(this.ngUnsubscribe),
-        catchError(() => {
-          alert('Failed to publish collection.');
-          return of(null);
-        })
-      )
-      .subscribe(response => {
-        if (!response) {
-          return;
-        }
-
-        if (response.code === 409) {
-          // object was already published
-          return;
-        }
-
-        this.rowData = response;
-
-        this.changeDetectionRef.detectChanges();
-      });
-  }
-
-  /**
-   * Unpublish the collection, removing the `public` role from the read array.
-   *
-   * @memberof MinesCollectionsTableRowComponent
-   */
-  unpublishCollection(): void {
-    this.factoryService
-      .unPublishRecord(this.rowData)
-      .pipe(
-        takeUntil(this.ngUnsubscribe),
-        catchError(() => {
-          alert('Failed to unpublish collection.');
-          return of(null);
-        })
-      )
-      .subscribe(response => {
-        if (!response) {
-          return;
-        }
-
-        if (response.code === 409) {
-          // object was already unpublished
-          return;
-        }
-
-        this.rowData = response;
-
-        this.changeDetectionRef.detectChanges();
-      });
-  }
-
-  /**
    * Delete the collection.
    *
    * @memberof MinesCollectionsTableRowComponent


### PR DESCRIPTION
Removed Publish/Unpublish actions from the Mines Collection list ellipsis.  These actions are no long needed due to workflow change.

https://bcmines.atlassian.net/browse/NRPT-417