### PR TITLE
NRPT-488: Upgrading Metabase

### DIFF
--- a/tools/docker-images/metabase/Dockerfile
+++ b/tools/docker-images/metabase/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_CTYPE en_US.UTF-8
 RUN apk add --update bash git wget make gettext ttf-dejavu fontconfig java-cacerts
 
 # add Metabase jar
-RUN wget -q http://downloads.metabase.com/v0.34.3/metabase.jar
+RUN wget -q https://downloads.metabase.com/v0.37.0.2/metabase.jar
 
 # create the plugins directory, with writable permissions
 RUN chmod -R 777 /app


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-488

There is an issue with timeouts for complicated or data heavy queries that was fixed in version 35. I am upgrading to the most recent version to see if the error is resolved.