### PR TITLE
NRPT-677 Fix public search aggregation lookup to use redacted_record_subset

### DIFF
--- a/api/materialized_views/search/redactedRecordSubset.js
+++ b/api/materialized_views/search/redactedRecordSubset.js
@@ -95,7 +95,7 @@ async function update(defaultLog) {
         'fullRecord.issuedTo.dateOfBirth': {
           $cond: {
             if: redactCondition,
-            then: '',
+            then: null,
             else: { $arrayElemAt: ['$fullRecord.issuedTo.dateOfBirth', 0] }
           }
         }

--- a/api/materialized_views/search/redactedRecordSubset.test.js
+++ b/api/materialized_views/search/redactedRecordSubset.test.js
@@ -57,7 +57,7 @@ describe('Record Individual issuedTo redaction test', () => {
     expect(redacted.issuedTo.middleName).toEqual('');
     expect(redacted.issuedTo.lastName).toEqual('Unpublished');
     expect(redacted.issuedTo.fullName).toEqual('Unpublished');
-    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+    expect(redacted.issuedTo.dateOfBirth).toEqual(null);
   });
 
   test('Unauthorized issuing agency and person over 19 are redacted', async () => {
@@ -75,7 +75,7 @@ describe('Record Individual issuedTo redaction test', () => {
     expect(redacted.issuedTo.middleName).toEqual('');
     expect(redacted.issuedTo.lastName).toEqual('Unpublished');
     expect(redacted.issuedTo.fullName).toEqual('Unpublished');
-    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+    expect(redacted.issuedTo.dateOfBirth).toEqual(null);
   });
 
   test('Unauthorized issuing agency and person under 19 are redacted', async () => {
@@ -93,6 +93,6 @@ describe('Record Individual issuedTo redaction test', () => {
     expect(redacted.issuedTo.middleName).toEqual('');
     expect(redacted.issuedTo.lastName).toEqual('Unpublished');
     expect(redacted.issuedTo.fullName).toEqual('Unpublished');
-    expect(redacted.issuedTo.dateOfBirth).toEqual('');
+    expect(redacted.issuedTo.dateOfBirth).toEqual(null);
   });
 });

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -563,7 +563,7 @@ let searchCollection = async function (
   // to finalize the facet
   searchResultAggregation.push({
     $lookup: {
-      from: 'nrpti',
+      from: subset && subset.includes('redactedRecord') ? 'redacted_record_subset' : 'nrpti',
       localField: '_id',
       foreignField: '_id',
       as: 'fullRecord'


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-677

Fixed a bug in the public search aggregation where it's doing a lookup on the `nrpti` collection and causing un-redacted data to end up in the search results.

Also fixed redaction materialized view setting dateOfBirth as emtpy string instead of null.

To test this you can take a copy of the live test DB and restore it locally.  Run the redacted_records_subset materialized view task(need to do this first otherwise API will crash).  Then search for `"Test 2"` on NRCED and you should get redacted individual name in the record.  

Currently this record isn't redacted on test because of this bug.  https://nrced-f00029-test.apps.silver.devops.gov.bc.ca/records;keywords=%22Test%202%22;ms=677;currentPage=1;pageSize=25;sortBy=-dateIssued