### PR TITLE
NRPT-503: Updates Importers To Always Unpublish

### DIFF
--- a/api/migrations/20200709183253-loadMemDocs.js
+++ b/api/migrations/20200709183253-loadMemDocs.js
@@ -227,7 +227,6 @@ exports.up = async function (db) {
             }
           }
           if (allNewDocs.length) {
-            console.log(`allnewDocs: ${JSON.stringify(allNewDocs)}`)
             bcmiCollection.records = bcmiCollection.records.concat(allNewDocs);
             await nrpti.findOneAndUpdate({ _schemaName: "CollectionBCMI", name: collection.displayName }, bcmiCollection)
           }
@@ -299,7 +298,7 @@ async function createMineDocument(nrpti, nrptiMine, collection, collectionDoc, n
   document.addedBy = 'BCMI Mine Doc Import';
   document.url = `https://${OBJ_STORE_URL}/${OBJ_STORE_BUCKET}/${document._id}/${collectionDoc.document.displayName}`;
   document.key = s3Key;
-  document.read = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI, 'public'];
+  document.read = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI];
   document.write = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI];
 
   // upload to s3
@@ -385,7 +384,7 @@ async function createMineDocument(nrpti, nrptiMine, collection, collectionDoc, n
   flavourData.sourceDateAdded = collectionDoc.document.dateAdded;
   flavourData.sourceDateUpdated = collectionDoc.document.dateUpdated;
   flavourData.sourceSystemRef = 'mem-admin';
-  flavourData.read = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI, 'public'];
+  flavourData.read = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI];
   flavourData.write = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI];
   await nrpti.insertOne(flavourData);
 

--- a/api/src/controllers/collection-controller.js
+++ b/api/src/controllers/collection-controller.js
@@ -379,15 +379,14 @@ const checkRecordExistsInCollection = async function (records, collectionId, edi
       }
     } else {
       // Ensure the record has the collectionId set
-      // Also, if we are associating a record, we auto-publish that record
+      // Also, if we are associating a record
       promises.push(collectionDB.findOneAndUpdate(
         { _id: new ObjectID(record) },
         {
           $set: {
             collectionId: new ObjectID(collectionId),
             isBcmiPublished: true
-          },
-          $addToSet: { read: 'public' }
+          }
         }
       ));
     }
@@ -400,7 +399,6 @@ const checkRecordExistsInCollection = async function (records, collectionId, edi
 }
 
 const createCollection = async function (collectionObj, user) {
-
   let CollectionBCMI = mongoose.model(RECORD_TYPE.CollectionBCMI._schemaName);
   let collection = new CollectionBCMI();
 
@@ -433,10 +431,12 @@ const createCollection = async function (collectionObj, user) {
     }
   }
 
-  // Add 'public' role and associated meta
-  collection.read.push('public');
-  collection.datePublished = new Date();
-  collection.publishedBy = user;
+  // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
+  if (collectionObj.addRole && collectionObj.addRole === 'public') {
+    collection.read.push('public');
+    collection.datePublished = new Date();
+    collection.publishedBy = user;
+  }
 
   // Set auditing meta
   collection.addedBy = user || collectionObj.addedBy;

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -335,6 +335,6 @@ exports.createBCMI = function (args, res, next, incomingObj) {
   incomingObj.sourceDateAdded && (permitBCMI.sourceDateAdded = incomingObj.sourceDateAdded);
   incomingObj.sourceDateUpdated && (permitBCMI.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (permitBCMI.sourceSystemRef = incomingObj.sourceSystemRef);
-
+  
   return permitBCMI;
 };

--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -9,7 +9,6 @@ const CollectionUtils = require('./collection-utils');
 const defaultLog = require('../../utils/logger')('core-datasource');
 const RECORD_TYPE = require('../../utils/constants/record-type-enum');
 const { getIntegrationUrl, getCoreAccessToken, getAuthHeader } = require('../integration-utils');
-const { publicGet } = require('../../controllers/record-controller');
 
 const CORE_API_BATCH_SIZE = process.env.CORE_API_BATCH_SIZE || 300;
 

--- a/api/src/integrations/epic/base-record-utils.js
+++ b/api/src/integrations/epic/base-record-utils.js
@@ -48,7 +48,7 @@ class BaseRecordUtils {
     const documents = [];
 
     if (epicRecord && epicRecord._id && epicRecord.documentFileName) {
-      const readRoles = [utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_BCMI, 'public'];
+      const readRoles = [utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_BCMI];
       const writeRoles = [utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_BCMI];
 
       const savedDocument = await DocumentController.createURLDocument(


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-503

This changes make all collections and records brought in with the mem-admin migration default to unpublished. It also updates the Core importer to set the record and collection state based on the Mine's state.

Changes will need to be made to update the status for records and collections that are manually created. Will update in another ticket.