### PR TITLE
NRPT-630 Fix COORS importer duplicates

### DIFF
--- a/api/migrations/20210105180728-removeDuplicateCoorsRecords.js
+++ b/api/migrations/20210105180728-removeDuplicateCoorsRecords.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Deleting duplicate COORS records ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    const records = await nrpti.find({ _sourceRefCorsId: { $exists: true } }).toArray();
+
+    const idsToDelete = [];
+
+    for (const record of records) {
+      idsToDelete.push(record._id);
+
+      if (records._flavourRecords && records._flavourRecords.length) {
+        for (const flavour of records._flavourRecords) {
+          idsToDelete.push(flavour);
+        }
+      }
+    }
+
+    await nrpti.deleteMany({ _id: { $in: idsToDelete } });
+
+    console.log(`Finished deleting ${records.length} duplicate COORS records`);
+  } catch (err) {
+    console.log(`Error deleting COORS records: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1
+};

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -88,7 +88,7 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (ticket._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefCorsId && (ticket._sourceRefCorsId = incomingObj._sourceRefCorsId);
+  incomingObj._sourceRefCoorsId && (ticket._sourceRefCoorsId = incomingObj._sourceRefCoorsId);
   incomingObj.collectionId &&
     ObjectId.isValid(incomingObj.collectionId) &&
     (ticket.collectionId = new ObjectId(incomingObj.collectionId));
@@ -217,7 +217,7 @@ exports.createLNG = function (args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (ticketLNG._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefCorsId && (ticketLNG._sourceRefCorsId = incomingObj._sourceRefCorsId);
+  incomingObj._sourceRefCoorsId && (ticketLNG._sourceRefCoorsId = incomingObj._sourceRefCoorsId);
 
   // set permissions and meta
   ticketLNG.read = utils.ApplicationAdminRoles;
@@ -345,7 +345,7 @@ exports.createNRCED = function (args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (ticketNRCED._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefCorsId && (ticketNRCED._sourceRefCorsId = incomingObj._sourceRefCorsId);
+  incomingObj._sourceRefCoorsId && (ticketNRCED._sourceRefCoorsId = incomingObj._sourceRefCoorsId);
 
   // set permissions and meta
   ticketNRCED.read = utils.ApplicationAdminRoles;

--- a/api/src/importers/coors/base-record-utils.js
+++ b/api/src/importers/coors/base-record-utils.js
@@ -56,11 +56,11 @@ class BaseRecordUtils {
    * Searches for an existing master record, and returns it if found.
    *
    * @param {*} nrptiRecord
-   * @returns {object} existing NRPTI master record, or null if none found or _sourceRefCorsId is null
+   * @returns {object} existing NRPTI master record, or null if none found or _sourceRefCoorsId is null
    * @memberof BaseRecordUtils
    */
   async findExistingRecord(nrptiRecord) {
-    if (!nrptiRecord._sourceRefCorsId) {
+    if (!nrptiRecord._sourceRefCoorsId) {
       return null;
     }
 
@@ -69,7 +69,7 @@ class BaseRecordUtils {
     return await masterRecordModel
       .findOne({
         _schemaName: this.recordType._schemaName,
-        _sourceRefCorsId: nrptiRecord._sourceRefCorsId
+        _sourceRefCoorsId: nrptiRecord._sourceRefCoorsId
       })
       .populate('_flavourRecords', '_id _schemaName');
   }

--- a/api/src/importers/coors/tickets-utils.js
+++ b/api/src/importers/coors/tickets-utils.js
@@ -36,7 +36,7 @@ class Tickets extends BaseRecordUtils {
 
     const ticket = { ...super.transformRecord(csvRow) };
 
-    ticket['_sourceRefCorsId'] = Number(csvRow['contravention_enforcement_id']) || '';
+    ticket['_sourceRefCoorsId'] = Number(csvRow['contravention_enforcement_id']) || '';
 
     ticket['recordType'] = 'Ticket';
     ticket['dateIssued'] = csvRow['ticket_date'] || null;

--- a/api/src/importers/coors/tickets-utils.test.js
+++ b/api/src/importers/coors/tickets-utils.test.js
@@ -13,7 +13,7 @@ describe('transformRecord', () => {
 
     expect(result).toEqual({
       _schemaName: 'Ticket',
-      _sourceRefCorsId: '',
+      _sourceRefCoorsId: '',
 
       recordType: 'Ticket',
       dateIssued: null,
@@ -48,7 +48,7 @@ describe('transformRecord', () => {
 
     expect(result).toEqual({
       _schemaName: 'Ticket',
-      _sourceRefCorsId: 123,
+      _sourceRefCoorsId: 123,
 
       recordType: 'Ticket',
       dateIssued: expect.any(String),

--- a/api/src/models/master/ticket.js
+++ b/api/src/models/master/ticket.js
@@ -9,7 +9,7 @@ module.exports = require('../../utils/model-schema-generator')(
     _epicProjectId: { type: 'ObjectId', default: null, index: true },
     _sourceRefId: { type: 'ObjectId', default: null, index: true },
     _epicMilestoneId: { type: 'ObjectId', default: null, index: true },
-    _sourceRefCorsId: { type: Number, default: null, index: true },
+    _sourceRefCoorsId: { type: Number, default: null, index: true },
 
     mineGuid: { type: String, default: null, index: true },
     read: [{ type: String, trim: true, default: 'sysadmin' }],


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-630

This PR fixes the previous incomplete COORS importer changes.  There were several places where the change from `_sourceRefCorsId` to `_sourceRefCoorsId` were missed.  This caused the importer to create duplicates.

Migration script is included to remove these duplicates

To test:
- Load current snapshot of prod and run the migration
- Run COORS importer using test file at https://chat.pathfinder.gov.bc.ca/group/7yTf7q3mWbKBAn2qa?msg=thf7bcJ54heLJGjPr
- There should be 4431 total COORS records