### PR TITLE
NOBUG: Small BCOGC Adjustments

### DIFF
--- a/angular/projects/common/src/app/models/master/common-models/penalty.ts
+++ b/angular/projects/common/src/app/models/master/common-models/penalty.ts
@@ -46,7 +46,7 @@ export class Penalty {
    * @memberof Penalty
    */
   public buildPenaltyValueString(): string {
-    if (!this.penalty.value) {
+    if (!this.penalty || !this.penalty.value) {
       return '';
     }
 

--- a/api/src/integrations/bcogc/administrative-penalties-utils.js
+++ b/api/src/integrations/bcogc/administrative-penalties-utils.js
@@ -40,6 +40,7 @@ class AdministrativePenalty extends BaseRecordUtils {
     penalty['recordType'] = RECORD_TYPE.AdministrativePenalty._schemaName;
     penalty['_sourceRefOgcPenaltyId'] = csvRow['Title'];
     penalty['author'] = 'BC Oil and Gas Commission';
+    penalty['issuingAgency'] = 'BC Oil and Gas Commission';
     penalty['recordName'] = csvRow['Title'];
     penalty['dateIssued'] = new Date(csvRow['Date Issued']);
     penalty['location'] = 'British Columbia';

--- a/api/src/integrations/bcogc/orders-utils.js
+++ b/api/src/integrations/bcogc/orders-utils.js
@@ -40,6 +40,7 @@ class Orders extends BaseRecordUtils {
     order['recordType'] = RECORD_TYPE.Order._schemaName;
     order['_sourceRefOgcOrderId'] = csvRow['Title'];
     order['author'] = 'BC Oil and Gas Commission';
+    order['issuingAgency'] = 'BC Oil and Gas Commission';
     order['recordName'] = csvRow['Title'];
     order['dateIssued'] = new Date(csvRow['Date Issued']);
 
@@ -49,6 +50,9 @@ class Orders extends BaseRecordUtils {
       act: 'Oil and Gas Activities Act',
       section: this.getOrderSection(csvRow),
     };
+
+    // Description set by the section number.
+    order['description'] = this.getOrderSection(csvRow) === 49 ? 'General Order' : 'Action Order';
 
     order['issuedTo'] = {
       type: 'Company',


### PR DESCRIPTION
Ticket - none

Adding in two missing fields for orders and one for issuing agency. Also fixed a NRCED bug if a record has no penalty. 