### PR TITLE
NRPT-606 Unset companyName and centroid if switching from company to individual

### DIFF
--- a/api/src/importers/nro/inspections-utils.js
+++ b/api/src/importers/nro/inspections-utils.js
@@ -82,8 +82,13 @@ class Inspections extends BaseRecordUtils {
         dateOfBirth: null,
         firstName: '',
         lastName: '',
-        middleName: ''
+        middleName: '',
+        // Unset companyName if it was previously set
+        companyName: ''
       };
+
+      // Unset long/lat in case it was previously.
+      inspection['centroid'] = null;
     }
 
     return inspection;

--- a/api/src/importers/nro/inspections-utils.test.js
+++ b/api/src/importers/nro/inspections-utils.test.js
@@ -21,7 +21,7 @@ describe('transformRecord', () => {
       recordType: 'Inspection',
       author: 'Natural Resource Officers',
       dateIssued: null,
-      issuedTo: { dateOfBirth: null, firstName: '', lastName: '', middleName: '', type: 'Individual' },
+      issuedTo: { dateOfBirth: null, firstName: '', lastName: '', middleName: '', type: 'Individual', companyName: '' },
       description: '-',
       sourceSystemRef: 'nro-inspections-csv',
       issuingAgency: 'Natural Resource Officers',
@@ -30,7 +30,8 @@ describe('transformRecord', () => {
       location: null,
       outcomeDescription: 'undefined - undefined',
       recordName: '-',
-      summary: '-'
+      summary: '-',
+      centroid: null
     });
   });
 


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-606

Force remove `companyName` and `centroid` fields because the entity type can change in the CSV files.  If `companyName` and `centroid` fields are previously set because the record was a company and in the new CSV file the record is an individual then the importer should delete those fields.