### PR TITLE
NRPT-557 Update AMP, Order and Document controller to handle wildfire create record logic

### DIFF
--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const ObjectId = require('mongoose').Types.ObjectId;
 const postUtils = require('../../utils/post-utils');
 const BusinessLogicManager = require('../../utils/business-logic-manager');
-const { userHasValidRoles } = require('../../utils/auth-utils');
+const { userHasValidRoles, userIsAdminWildfire } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 /**
@@ -172,6 +172,14 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
   incomingObj.isNrcedPublished && (administrativePenalty.isNrcedPublished = incomingObj.isNrcedPublished);
   incomingObj.isLngPublished && (administrativePenalty.isLngPublished = incomingObj.isLngPublished);
 
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    administrativePenalty.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenalty.write.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenalty.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenalty.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
+
   return administrativePenalty;
 };
 
@@ -206,7 +214,7 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
  */
 exports.createLNG = function (args, res, next, incomingObj) {
   // Confirm user has correct role to create this type of record.
-  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_LNG], args.swagger.params.auth_payload.realm_access.roles)) {
+  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN_WF], args.swagger.params.auth_payload.realm_access.roles)) {
     throw new Error('Missing valid user role.');
   }
 
@@ -297,6 +305,14 @@ exports.createLNG = function (args, res, next, incomingObj) {
   incomingObj.sourceDateUpdated && (administrativePenaltyLNG.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (administrativePenaltyLNG.sourceSystemRef = incomingObj.sourceSystemRef);
 
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    administrativePenaltyLNG.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyLNG.write.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyLNG.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyLNG.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
+
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (incomingObj.addRole && incomingObj.addRole === 'public') {
     administrativePenaltyLNG.read.push('public');
@@ -340,7 +356,7 @@ exports.createLNG = function (args, res, next, incomingObj) {
  */
 exports.createNRCED = function (args, res, next, incomingObj) {
   // Confirm user has correct role to create this type of record.
-  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_NRCED], args.swagger.params.auth_payload.realm_access.roles)) {
+  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_WF], args.swagger.params.auth_payload.realm_access.roles)) {
     throw new Error('Missing valid user role.');
   }
 
