### PR TITLE
NRPT-39 Fix public redaction unpublished name display and documents showing

### DIFF
--- a/api/materialized_views/search/redactedRecordSubset.test.js
+++ b/api/materialized_views/search/redactedRecordSubset.test.js
@@ -69,11 +69,8 @@ describe('Record Individual issuedTo redaction test', () => {
     await redactedRecordSubset.update(defaultLog);
 
     const redacted = await redacted_record_subset.findOne();
-    expect(redacted.issuedTo.firstName).toEqual('Unpublished');
-    expect(redacted.issuedTo.middleName).toEqual('');
-    expect(redacted.issuedTo.lastName).toEqual('Unpublished');
-    expect(redacted.issuedTo.fullName).toEqual('Unpublished');
-    expect(redacted.issuedTo.dateOfBirth).toEqual(null);
+    // Expect undefined because entire issuedTo field is redacted
+    expect(redacted.issuedTo).toEqual(undefined);
   });
 
   test('Unauthorized issuing agency and person under 19 are redacted', async () => {
@@ -87,10 +84,7 @@ describe('Record Individual issuedTo redaction test', () => {
     await redactedRecordSubset.update(defaultLog);
 
     const redacted = await redacted_record_subset.findOne();
-    expect(redacted.issuedTo.firstName).toEqual('Unpublished');
-    expect(redacted.issuedTo.middleName).toEqual('');
-    expect(redacted.issuedTo.lastName).toEqual('Unpublished');
-    expect(redacted.issuedTo.fullName).toEqual('Unpublished');
-    expect(redacted.issuedTo.dateOfBirth).toEqual(null);
+    // Expect undefined because entire issuedTo field is redacted
+    expect(redacted.issuedTo).toEqual(undefined);
   });
 });

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -526,7 +526,7 @@ let searchCollection = async function (
   // For read only users, we need to redact out the details
   // of any individual where the birthdate is null or the individual
   // is less then 19 years old.
-  if (!roles.some(r => ApplicationAdminRoles.indexOf(r) >= 0)) {
+  if (!roles.some(r => ApplicationAdminRoles.indexOf(r) >= 0) && !(subset && subset.includes('redactedRecord'))) {
       searchResultAggregation = searchResultAggregation.concat(issuedToRedaction(roles));
   }
 
@@ -895,7 +895,7 @@ const executeQuery = async function (args, res, next) {
     });
 
     // Redact issued if user is only wildfire or read-only user
-    if (populate && !roles.some(r => ApplicationAdminRoles.indexOf(r) >= 0)) {
+    if (populate && !roles.some(r => ApplicationAdminRoles.indexOf(r) >= 0) && !(subset && subset.includes('redactedRecord'))) {
       aggregation = aggregation.concat(issuedToRedaction(roles));
     }
 


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-39

Some tweaks to the existing public issuing agency redaction code.

- Completely removed the `issuedTo` field if issuing agency isn't authorized.  This fixes redacted name not displaying just "Unpublished" on NRCED.  See [Kyle's comment](https://bcmines.atlassian.net/browse/NRPT-39?focusedCommentId=18981)
- Unset `documents` array if issuing agency isn't authorized
- Bypassed the redaction in `search` controller if it's a public search.  The redaction in search controller isn't needed for public searches because the data is already redacted in the view.  It's also causing data issues with the `issuedTo` field