### PR TITLE
NRPT-664 Use CASE_CONTRAVENTION_ID and ENFORCEMENT_ACTION_ID for COORS Ticket

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.spec.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.spec.ts
@@ -258,7 +258,8 @@ describe('ImportCSVComponent', () => {
 
       // values found in CsvConstants.coorsTicketCsvRequiredHeaders, with some removed to trigger validation errors
       component.validateRequiredHeaders([
-        'CONTRAVENTION_ENFORCEMENT_ID',
+        'CASE_CONTRAVENTION_ID',
+        'ENFORCEMENT_ACTION_ID',
         'TICKET_DATE',
         // 'FIRST_NAME',
         'MIDDLE_NAME',

--- a/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
@@ -107,7 +107,8 @@ export class CsvConstants {
    * @memberof CsvConstants
    */
   public static readonly coorsTicketCsvRequiredHeaders = [
-    'CONTRAVENTION_ENFORCEMENT_ID',
+    'ENFORCEMENT_ACTION_ID',
+    'CASE_CONTRAVENTION_ID',
     'TICKET_DATE',
     'FIRST_NAME',
     'MIDDLE_NAME',
@@ -133,7 +134,7 @@ export class CsvConstants {
    * @static
    * @memberof CsvConstants
    */
-  public static readonly coorsTicketCsvRequiredFields = ['CONTRAVENTION_ENFORCEMENT_ID'];
+  public static readonly coorsTicketCsvRequiredFields = ['ENFORCEMENT_ACTION_ID', 'CASE_CONTRAVENTION_ID'];
 
   /**
    * Fields for COORS Ticket csv that have a required format.

--- a/api/migrations/20210218154834-removeCoorsTickets.js
+++ b/api/migrations/20210218154834-removeCoorsTickets.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Deleting COORS Ticket records with old IDs ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    const results = await nrpti.deleteMany({
+      _schemaName: { $in: ['Ticket', 'TicketLNG', 'TicketNRCED'] },
+      sourceSystemRef: 'coors-csv'
+    });
+
+    console.log(`Finished deleting ${results.deletedCount} COORS Ticket records`);
+  } catch (err) {
+    console.log(`Error deleting COORS Ticket records: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1
+};

--- a/api/src/importers/coors/tickets-utils.js
+++ b/api/src/importers/coors/tickets-utils.js
@@ -36,7 +36,11 @@ class Tickets extends BaseRecordUtils {
 
     const ticket = { ...super.transformRecord(csvRow) };
 
-    ticket['_sourceRefCoorsId'] = Number(csvRow['contravention_enforcement_id']) || '';
+    let sourceRefId = '';
+    if (csvRow['case_contravention_id'] && csvRow['enforcement_action_id']) {
+      sourceRefId = `${csvRow['case_contravention_id']}-${csvRow['enforcement_action_id']}`
+    }
+    ticket['_sourceRefCoorsId'] = sourceRefId;
 
     ticket['recordType'] = 'Ticket';
     ticket['dateIssued'] = csvRow['ticket_date'] || null;

--- a/api/src/importers/coors/tickets-utils.test.js
+++ b/api/src/importers/coors/tickets-utils.test.js
@@ -19,7 +19,7 @@ describe('transformRecord', () => {
       dateIssued: null,
       issuedTo: { dateOfBirth: null, firstName: '', lastName: '', middleName: '', type: 'Individual' },
       issuingAgency: '',
-      author: '',      
+      author: '',
       legislation: { act: '', paragraph: '', regulation: '', section: '', subSection: '' },
       location: '',
       offence: '',
@@ -32,7 +32,8 @@ describe('transformRecord', () => {
 
   it('transforms csv row fields into NRPTI record fields', () => {
     const result = tickets.transformRecord({
-      contravention_enforcement_id: 123,
+      case_contravention_id: 123,
+      enforcement_action_id: 123,
       ticket_date: '12/30/2019',
       case_number: 'P-123456',
       act: 'Fisheries Canada',
@@ -48,7 +49,7 @@ describe('transformRecord', () => {
 
     expect(result).toEqual({
       _schemaName: 'Ticket',
-      _sourceRefCoorsId: 123,
+      _sourceRefCoorsId: '123-123',
 
       recordType: 'Ticket',
       dateIssued: expect.any(String),

--- a/api/src/models/master/ticket.js
+++ b/api/src/models/master/ticket.js
@@ -9,7 +9,7 @@ module.exports = require('../../utils/model-schema-generator')(
     _epicProjectId: { type: 'ObjectId', default: null, index: true },
     _sourceRefId: { type: 'ObjectId', default: null, index: true },
     _epicMilestoneId: { type: 'ObjectId', default: null, index: true },
-    _sourceRefCoorsId: { type: Number, default: null, index: true },
+    _sourceRefCoorsId: { type: String, default: null, index: true },
 
     mineGuid: { type: String, default: null, index: true },
     read: [{ type: String, trim: true, default: 'sysadmin' }],


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-664

This PR updates COORS Ticket CSV import to use `CASE_CONTRAVENTION_ID` and `ENFORCEMENT_ACTION_ID` for the source ref ID.

Also removes the old Ticket records that just used `CONTRAVENTION_ENFORCEMENT_ID` for ID.

Test CSV file at https://chat.developer.gov.bc.ca/group/7yTf7q3mWbKBAn2qa?msg=we3GCRdezyc8NXHwd