### PR TITLE
NRPT-479: Fixes Permit Flavour Issue With Migration

### DIFF
--- a/api/migrations/20200709183253-loadMemDocs.js
+++ b/api/migrations/20200709183253-loadMemDocs.js
@@ -281,16 +281,7 @@ async function createMineDocument(nrpti, nrptiMine, collection, collectionDoc, n
   const issuingAgency = collection.isForMEM ? 'EMPR' : collection.isForEAO ? 'EAO' : 'ENV';
 
   // BCMI flavour
-  //
-  if (flavourData.recordType === 'Permit') {
-    flavourData.amendmentDocument = {
-      documentId: document._id,
-      documentName: document.fileName,
-      _sourceRefId: 'mem-admin'
-    };
-  } else {
-    flavourData.documents = [document._id];
-  }
+  flavourData.documents = [document._id];
   flavourData._master = new ObjectID(masterData._id);
   flavourData.collectionId = new ObjectID(newCollectionId);
   flavourData.mineGuid = nrptiMine._sourceRefId;


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-479

This fixes an issue where the mem-admin migration was still using the old BCMI Permit field 'amendmentDocuments' rather than the standard 'documents' field. 