### PR TITLE
NRPT-506 Fix Core-doc importer creating duplicate documents

### DIFF
--- a/api/src/controllers/put/administrative-penalty.js
+++ b/api/src/controllers/put/administrative-penalty.js
@@ -97,7 +97,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/administrative-sanction.js
+++ b/api/src/controllers/put/administrative-sanction.js
@@ -97,7 +97,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/agreement.js
+++ b/api/src/controllers/put/agreement.js
@@ -82,7 +82,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/annual-report.js
+++ b/api/src/controllers/put/annual-report.js
@@ -83,7 +83,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/certificate-amendment.js
+++ b/api/src/controllers/put/certificate-amendment.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/certificate.js
+++ b/api/src/controllers/put/certificate.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/construction-plan.js
+++ b/api/src/controllers/put/construction-plan.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/correspondence.js
+++ b/api/src/controllers/put/correspondence.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/court-conviction.js
+++ b/api/src/controllers/put/court-conviction.js
@@ -97,7 +97,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/dam-safety-inspection.js
+++ b/api/src/controllers/put/dam-safety-inspection.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/management-plan.js
+++ b/api/src/controllers/put/management-plan.js
@@ -83,7 +83,7 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/order.js
+++ b/api/src/controllers/put/order.js
@@ -98,7 +98,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/permit.js
+++ b/api/src/controllers/put/permit.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/report.js
+++ b/api/src/controllers/put/report.js
@@ -84,7 +84,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/restorative-justice.js
+++ b/api/src/controllers/put/restorative-justice.js
@@ -97,7 +97,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/self-report.js
+++ b/api/src/controllers/put/self-report.js
@@ -82,7 +82,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj, $addToSet: {}, $pull: {} };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/ticket.js
+++ b/api/src/controllers/put/ticket.js
@@ -98,7 +98,7 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/controllers/put/warning.js
+++ b/api/src/controllers/put/warning.js
@@ -97,7 +97,7 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
+    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
   }
 
   return updateObj;

--- a/api/src/integrations/core-documents/datasource.js
+++ b/api/src/integrations/core-documents/datasource.js
@@ -259,7 +259,10 @@ class CoreDocumentsDataSource {
     try {
       // Before saving we want to transform to remove anything associated with the mongoose model
       const transformedAmendment = permitUtils.transformRecord(permit);
-      await permitUtils.updateRecord(transformedAmendment, permit);
+      const result = await permitUtils.updateRecord(transformedAmendment, permit);
+
+      if(result.length && result[0].status && result[0].status === 'failure')
+        throw Error(`permitUtils.updateRecord failed: ${result[0].errorMessage}`);
     } catch (error) {
       throw new Error(`updateAmendment - unexpected error: ${error.message}`);
     }

--- a/api/src/utils/s3-cleanup.js
+++ b/api/src/utils/s3-cleanup.js
@@ -113,9 +113,9 @@ async function run(dryRun) {
 
       console.log('Done');
     }
-  }
-
-  console.log('\nThere are no orphan objects in S3.');
+  } else {
+    console.log('\nThere are no orphan objects in S3.');
+  }  
 }
 
 /**


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-506

This issue was caused by Permit master record DB update operation failing.  The DB operation failure was caused by a previous change to [PutUtils.editRecordWithFlavours](https://github.com/BcGovNeal/NRPTI/commit/c0628ede3519f696810f047c387531f2ff31367b#diff-e69b25854c520ba3729e82916e80a05027f56b4eb81f364194f15311a3d989fc).  This change caused a conflict in all records' `editMaster` function because it'll try to update the master records' `_flavourIds` field using both `$set` and `$addToSet`.

This PR removes the `$addToSet` operation and uses the `$set` operation instead for updating flavour ids.