### PR TITLE
NRPT-438: return collection docs in sort order defined by collection

### DIFF
--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -897,17 +897,40 @@ const executeQuery = async function (args, res, next) {
       {
         $match: { _id: mongoose.Types.ObjectId(args.swagger.params._id.value) }
       },
-      // lookup the records
+      // lookup the records and set order as defined by collection records array
       {
-        $lookup: { from: 'nrpti', localField: 'records', foreignField: '_id', as: 'populatedRecords' }
+        $lookup: {
+          from: 'nrpti',
+          let: { orderedRecords: '$records' },
+          pipeline: [
+            { $match: { $expr: { $in: [ '$_id', '$$orderedRecords' ]}}},
+            { $addFields: { "sortOrder": { "$indexOfArray": [ "$$orderedRecords", "$_id" ]}}},
+          ],
+          as: 'sortedRecords'
+        }
       },
-      // lookup the documents
+      // turf unused collection info
       {
-        $lookup: { from: 'nrpti', localField: 'populatedRecords.documents', foreignField: '_id', as: 'documents' }
+        $project: { sortedRecords: 1, _id: 0 }
+      },
+      {
+        $unwind: { path: '$sortedRecords' }
+      },
+      // lookup the documents and copy the record order
+      {
+        $lookup: {
+          from: 'nrpti',
+          let: { orderedRecords: '$sortedRecords' },
+          pipeline: [
+            { $match: { $expr: { $in: [ '$_id', '$$orderedRecords.documents' ]}}},
+            { $addFields: { '_sort': '$$orderedRecords.sortOrder' }}
+          ],
+          as: 'documents'
+        }
       },
       // turf the uneeded attributes
       {
-        $project: { documents: 1 }
+        $project: { documents: 1, _id: 0 }
       },
       // unwind the documents array so we have a flat array of document records
       {
@@ -916,6 +939,10 @@ const executeQuery = async function (args, res, next) {
       // push everything off the document attribute to the root
       {
         $replaceRoot: { newRoot: '$documents' }
+      },
+      // sort the docs
+      {
+        $sort: { "_sort": 1 }
       },
       // redact based on scope
       {
@@ -947,7 +974,6 @@ const executeQuery = async function (args, res, next) {
 
     const db = mongodb.connection.db(process.env.MONGODB_DATABASE || 'nrpti-dev');
     const collection = db.collection('nrpti');
-
     data = await collection.aggregate(aggregation, {
       allowDiskUse: true,
       collation: {


### PR DESCRIPTION
Sort order is defined by a collection's records array, the mongo lookups did not preserve order. Docs should now be returned in the proper order.

- [NRPT-438](https://bcmines.atlassian.net/browse/NRPT-438)
