### PR TITLE
NRPT-39  Add authorized issuing agency published record redaction

### DIFF
--- a/api/materialized_views/search/redactedRecordSubset.test.js
+++ b/api/materialized_views/search/redactedRecordSubset.test.js
@@ -1,0 +1,98 @@
+const defaultLog = require('../../src/utils/logger')('redactedRecordSubset.test');
+const redactedRecordSubset = require('./redactedRecordSubset');
+const { generateIssuedTo } = require('../../test/factories/factory_helper');
+
+jest.setTimeout(100000);
+
+describe('Record Individual issuedTo redaction test', () => {
+  let nrptiCollection = null;
+  let redacted_record_subset = null;
+
+  beforeAll(async () => {
+    const MongoClient = require('mongodb').MongoClient;
+
+    const client = await MongoClient.connect(process.env.MONGO_URI);
+    const db = client.db(process.env.MONGODB_DATABASE || 'nrpti-dev');
+    nrptiCollection = db.collection('nrpti');
+    redacted_record_subset = db.collection('redacted_record_subset');
+
+    // await createTestRecords(nrptiCollection);
+  });
+
+  beforeEach(async () => {
+    await redacted_record_subset.deleteMany();
+    await nrptiCollection.deleteMany();
+  });
+
+  test('Authorized issuing agency and person over 19 are not redacted', async () => {
+    const testRecord = {
+      issuedTo: generateIssuedTo( false, true, false ),
+      _schemaName: 'Schema',
+      issuingAgency: 'BC Parks'
+    };
+
+    await nrptiCollection.insertOne(testRecord);
+    await redactedRecordSubset.update(defaultLog);
+
+    const redacted = await redacted_record_subset.findOne();
+    expect(redacted.issuedTo.firstName).toEqual(testRecord.issuedTo.firstName);
+    expect(redacted.issuedTo.middleName).toEqual(testRecord.issuedTo.middleName);
+    expect(redacted.issuedTo.lastName).toEqual(testRecord.issuedTo.lastName);
+    expect(redacted.issuedTo.fullName).toEqual(testRecord.issuedTo.fullName);
+    expect(redacted.issuedTo.dateOfBirth).toEqual(expect.any(Date));
+  });
+
+  test('Authorized issuing agency and person under 19 are redacted', async () => {
+    const testRecord = {
+      issuedTo: generateIssuedTo( true, false, false ),
+      _schemaName: 'Schema',
+      issuingAgency: 'BC Parks'
+    };
+
+    await nrptiCollection.insertOne(testRecord);
+    await redactedRecordSubset.update(defaultLog);
+
+    const redacted = await redacted_record_subset.findOne();
+    expect(redacted.issuedTo.firstName).toEqual('Unpublished');
+    expect(redacted.issuedTo.middleName).toEqual('');
+    expect(redacted.issuedTo.lastName).toEqual('Unpublished');
+    expect(redacted.issuedTo.fullName).toEqual('Unpublished');
+    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+  });
+
+  test('Unauthorized issuing agency and person over 19 are redacted', async () => {
+    const testRecord = {
+      issuedTo: generateIssuedTo( false, true, false ),
+      _schemaName: 'Schema',
+      issuingAgency: 'Unauthorized'
+    };
+
+    await nrptiCollection.insertOne(testRecord);
+    await redactedRecordSubset.update(defaultLog);
+
+    const redacted = await redacted_record_subset.findOne();
+    expect(redacted.issuedTo.firstName).toEqual('Unpublished');
+    expect(redacted.issuedTo.middleName).toEqual('');
+    expect(redacted.issuedTo.lastName).toEqual('Unpublished');
+    expect(redacted.issuedTo.fullName).toEqual('Unpublished');
+    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+  });
+
+  test('Unauthorized issuing agency and person under 19 are redacted', async () => {
+    const testRecord = {
+      issuedTo: generateIssuedTo( true, false, false ),
+      _schemaName: 'Schema',
+      issuingAgency: 'Unauthorized'
+    };
+
+    await nrptiCollection.insertOne(testRecord);
+    await redactedRecordSubset.update(defaultLog);
+
+    const redacted = await redacted_record_subset.findOne();
+    expect(redacted.issuedTo.firstName).toEqual('Unpublished');
+    expect(redacted.issuedTo.middleName).toEqual('');
+    expect(redacted.issuedTo.lastName).toEqual('Unpublished');
+    expect(redacted.issuedTo.fullName).toEqual('Unpublished');
+    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+  });
+});

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -126,3 +126,11 @@ exports.COURT_CONVICTION_PENALTY_TYPES = [
 ];
 
 exports.PENALTY_VALUE_TYPES = ['Years', 'Months', 'Days', 'Dollars', 'Hours', 'Other'];
+
+exports.AUTHORIZED_PUBLISH_AGENCIES = [  
+  'BC Parks',
+  'Climate Action Secretariat',
+  'Conservation Officer Service',
+  'EAO',
+  'Environmental Protection Division',
+];

--- a/api/test/factories/factory_helper.js
+++ b/api/test/factories/factory_helper.js
@@ -1,5 +1,6 @@
 const canada = require('canada');
 const _ = require('lodash');
+const moment = require('moment');
 const bsonObjectId = require('bson').ObjectId;
 const mongTypes = require('mongoose').Types;
 let faker = require('faker/locale/en');
@@ -27,7 +28,7 @@ function generateFakePerson({ firstName, middleName, lastName, genUnderAge, genA
     if (underage) {
       dateOfBirth = faker.date.past(12, today.toISOString())
     } else if (adult) {
-      dateOfBirth = faker.date.past(20, today.toISOString());
+      dateOfBirth = faker.date.between('1960-01-01', moment().subtract(20, 'years').toISOString());
     } else {
       // faker expects simple date string or isostring
       dateOfBirth = faker.date.between('1960-01-01', today.toISOString())


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-39

To test this you'll need to trigger the `redactedRecordSubset` task via `api/task` with payload `{"taskType":"updateMaterializedView", "materializedViewSubset":"redactedRecordSubset"}`

Records that are not not from the following issuing agencies are redacted regardless of the individual's age.
```
  'BC Parks',
  'Climate Action Secretariat',
  'Conservation Officer Service',
  'EAO',
  'Environmental Protection Division',
```

Also fixed a minor bug in `generateFakePerson` that's not actually generating adult person