@@ -430,6 +446,14 @@ exports.createNRCED = function (args, res, next, incomingObj) {
   incomingObj.sourceDateAdded && (administrativePenaltyNRCED.sourceDateAdded = incomingObj.sourceDateAdded);
   incomingObj.sourceDateUpdated && (administrativePenaltyNRCED.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (administrativePenaltyNRCED.sourceSystemRef = incomingObj.sourceSystemRef);
+
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    administrativePenaltyNRCED.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyNRCED.write.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyNRCED.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    administrativePenaltyNRCED.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
 
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (incomingObj.addRole && incomingObj.addRole === 'public') {

--- a/api/src/controllers/post/administrative-penalty.test.js
+++ b/api/src/controllers/post/administrative-penalty.test.js
@@ -1,0 +1,111 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let AddAdministrativePenalty = require('./administrative-penalty');
+const utils = require('../../utils/constants/misc');
+
+// May require additional time for downloading MongoDB binaries
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+let mongoServer;
+
+// Setup mongoose with mongodb-memory-server
+beforeAll(async () => {
+  mongoServer = new MongoMemoryServer();
+  const mongoUri = await mongoServer.getUri();
+  await mongoose.connect(mongoUri, {}, err => {
+    if (err) console.error(err);
+  });
+
+  require('../../models');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const wfRole = [utils.ApplicationRoles.ADMIN_WF];
+
+const args = {
+  swagger: {
+    params: {
+      auth_payload: {
+        displayName: 'test_user',
+        realm_access: { roles: [utils.ApplicationRoles.ADMIN] }
+      }
+    }
+  }
+};
+
+const wfArgs = {
+  swagger: {
+    params: {
+      auth_payload: {
+        displayName: 'test_user',
+        realm_access: { roles: [utils.ApplicationRoles.ADMIN_WF] }
+      }
+    }
+  }
+};
+
+describe('administrative-penalty', () => {
+  describe('createMaster', () => {
+    it('creates master record without admin:wf roles when user is not wildfire user', async () => {
+      const result = AddAdministrativePenalty.createMaster(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates master record with admin:wf roles when user is wildfire user', async () => {
+      const result = AddAdministrativePenalty.createMaster(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+
+  describe('createNRCED', () => {
+    it('creates NRCED record without admin:wf roles when user is not wildfire user', async () => {
+      const result = AddAdministrativePenalty.createNRCED(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates NRCED record with admin:wf roles when user is wildfire user', async () => {
+      const result = AddAdministrativePenalty.createNRCED(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+
+  describe('createLNG', () => {
+    it('creates LNG record without admin:wf roles when user is not wildfire user', async () => {
+      const result = AddAdministrativePenalty.createLNG(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates LNG record with admin:wf roles when user is wildfire user', async () => {
+      const result = AddAdministrativePenalty.createLNG(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+});

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const ObjectId = require('mongoose').Types.ObjectId;
 const postUtils = require('../../utils/post-utils');
 const BusinessLogicManager = require('../../utils/business-logic-manager');
-const { userHasValidRoles } = require('../../utils/auth-utils');
+const { userHasValidRoles, userIsAdminWildfire } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 /**
@@ -168,6 +168,14 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
   incomingObj.isLngPublished && (order.isLngPublished = incomingObj.isLngPublished);
   incomingObj.isBcmiPublished && (order.isBcmiPublished = incomingObj.isBcmiPublished);
 
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    order.read.push(utils.ApplicationRoles.ADMIN_WF);
+    order.write.push(utils.ApplicationRoles.ADMIN_WF);
+    order.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    order.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
+
   return order;
 };
 
@@ -202,7 +210,7 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
  */
 exports.createLNG = function (args, res, next, incomingObj) {
   // Confirm user has correct role for this type of record.
-  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN], args.swagger.params.auth_payload.realm_access.roles)) {
+  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN_LNG, utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_WF], args.swagger.params.auth_payload.realm_access.roles)) {
     throw new Error('Missing valid user role.');
   }
 
@@ -287,6 +295,14 @@ exports.createLNG = function (args, res, next, incomingObj) {
   incomingObj.sourceDateUpdated && (orderLNG.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (orderLNG.sourceSystemRef = incomingObj.sourceSystemRef);
 
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    orderLNG.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderLNG.write.push(utils.ApplicationRoles.ADMIN_WF);
+    orderLNG.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderLNG.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
+
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (incomingObj.addRole && incomingObj.addRole === 'public') {
     orderLNG.read.push('public');
@@ -330,7 +346,7 @@ exports.createLNG = function (args, res, next, incomingObj) {
  */
 exports.createNRCED = function (args, res, next, incomingObj) {
   // Confirm user has correct role for this type of role.
-  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_NRCED], args.swagger.params.auth_payload.realm_access.roles)) {
+  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_NRCED, utils.ApplicationRoles.ADMIN_WF], args.swagger.params.auth_payload.realm_access.roles)) {
     throw new Error('Missing valid user role.');
   }
 
@@ -417,6 +433,14 @@ exports.createNRCED = function (args, res, next, incomingObj) {
   incomingObj.sourceDateUpdated && (orderNRCED.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (orderNRCED.sourceSystemRef = incomingObj.sourceSystemRef);
 
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    orderNRCED.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderNRCED.write.push(utils.ApplicationRoles.ADMIN_WF);
+    orderNRCED.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderNRCED.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
+
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (incomingObj.addRole && incomingObj.addRole === 'public') {
     orderNRCED.read.push('public');
@@ -461,7 +485,7 @@ exports.createNRCED = function (args, res, next, incomingObj) {
  */
 exports.createBCMI = function (args, res, next, incomingObj) {
   // Confirm user has correct role for this type of role.
-  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI], args.swagger.params.auth_payload.realm_access.roles)) {
+  if (!userHasValidRoles([utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI, utils.ApplicationRoles.ADMIN_WF], args.swagger.params.auth_payload.realm_access.roles)) {
     throw new Error('Missing valid user role.');
   }
 
@@ -554,6 +578,14 @@ exports.createBCMI = function (args, res, next, incomingObj) {
   incomingObj.sourceDateAdded && (orderBCMI.sourceDateAdded = incomingObj.sourceDateAdded);
   incomingObj.sourceDateUpdated && (orderBCMI.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (orderBCMI.sourceSystemRef = incomingObj.sourceSystemRef);
+
+  // Add admin:wf read/write roles if user is wildfire user
+  if (args && userIsAdminWildfire(args.swagger.params.auth_payload.realm_access.roles)) {
+    orderBCMI.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderBCMI.write.push(utils.ApplicationRoles.ADMIN_WF);
+    orderBCMI.issuedTo.read.push(utils.ApplicationRoles.ADMIN_WF);
+    orderBCMI.issuedTo.write.push(utils.ApplicationRoles.ADMIN_WF);
+  }
 
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (incomingObj.addRole && incomingObj.addRole === 'public') {

--- a/api/src/controllers/post/order.test.js
+++ b/api/src/controllers/post/order.test.js
@@ -1,0 +1,131 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let Order = require('./order');
+const utils = require('../../utils/constants/misc');
+
+// May require additional time for downloading MongoDB binaries
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
+let mongoServer;
+
+// Setup mongoose with mongodb-memory-server
+beforeAll(async () => {
+  mongoServer = new MongoMemoryServer();
+  const mongoUri = await mongoServer.getUri();
+  await mongoose.connect(mongoUri, {}, err => {
+    if (err) console.error(err);
+  });
+
+  require('../../models');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const wfRole = [utils.ApplicationRoles.ADMIN_WF];
+
+const args = {
+  swagger: {
+    params: {
+      auth_payload: {
+        displayName: 'test_user',
+        realm_access: { roles: [utils.ApplicationRoles.ADMIN] }
+      }
+    }
+  }
+};
+
+const wfArgs = {
+  swagger: {
+    params: {
+      auth_payload: {
+        displayName: 'test_user',
+        realm_access: { roles: [utils.ApplicationRoles.ADMIN_WF] }
+      }
+    }
+  }
+};
+
+describe('administrative-penalty', () => {
+  describe('createMaster', () => {
+    it('creates master record without admin:wf roles when user is not wildfire user', async () => {
+      const result = Order.createMaster(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates master record with admin:wf roles when user is wildfire user', async () => {
+      const result = Order.createMaster(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+
+  describe('createNRCED', () => {
+    it('creates NRCED record without admin:wf roles when user is not wildfire user', async () => {
+      const result = Order.createNRCED(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates NRCED record with admin:wf roles when user is wildfire user', async () => {
+      const result = Order.createNRCED(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+
+  describe('createLNG', () => {
+    it('creates LNG record without admin:wf roles when user is not wildfire user', async () => {
+      const result = Order.createLNG(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates LNG record with admin:wf roles when user is wildfire user', async () => {
+      const result = Order.createLNG(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+
+  describe('createBCMI', () => {
+    it('creates BCMI record without admin:wf roles when user is not wildfire user', async () => {
+      const result = Order.createBCMI(args, null, null, {});
+
+      expect(result.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.not.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.not.arrayContaining(wfRole));
+    });
+
+    it('creates BCMI record with admin:wf roles when user is wildfire user', async () => {
+      const result = Order.createBCMI(wfArgs, null, null, {});
+
+      expect(result.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.write).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.read).toEqual(expect.arrayContaining(wfRole));
+      expect(result.issuedTo.write).toEqual(expect.arrayContaining(wfRole));
+    });
+  });
+});

--- a/api/src/utils/auth-utils.js
+++ b/api/src/utils/auth-utils.js
@@ -179,8 +179,8 @@ exports.userHasValidRoles = function(validRoles, userRoles) {
 };
 
 /**
- * Checks if a user is a wildfire user based on his/her roles.  
- * The user is a wildfire user if his/her roles only contains the admin:wf role
+ * Checks if a user is a wildfire user based on their role.  
+ * The user is a wildfire user if their role only contains the admin:wf role
  * and no other admin roles.
  * 
  * @param {Array<string>|string} userRoles Roles to match against.

--- a/api/src/utils/auth-utils.test.js
+++ b/api/src/utils/auth-utils.test.js
@@ -1,0 +1,49 @@
+const authUtils = require('./auth-utils');
+const utils = require('./constants/misc');
+
+describe('userIsAdminWildfire', () => {
+  it('returns false if roles array is null', () => {
+    const result = authUtils.userIsAdminWildfire([]);
+
+    expect(result).toEqual(false);
+  });
+
+  it('returns false if roles array is emtpy', () => {
+    const result = authUtils.userIsAdminWildfire([]);
+
+    expect(result).toEqual(false);
+  });
+
+  it('returns false if roles array only contains the default roles', () => {
+    const result = authUtils.userIsAdminWildfire([
+      utils.ApplicationRoles.PUBLIC,
+      utils.KeycloakDefaultRoles.PUBLIC,
+      utils.KeycloakDefaultRoles.UMA_AUTHORIZATION
+    ]);
+
+    expect(result).toEqual(false);
+  });
+
+  it('returns false if roles array contains other admin roles', () => {
+    const result = authUtils.userIsAdminWildfire([utils.ApplicationRoles.ADMIN_BCMI, utils.ApplicationRoles.ADMIN_WF]);
+
+    expect(result).toEqual(false);
+  });
+
+  it('returns true if roles array only contains admin:wf role', () => {
+    const result = authUtils.userIsAdminWildfire([utils.ApplicationRoles.ADMIN_WF]);
+
+    expect(result).toEqual(true);
+  });
+
+  it('returns true if roles array contains admin:wf role and default roles', () => {
+    const result = authUtils.userIsAdminWildfire([
+      utils.ApplicationRoles.ADMIN_WF,
+      utils.ApplicationRoles.PUBLIC,
+      utils.KeycloakDefaultRoles.OFFLINE_ACCESS,
+      utils.KeycloakDefaultRoles.UMA_AUTHORIZATION
+    ]);
+
+    expect(result).toEqual(true);
+  });
+});

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -1,15 +1,27 @@
 exports.SYSTEM_USER = 'SYSTEM_USER';
 
-exports.ApplicationRoles = {
+const ApplicationRoles = {
   ADMIN: 'sysadmin',
   ADMIN_NRCED: 'admin:nrced',
   ADMIN_LNG: 'admin:lng',
   ADMIN_BCMI: 'admin:bcmi',
+  ADMIN_WF: 'admin:wf',
+  PUBLIC: 'public'
 };
 
-exports.ApplicationAdminRoles = Object.keys(this.ApplicationRoles).map(role => {
-  return this.ApplicationRoles[role];
-});
+exports.ApplicationRoles = ApplicationRoles;
+
+exports.ApplicationAdminRoles = [
+  ApplicationRoles.ADMIN,
+  ApplicationRoles.ADMIN_NRCED,
+  ApplicationRoles.ADMIN_LNG,
+  ApplicationRoles.ADMIN_BCMI
+];
+
+exports.KeycloakDefaultRoles = {
+  OFFLINE_ACCESS: 'offline_access',
+  UMA_AUTHORIZATION: 'uma_authorization'
+};
 
 exports.IssuedToEntityTypes = {
   Company: 'Company',


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-557

This PR adds logic to inject the `admin:wf` role to `read`/`write` arrays on AMP, Order`and Document records created by wildfire users.

The UI has not been updated to allow wildfire users to create NRCED and LNG records yet, so tests will need to be done with Postman.  Alternatively you can edit `userInLngRole()` and `userInNrcedRole()` in `factory.service.ts` to make the NRCED and LNG fields editable for wildfire role.