### PR TITLE
NRPT-11 ALC Inspections CSV import

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
@@ -15,17 +15,19 @@ import { Constants } from '../../utils/constants/misc';
 })
 export class ImportCSVComponent implements OnInit {
   public dataSourceTypes = [
-    { displayName: 'COORS', value: 'coors-csv' },
-    { displayName: 'NRIS-FLNR', value: 'nro-csv' },
+    { displayName: 'ALC', value: 'alc-csv' },
     { displayName: 'AGRI-CMDB', value: 'cmdb-csv' },
-    { displayName: 'AGRI-MIS', value: 'mis-csv' }
+    { displayName: 'AGRI-MIS', value: 'mis-csv' },
+    { displayName: 'COORS', value: 'coors-csv' },
+    { displayName: 'NRIS-FLNR', value: 'nro-csv' }
   ];
 
   public csvTypes: any = {
     'coors-csv': ['Administrative Sanction', 'Court Conviction', 'Ticket'],
     'nro-csv': ['Inspection'],
     'mis-csv': ['Inspection'],
-    'cmdb-csv': ['Inspection']
+    'cmdb-csv': ['Inspection'],
+    'alc-csv': ['Inspection']
   };
 
   public dataSourceType = null;

--- a/angular/projects/admin-nrpti/src/app/utils/constants/alc-csv-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/alc-csv-constants.ts
@@ -1,0 +1,48 @@
+import { IRequiredFormat, IDateField } from './csv-constants';
+
+/**
+ * Expected headers for ALC Inspection csv.
+ *
+ * Note: sort order and letter case of headers is not important.
+ */
+export const alcInspectionCsvRequiredHeaders = [
+  'Record ID',
+  'Record Type',
+  'Date',
+  'Local Government',
+  'Inspection Property Owner',
+  'Reason',
+  'Section',
+  'Compliance Status',
+  'C&E Actions',
+  'Status'
+];
+
+/**
+ * Required fields for ALC Inspection  csv.
+ *
+ */
+export const alcInspectionCsvRequiredFields = [
+  'Record ID',
+  'Record Type',
+  'Compliance Status',
+  'C&E Actions',
+  'Date',
+  'Status'
+];
+
+/**
+ * Fields for ALC Inspection csv that have a required format.
+ *
+ * @type {IRequiredFormat[]}
+ */
+export const alcInspectionsCsvRequiredFormats: IRequiredFormat[] = [
+  { field: 'Date', type: 'date', format: 'YYYY-MM-DD' }
+];
+
+/**
+ * Fields for ALC Inspection csv that represent dates.
+ *
+ * @type {IDateField[]}
+ */
+export const alcInspectionsCsvDateFields: IDateField[] = [{ field: 'Date', format: 'YYYY-MM-DD' }];

--- a/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
@@ -1,3 +1,10 @@
+import {
+  alcInspectionCsvRequiredHeaders,
+  alcInspectionCsvRequiredFields,
+  alcInspectionsCsvRequiredFormats,
+  alcInspectionsCsvDateFields
+} from './alc-csv-constants';
+
 /**
  * Required format object to specify fields whose value must have a specific format.
  *
@@ -69,7 +76,7 @@ export class CsvConstants {
     'CASE_CONTRAVENTION_ID',
     'ENFORCEMENT_ACTION_ID',
     'RECORD_TYPE_CODE',
-    'BUSINESS_REVIEWED_IND',
+    'BUSINESS_REVIEWED_IND'
   ];
 
   /**
@@ -170,7 +177,7 @@ export class CsvConstants {
    * @static
    * @memberof CsvConstants
    */
-   public static readonly coorsConvictionCsvRequiredHeaders = [
+  public static readonly coorsConvictionCsvRequiredHeaders = [
     'CASE_CONTRAVENTION_ID',
     'ENFORCEMENT_ACTION_ID',
     'FINAL_DECISION_DATE',
@@ -198,10 +205,7 @@ export class CsvConstants {
    * @static
    * @memberof CsvConstants
    */
-  public static readonly coorsConvictionCsvRequiredFields = [
-    'CASE_CONTRAVENTION_ID',
-    'ENFORCEMENT_ACTION_ID'
-  ];
+  public static readonly coorsConvictionCsvRequiredFields = ['CASE_CONTRAVENTION_ID', 'ENFORCEMENT_ACTION_ID'];
 
   /**
    * Fields for COORS Ticket csv that have a required format.
@@ -299,7 +303,7 @@ export class CsvConstants {
     'Function',
     'Action Taken',
     'Activity',
-    'Report Status',
+    'Report Status'
   ];
 
   /**
@@ -330,9 +334,7 @@ export class CsvConstants {
    * @type {IDateField[]}
    * @memberof CsvConstants
    */
-  public static readonly nroInspectionCsvDateFields: IDateField[] = [
-    { field: 'Date', format: 'YYYY-MM-DD' }
-  ];
+  public static readonly nroInspectionCsvDateFields: IDateField[] = [{ field: 'Date', format: 'YYYY-MM-DD' }];
 
   /**
    * Expected headers for AGRI MIS Inspection csv.
@@ -379,16 +381,14 @@ export class CsvConstants {
    * @type {IDateField[]}
    * @memberof CsvConstants
    */
-  public static readonly misInspectionsCsvDateFields: IDateField[] = [
-    { field: 'Created ', format: 'MM/DD/YYYY' }
-  ];
+  public static readonly misInspectionsCsvDateFields: IDateField[] = [{ field: 'Created ', format: 'MM/DD/YYYY' }];
 
-    /**
-     * Expected headers for AGRI CMDB Inspection csv.
-     *
-     * @static
-     * @memberof CsvConstants
-     */
+  /**
+   * Expected headers for AGRI CMDB Inspection csv.
+   *
+   * @static
+   * @memberof CsvConstants
+   */
   public static readonly cmdbInspectionCsvRequiredHeaders = [
     'Inspection ID',
     'Inspection Type',
@@ -405,11 +405,7 @@ export class CsvConstants {
    * @memberof CsvConstants
    */
   // todo revist make sure there aren't more required fields to add
-  public static readonly cmdbInspectionCsvRequiredFields = [
-    'Inspection ID',
-    'Date Issued',
-    'Company Name'
-  ];
+  public static readonly cmdbInspectionCsvRequiredFields = ['Inspection ID', 'Date Issued', 'Company Name'];
 
   /**
    * Fields for AGRI CMDB Inspection csv that have a required format.
@@ -429,9 +425,7 @@ export class CsvConstants {
    * @type {IDateField[]}
    * @memberof CsvConstants
    */
-  public static readonly cmdbInspectionsCsvDateFields: IDateField[] = [
-    { field: 'Date', format: 'MM/DD/YYYY' }
-  ];
+  public static readonly cmdbInspectionsCsvDateFields: IDateField[] = [{ field: 'Date', format: 'MM/DD/YYYY' }];
 
   /**
    * Get the array of required csv headers for the provided dataSourceType and recordType.
@@ -480,6 +474,12 @@ export class CsvConstants {
     if (dataSourceType === 'cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionCsvRequiredHeaders;
+      }
+    }
+
+    if (dataSourceType === 'alc-csv') {
+      if (recordType === 'Inspection') {
+        return alcInspectionCsvRequiredHeaders;
       }
     }
 
@@ -536,6 +536,12 @@ export class CsvConstants {
       }
     }
 
+    if (dataSourceType === 'alc-csv') {
+      if (recordType === 'Inspection') {
+        return alcInspectionCsvRequiredFields;
+      }
+    }
+
     return null;
   }
 
@@ -589,6 +595,12 @@ export class CsvConstants {
       }
     }
 
+    if (dataSourceType === 'alc-csv') {
+      if (recordType === 'Inspection') {
+        return alcInspectionsCsvRequiredFormats;
+      }
+    }
+
     return null;
   }
 
@@ -639,6 +651,12 @@ export class CsvConstants {
     if (dataSourceType === 'cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionsCsvDateFields;
+      }
+    }
+
+    if (dataSourceType === 'alc-csv') {
+      if (recordType === 'Inspection') {
+        return alcInspectionsCsvDateFields;
       }
     }
 

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -104,6 +104,7 @@ exports.createMaster = function(args, res, next, incomingObj, flavourIds) {
   incomingObj.mineGuid && (inspection.mineGuid = incomingObj.mineGuid);
   incomingObj._sourceRefAgriMisId && (inspection._sourceRefAgriMisId = incomingObj._sourceRefAgriMisId);
   incomingObj._sourceRefAgriCmdbId && (inspection._sourceRefAgriCmdbId = incomingObj._sourceRefAgriCmdbId);
+  incomingObj._sourceRefStringId && (inspection._sourceRefStringId = incomingObj._sourceRefStringId);
 
   // set permissions
   inspection.read = utils.ApplicationAdminRoles;
@@ -244,9 +245,8 @@ exports.createLNG = function(args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (inspectionLNG._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefNrisId &&
-    ObjectId.isValid(incomingObj._sourceRefNrisId) &&
-    (inspectionLNG._sourceRefNrisId = incomingObj._sourceRefNrisId);
+  incomingObj._sourceRefNrisId && (inspectionLNG._sourceRefNrisId = incomingObj._sourceRefNrisId);
+  incomingObj._sourceRefStringId && (inspectionLNG._sourceRefStringId = incomingObj._sourceRefStringId);
 
   // set permissions and meta
   inspectionLNG.read = utils.ApplicationAdminRoles;
@@ -389,11 +389,10 @@ exports.createNRCED = function(args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (inspectionNRCED._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefNrisId &&
-    ObjectId.isValid(incomingObj._sourceRefNrisId) &&
-    (inspectionNRCED._sourceRefNrisId = incomingObj._sourceRefNrisId);
+  incomingObj._sourceRefNrisId && (inspectionNRCED._sourceRefNrisId = incomingObj._sourceRefNrisId);
   incomingObj._sourceRefAgriMisId && (inspectionNRCED._sourceRefAgriMisId = incomingObj._sourceRefAgriMisId);
   incomingObj._sourceRefAgriCmdbId && (inspectionNRCED._sourceRefAgriCmdbId = incomingObj._sourceRefAgriCmdbId);
+  incomingObj._sourceRefStringId && (inspectionNRCED._sourceRefStringId = incomingObj._sourceRefStringId);
 
   // set permissions and meta
   inspectionNRCED.read = utils.ApplicationAdminRoles;
@@ -537,9 +536,7 @@ exports.createBCMI = function(args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (inspectionBCMI._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-  incomingObj._sourceRefNrisId &&
-    ObjectId.isValid(incomingObj._sourceRefNrisId) &&
-    (inspectionBCMI._sourceRefNrisId = incomingObj._sourceRefNrisId);
+    incomingObj._sourceRefNrisId && (inspectionBCMI._sourceRefNrisId = incomingObj._sourceRefNrisId);
   incomingObj.collectionId &&
     ObjectId.isValid(incomingObj.collectionId) &&
     (inspectionBCMI.collectionId = new ObjectId(incomingObj.collectionId));

--- a/api/src/importers/alc/base-record-utils.js
+++ b/api/src/importers/alc/base-record-utils.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const defaultLog = require('../../utils/logger')('alc-csv-base-record-utils');
+const RecordController = require('./../../controllers/record-controller');
+
+/**
+ * ALC csv base record type handler that can be used directly, or extended if customizations are needed.
+ *
+ * @class BaseRecordUtils
+ */
+class BaseRecordUtils {
+  /**
+   * Creates an instance of BaseRecordUtils.
+   *
+   * @param {*} auth_payload user information for auditing
+   * @param {*} recordType an item from record-type-enum.js -> RECORD_TYPE
+   * @param {*} csvRow an array containing the values from a single csv row.
+   * @memberof BaseRecordUtils
+   */
+  constructor(auth_payload, recordType, csvRow) {
+    if (!recordType) {
+      throw Error('BaseRecordUtils - required recordType must be non-null.');
+    }
+
+    this.auth_payload = auth_payload;
+    this.recordType = recordType;
+    this.csvRow = csvRow;
+  }
+
+  /**
+   * Transform an alc-csv row into a NRPTI record.
+   *
+   * Note: Only transforms common fields found in ALL supported alc-csv types.
+   *       To include other values, extend this class and adjust the object returned by this function as needed.
+   *
+   * @param {object} csvRow alc-csv row (required)
+   * @returns {object} NRPTI record.
+   * @throws {Error} if record is not provided.
+   * @memberof BaseRecordUtils
+   */
+  transformRecord(csvRow) {
+    if (!csvRow) {
+      throw Error('transformRecord - required csvRow must be non-null.');
+    }
+
+    return {
+      _schemaName: this.recordType._schemaName,
+      recordType: this.recordType.displayName,
+
+      sourceSystemRef: 'alc-csv'
+    };
+  }
+
+  /**
+   * Searches for an existing master record, and returns it if found.
+   *
+   * @param {*} nrptiRecord
+   * @returns {object} existing NRPTI master record, or null if none found or _sourceRefStringId is null
+   * @memberof BaseRecordUtils
+   */
+  async findExistingRecord(nrptiRecord) {
+    if (!nrptiRecord._sourceRefStringId) {
+      return null;
+    }
+
+    const masterRecordModel = mongoose.model(this.recordType._schemaName);
+
+    return await masterRecordModel
+      .findOne({
+        _schemaName: this.recordType._schemaName,
+        _sourceRefStringId: nrptiRecord._sourceRefStringId
+      })
+      .populate('_flavourRecords', '_id _schemaName');
+  }
+
+  /**
+   * Update an existing NRPTI master record and its flavour records (if any).
+   *
+   * @param {*} nrptiRecord
+   * @param {*} existingRecord
+   * @returns {object} object containing the update master and flavour records (if any)
+   * @memberof BaseRecordUtils
+   */
+  async updateRecord(nrptiRecord, existingRecord) {
+    if (!nrptiRecord) {
+      throw Error('updateRecord - required nrptiRecord must be non-null.');
+    }
+
+    if (!existingRecord) {
+      throw Error('updateRecord - required existingRecord must be non-null.');
+    }
+
+    try {
+      // build update Obj, which needs to include the flavour record ids
+      const updateObj = { ...nrptiRecord, _id: existingRecord._id };
+
+      updateObj.updatedBy = (this.auth_payload && this.auth_payload.preferred_username) || '';
+      updateObj.dateUpdated = new Date();
+
+      existingRecord._flavourRecords.forEach(flavourRecord => {
+        updateObj[flavourRecord._schemaName] = { _id: flavourRecord._id, addRole: 'public' };
+      });
+
+      return await RecordController.processPutRequest(
+        { swagger: { params: { auth_payload: this.auth_payload } } },
+        null,
+        null,
+        this.recordType.recordControllerName,
+        [updateObj]
+      );
+    } catch (error) {
+      defaultLog.error(`Failed to save ${this.recordType._schemaName} record: ${error.message}`);
+    }
+  }
+
+  /**
+   * Create a new NRPTI master and flavour records.
+   *
+   * @async
+   * @param {object} nrptiRecord NRPTI record (required)
+   * @returns {object} object containing the newly inserted master and flavour records
+   * @memberof BaseRecordUtils
+   */
+  async createItem(nrptiRecord) {
+    if (!nrptiRecord) {
+      throw Error('createItem - required nrptiRecord must be non-null.');
+    }
+
+    try {
+      // build create Obj, which should include the flavour record details
+      const createObj = { ...nrptiRecord };
+
+      createObj.addedBy = (this.auth_payload && this.auth_payload.preferred_username) || '';
+      createObj.dateAdded = new Date();
+
+      // publish to NRCED
+      if (this.recordType.flavours.nrced) {
+        createObj[this.recordType.flavours.nrced._schemaName] = {
+          addRole: 'public'
+        };
+      }
+
+      return await RecordController.processPostRequest(
+        { swagger: { params: { auth_payload: this.auth_payload } } },
+        null,
+        null,
+        this.recordType.recordControllerName,
+        [createObj]
+      );
+    } catch (error) {
+      defaultLog.error(`Failed to create ${this.recordType._schemaName} record: ${error.message}`);
+    }
+  }
+}
+
+module.exports = BaseRecordUtils;

--- a/api/src/importers/alc/base-record-utils.test.js
+++ b/api/src/importers/alc/base-record-utils.test.js
@@ -1,0 +1,132 @@
+const BaseRecordUtils = require('./base-record-utils');
+const RecordController = require('../../controllers/record-controller');
+const RECORD_TYPE = require('../../utils/constants/record-type-enum');
+const MiscConstants = require('../../utils/constants/misc');
+
+describe('BaseRecordUtils', () => {
+  describe('constructor', () => {
+    it('throws an error if no recordType provided', () => {
+      expect(() => {
+        new BaseRecordUtils(null);
+      }).toThrow('BaseRecordUtils - required recordType must be non-null.');
+    });
+  });
+
+  describe('transformRecord', () => {
+    it('throws error if no csvRow provided', () => {
+      const baseRecordUtils = new BaseRecordUtils(null, RECORD_TYPE.Inspection);
+      expect(() => baseRecordUtils.transformRecord(null)).toThrow(
+        'transformRecord - required csvRow must be non-null.'
+      );
+    });
+
+    it('returns transformed csvRow record', () => {
+      const baseRecordUtils = new BaseRecordUtils(null, RECORD_TYPE.Inspection);
+
+      const csvRow = {};
+
+      const expectedResult = {
+        _schemaName: 'Inspection',
+        recordType: 'Inspection',
+
+        sourceSystemRef: 'alc-csv'
+      };
+
+      const result = baseRecordUtils.transformRecord(csvRow);
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('updateRecord', () => {
+    it('throws error when nrptiRecord is not provided', async () => {
+      const baseRecordUtils = new BaseRecordUtils(null, RECORD_TYPE.Inspection);
+      await expect(baseRecordUtils.updateRecord(null, {})).rejects.toThrow(
+        'updateRecord - required nrptiRecord must be non-null.'
+      );
+    });
+
+    it('throws error when existingRecord is not provided', async () => {
+      const baseRecordUtils = new BaseRecordUtils(null, RECORD_TYPE.Inspection);
+      await expect(baseRecordUtils.updateRecord({}, null)).rejects.toThrow(
+        'updateRecord - required existingRecord must be non-null.'
+      );
+    });
+
+    it('calls `processPutRequest` when all arguments provided', async () => {
+      const baseRecordUtils = new BaseRecordUtils('authPayload', RECORD_TYPE.Inspection);
+
+      const processPutRequestSpy = jest.spyOn(RecordController, 'processPutRequest').mockImplementation(() => {
+        return Promise.resolve({ test: 'record' });
+      });
+
+      const nrptiRecord = { newField: 'abc', issuedTo: { type: MiscConstants.IssuedToEntityTypes.Individual } };
+      const existingRecord = { _id: 123, _flavourRecords: [{ _id: 321, _schemaName: 'flavourSchema' }] };
+
+      const result = await baseRecordUtils.updateRecord(nrptiRecord, existingRecord);
+
+      expect(processPutRequestSpy).toHaveBeenCalledWith(
+        { swagger: { params: { auth_payload: 'authPayload' } } },
+        null,
+        null,
+        RECORD_TYPE.Inspection.recordControllerName,
+        [
+          {
+            _id: 123,
+            newField: 'abc',
+            updatedBy: '',
+            dateUpdated: expect.any(Date),
+            flavourSchema: {
+              _id: 321,
+              addRole: 'public'
+            },
+            issuedTo: { type: MiscConstants.IssuedToEntityTypes.Individual }
+          }
+        ]
+      );
+
+      expect(result).toEqual({ test: 'record' });
+    });
+  });
+
+  describe('createItem', () => {
+    it('throws error when nrptiRecord is not provided', async () => {
+      const baseRecordUtils = new BaseRecordUtils(null, RECORD_TYPE.Inspection);
+      await expect(baseRecordUtils.createItem(null)).rejects.toThrow(
+        'createItem - required nrptiRecord must be non-null.'
+      );
+    });
+
+    it('calls `processPostRequest` when all arguments provided', async () => {
+      const baseRecordUtils = new BaseRecordUtils('authPayload', RECORD_TYPE.Inspection);
+
+      const processPostRequestSpy = jest.spyOn(RecordController, 'processPostRequest').mockImplementation(() => {
+        return Promise.resolve({ test: 'record' });
+      });
+
+      const nrptiRecord = { newField: 'abc', issuedTo: { type: MiscConstants.IssuedToEntityTypes.Individual } };
+
+      const result = await baseRecordUtils.createItem(nrptiRecord);
+
+      expect(processPostRequestSpy).toHaveBeenCalledWith(
+        { swagger: { params: { auth_payload: 'authPayload' } } },
+        null,
+        null,
+        RECORD_TYPE.Inspection.recordControllerName,
+        [
+          {
+            newField: 'abc',
+            addedBy: '',
+            dateAdded: expect.any(Date),
+            issuedTo: { type: MiscConstants.IssuedToEntityTypes.Individual },
+            InspectionNRCED: {
+              addRole: 'public'
+            }
+          }
+        ]
+      );
+
+      expect(result).toEqual({ test: 'record' });
+    });
+  });
+});

--- a/api/src/importers/alc/datasource.js
+++ b/api/src/importers/alc/datasource.js
@@ -1,0 +1,166 @@
+const defaultLog = require('../../utils/logger')('alc-csv-datasource');
+const RECORD_TYPE = require('../../utils/constants/record-type-enum');
+
+class AlcCsvDataSource {
+  /**
+   * Creates an instance of DataSource.
+   *
+   * @param {*} taskAuditRecord audit record hook for this import instance
+   * @param {*} auth_payload information about the user account that started this update
+   * @param {*} recordType record type to create from the csv file
+   * @param {*} csvRows array of csv row objects to import
+   * @memberof AlcCsvDataSource
+   */
+  constructor(taskAuditRecord, auth_payload, recordType, csvRows) {
+    this.taskAuditRecord = taskAuditRecord;
+    this.auth_payload = auth_payload;
+    this.recordType = recordType;
+
+    // Only process records that are Status = 'Complete', Reason != 'File Closure', Record Type = Inspection
+    if (csvRows) {
+      this.csvRows = csvRows.filter(row => {
+        const reportStatus = row['status'];
+        const reason = row['reason'];
+        const type = row['record type'];
+
+        if (!(reportStatus && reportStatus.toLowerCase() === 'complete')) return false;
+        if (!(reason && reason.toLowerCase() !== 'file closure')) return false;
+        if (!(type && type.toLowerCase() === 'inspection')) return false;
+
+        return true;
+      });
+    }
+
+    // Set initial status
+    this.status = { itemsProcessed: 0, itemTotal: 0, individualRecordStatus: [] };
+  }
+
+  /**
+   * Run the ALC csv importer.
+   *
+   * @returns final status of importer
+   * @memberof AlcCsvDataSource
+   */
+  async run() {
+    defaultLog.info('run - import alc-csv');
+
+    this.status.itemTotal = this.csvRows.length;
+
+    await this.taskAuditRecord.updateTaskRecord({ status: 'Running', itemTotal: this.csvRows.length });
+
+    await this.batchProcessRecords();
+
+    return this.status;
+  }
+
+  /**
+   * Runs processRecord() on each csv row, in batches.
+   *
+   * Batch size configured by env variable `CSV_IMPORT_BATCH_SIZE` if it exists, or 100 by default.
+   *
+   * @memberof AlcCsvDataSource
+   */
+  async batchProcessRecords() {
+    try {
+      let batchSize = process.env.CSV_IMPORT_BATCH_SIZE || 100;
+
+      const recordTypeConfig = this.getRecordTypeConfig();
+
+      if (!recordTypeConfig) {
+        throw Error('batchProcessRecords - failed to find matching recordTypeConfig.');
+      }
+
+      let promises = [];
+      for (let i = 0; i < this.csvRows.length; i++) {
+        promises.push(this.processRecord(this.csvRows[i], recordTypeConfig));
+
+        if (i % batchSize === 0 || i === this.csvRows.length - 1) {
+          await Promise.all(promises);
+          promises = [];
+        }
+      }
+    } catch (error) {
+      this.status.message = 'batchProcessRecords - unexpected error';
+      this.status.error = error.message;
+
+      defaultLog.error(`batchProcessRecords - unexpected error: ${error.message}`);
+    }
+  }
+
+  /**
+   * Perform all steps necessary to process and save a single row of the csv file.
+   *
+   * @param {*} csvRow object of values for a single row
+   * @param {*} recordTypeConfig object containing record type specific details
+   * @memberof AlcCsvDataSource
+   */
+  async processRecord(csvRow, recordTypeConfig) {
+    // set status defaults
+    let recordStatus = {};
+
+    try {
+      if (!csvRow) {
+        throw Error('processRecord - required csvRow is null.');
+      }
+
+      if (!recordTypeConfig) {
+        throw Error('processRecord - required recordTypeConfig is null.');
+      }
+
+      // Get a new instance of the record utils that correspond with the current recordType
+      const recordTypeUtils = recordTypeConfig.getUtil(this.auth_payload, csvRow);
+
+      // Perform any data transformations necessary to convert the csv row into a NRPTI record
+      const nrptiRecord = recordTypeUtils.transformRecord(csvRow);
+
+      // Check if this record already exists
+      const existingRecord = await recordTypeUtils.findExistingRecord(nrptiRecord);
+
+      let savedRecord = null;
+      if (existingRecord) {
+        // update existing record
+        savedRecord = await recordTypeUtils.updateRecord(nrptiRecord, existingRecord);
+      } else {
+        // create new record
+        savedRecord = await recordTypeUtils.createItem(nrptiRecord);
+      }
+
+      if (savedRecord && savedRecord.length > 0 && savedRecord[0].status === 'success') {
+        this.status.itemsProcessed++;
+
+        await this.taskAuditRecord.updateTaskRecord({ itemsProcessed: this.status.itemsProcessed });
+      } else {
+        throw Error('processRecord - savedRecord is null.');
+      }
+    } catch (error) {
+      recordStatus.message = 'processRecord - unexpected error';
+      recordStatus.error = error.message;
+
+      // only add individual record status when an error occurs
+      this.status.individualRecordStatus.push(recordStatus);
+
+      // Do not re-throw error, as a single failure is not cause to stop the other records from processing
+      defaultLog.error(`processRecord - unexpected error: ${error.message}`);
+    }
+  }
+
+  /**
+   * Supported ALC csv record type configs.
+   *
+   * @returns {*} object with getUtil method to create a new instance of the record type utils.
+   * @memberof AlcCsvDataSource
+   */
+  getRecordTypeConfig() {
+    if (this.recordType === 'Inspection') {
+      return {
+        getUtil: (auth_payload, csvRow) => {
+          return new (require('./inspections-utils'))(auth_payload, RECORD_TYPE.Inspection, csvRow);
+        }
+      };
+    }
+
+    return null;
+  }
+}
+
+module.exports = AlcCsvDataSource;

--- a/api/src/importers/alc/datasource.test.js
+++ b/api/src/importers/alc/datasource.test.js
@@ -1,0 +1,128 @@
+const AlcCsvDataSource = require('./datasource');
+
+describe('AlcCsvDataSource', () => {
+  describe('constructor', () => {
+    it('sets taskAuditRecord', () => {
+      const dataSource = new AlcCsvDataSource('taskAuditRecord', null, null, null);
+      expect(dataSource.taskAuditRecord).toEqual('taskAuditRecord');
+    });
+
+    it('sets auth_payload', () => {
+      const dataSource = new AlcCsvDataSource(null, 'authPayload', null, null);
+      expect(dataSource.auth_payload).toEqual('authPayload');
+    });
+
+    it('sets recordType', () => {
+      const dataSource = new AlcCsvDataSource(null, null, 'recordType', null);
+      expect(dataSource.recordType).toEqual('recordType');
+    });
+
+    it('sets recordType', () => {
+      const dataSource = new AlcCsvDataSource(null, null, null, []);
+      expect(dataSource.csvRows).toEqual([]);
+    });
+
+    it('sets default status fields', () => {
+      const dataSource = new AlcCsvDataSource();
+      expect(dataSource.status).toEqual({
+        itemsProcessed: 0,
+        itemTotal: 0,
+        individualRecordStatus: []
+      });
+    });
+  });
+
+  describe('processRecord', () => {
+    it('sets an error if csvRow is null', async () => {
+      const dataSource = new AlcCsvDataSource();
+
+      await dataSource.processRecord(null, 'recordTypeConfig');
+
+      expect(dataSource.status.individualRecordStatus[0]).toEqual({
+        message: 'processRecord - unexpected error',
+        error: 'processRecord - required csvRow is null.'
+      });
+    });
+
+    it('sets an error if recordTypeConfig is null', async () => {
+      const dataSource = new AlcCsvDataSource();
+
+      await dataSource.processRecord('recordTypeConfig', null);
+
+      expect(dataSource.status.individualRecordStatus[0]).toEqual({
+        message: 'processRecord - unexpected error',
+        error: 'processRecord - required recordTypeConfig is null.'
+      });
+    });
+
+    it('transforms, saves, and updates the status for the new csvRow', async () => {
+      const taskAuditRecord = { updateTaskRecord: jest.fn(() => {}) };
+
+      const dataSource = new AlcCsvDataSource(taskAuditRecord, null, null, null);
+
+      const csvRow = {};
+
+      const recordTypeConfig = { getUtil: () => recordTypeUtils };
+      const recordTypeUtils = {
+        transformRecord: jest.fn(() => {
+          return { transformed: true };
+        }),
+        findExistingRecord: jest.fn(() => null),
+        createItem: jest.fn(() => {
+          return [{ status: 'success' }];
+        }),
+        updateRecord: jest.fn(() => {
+          return [{ status: 'failure' }];
+        })
+      };
+
+      await dataSource.processRecord(csvRow, recordTypeConfig);
+
+      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow);
+
+      expect(recordTypeUtils.findExistingRecord).toHaveBeenCalledWith({ transformed: true });
+
+      expect(recordTypeUtils.createItem).toHaveBeenCalledWith({ transformed: true });
+
+      expect(dataSource.status.itemsProcessed).toEqual(1);
+
+      expect(taskAuditRecord.updateTaskRecord).toHaveBeenCalledWith({ itemsProcessed: 1 });
+    });
+
+    it('transforms, saves, and updates the status for the existing csvRow', async () => {
+      const taskAuditRecord = { updateTaskRecord: jest.fn(() => {}) };
+
+      const dataSource = new AlcCsvDataSource(taskAuditRecord, null, null, null);
+
+      const csvRow = {};
+
+      const recordTypeConfig = { getUtil: () => recordTypeUtils };
+      const recordTypeUtils = {
+        transformRecord: jest.fn(() => {
+          return { transformed: true };
+        }),
+        findExistingRecord: jest.fn(() => {
+          return { _id: 123 };
+        }),
+        createItem: jest.fn(() => {
+          return [{ status: 'failure' }];
+        }),
+        updateRecord: jest.fn(() => {
+          return [{ status: 'success' }];
+        })
+      };
+
+      await dataSource.processRecord(csvRow, recordTypeConfig);
+
+      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow);
+
+      expect(recordTypeUtils.findExistingRecord).toHaveBeenCalledWith({ transformed: true });
+
+      expect(recordTypeUtils.updateRecord).toHaveBeenCalledWith({ transformed: true }, { _id: 123 });
+
+      expect(dataSource.status.itemsProcessed).toEqual(1);
+
+      expect(taskAuditRecord.updateTaskRecord).toHaveBeenCalledWith({ itemsProcessed: 1 });
+    });
+  });
+});

--- a/api/src/importers/alc/inspections-utils.js
+++ b/api/src/importers/alc/inspections-utils.js
@@ -33,7 +33,7 @@ class Inspections extends BaseRecordUtils {
 
     const inspection = { ...super.transformRecord(csvRow) };
 
-    inspection['_sourceRefStringId'] = Number(csvRow['record id']) || '';
+    inspection['_sourceRefStringId'] = csvRow['record id'] || '';
 
     inspection['recordType'] = 'Inspection';
     inspection['dateIssued'] = csvRow['date'] || null;

--- a/api/src/importers/alc/inspections-utils.js
+++ b/api/src/importers/alc/inspections-utils.js
@@ -1,0 +1,82 @@
+const BaseRecordUtils = require('./base-record-utils');
+const CsvUtils = require('./utils/csv-utils');
+const MiscConstants = require('../../utils/constants/misc');
+
+/**
+ * ALC csv Inspections record handler.
+ *
+ * @class Inspections
+ */
+class Inspections extends BaseRecordUtils {
+  /**
+   * Creates an instance of Inspections.
+   *
+   * @param {*} auth_payload user information for auditing
+   * @param {*} recordType an item from record-type-enum.js -> RECORD_TYPE
+   * @param {*} csvRow an object containing the values from a single csv row.
+   * @memberof Inspections
+   */
+  constructor(auth_payload, recordType, csvRow) {
+    super(auth_payload, recordType, csvRow);
+  }
+
+  /**
+   * Convert the csv row object into the object expected by the API record post/put controllers.
+   *
+   * @returns an inspection object matching the format expected by the API record post/put controllers.
+   * @memberof Inspections
+   */
+  transformRecord(csvRow) {
+    if (!csvRow) {
+      throw Error('transformRecord - required csvRow must be non-null.');
+    }
+
+    const inspection = { ...super.transformRecord(csvRow) };
+
+    inspection['_sourceRefStringId'] = Number(csvRow['record id']) || '';
+
+    inspection['recordType'] = 'Inspection';
+    inspection['dateIssued'] = csvRow['date'] || null;
+
+    inspection['issuingAgency'] = 'Agricultural Land Commission';
+    inspection['author'] = 'Agricultural Land Commission';
+
+    inspection['recordName'] = (csvRow['record id'] && `ALC Inspection - Record ${csvRow['record id']}`) || '-';
+    inspection['description'] = (csvRow['reason'] && `Activity Inspected: ${csvRow['reason']}`) || '-';
+    inspection['summary'] = (csvRow['reason'] && `Activity Inspected: ${csvRow['reason']}`) || '-';
+
+    inspection['location'] = csvRow['local government'] || null;
+
+    inspection['legislation'] = {
+      act: 'Agricultural Land Commission Act',
+      section: '49',
+      subSection: '1'
+    };
+    inspection['legislationDescription'] = 'Inspection to verify compliance with regulatory requirements';
+
+    inspection['outcomeDescription'] = CsvUtils.getOutcomeDescription(csvRow);
+
+    const entityType = CsvUtils.getEntityType(csvRow);
+
+    if (entityType === MiscConstants.IssuedToEntityTypes.Company) {
+      inspection['issuedTo'] = {
+        type: MiscConstants.IssuedToEntityTypes.Company,
+        companyName: csvRow['inspection property owner']
+      };
+    }
+
+    if (entityType === MiscConstants.IssuedToEntityTypes.Individual) {
+      inspection['issuedTo'] = {
+        type: MiscConstants.IssuedToEntityTypes.Individual,
+        dateOfBirth: null,
+        firstName: '',
+        lastName: '',
+        middleName: '',
+      };
+    }
+
+    return inspection;
+  }
+}
+
+module.exports = Inspections;

--- a/api/src/importers/alc/inspections-utils.test.js
+++ b/api/src/importers/alc/inspections-utils.test.js
@@ -1,0 +1,80 @@
+const Inspections = require('./inspections-utils');
+const RECORD_TYPE = require('../../utils/constants/record-type-enum');
+const MiscConstants = require('../../utils/constants/misc');
+
+describe('transformRecord', () => {
+  const inspections = new Inspections('authPayload', RECORD_TYPE.Inspection, null);
+
+  it('throws an error if null csvRow parameter provided', () => {
+    expect(() => inspections.transformRecord(null)).toThrow('transformRecord - required csvRow must be non-null.');
+  });
+
+  it('returns basic fields if empty csvRow parameter provided', () => {
+    const result = inspections.transformRecord({});
+
+    expect(result).toEqual({
+      _schemaName: 'Inspection',
+      _sourceRefStringId: '',
+
+      recordType: 'Inspection',
+      author: 'Agricultural Land Commission',
+      dateIssued: null,
+      issuedTo: { dateOfBirth: null, firstName: '', lastName: '', middleName: '', type: 'Individual' },
+      description: '-',
+      sourceSystemRef: 'alc-csv',
+      issuingAgency: 'Agricultural Land Commission',
+      legislation: {
+        act: 'Agricultural Land Commission Act',
+        section: '49',
+        subSection: '1'
+      },
+      legislationDescription: 'Inspection to verify compliance with regulatory requirements',
+      location: null,
+      outcomeDescription: 'undefined - undefined',
+      recordName: '-',
+      summary: '-'
+    });
+  });
+
+  it('transforms csv row fields into NRPTI record fields', () => {
+    const result = inspections.transformRecord({
+      'record id': 123,
+      date: '2020-11-23',
+      'local government': 'West Coast',
+      reason: 'reason',
+      section: '20 (1) Non-farm use of land without authority',
+      'c&e actions': 'Notice of Contravention',
+      'compliance status': 'Alleged Non-Compliance'
+    });
+
+    expect(result).toEqual({
+      _schemaName: 'Inspection',
+      _sourceRefStringId: 123,
+
+      recordType: 'Inspection',
+      recordName: 'ALC Inspection - Record 123',
+      author: 'Agricultural Land Commission',
+      description: 'Activity Inspected: reason',
+      summary: 'Activity Inspected: reason',
+      dateIssued: expect.any(String),
+      issuedTo: {
+        dateOfBirth: null,
+        firstName: '',
+        lastName: '',
+        middleName: '',
+        type: MiscConstants.IssuedToEntityTypes.Individual
+      },
+      issuingAgency: 'Agricultural Land Commission',
+      legislation: {
+        act: 'Agricultural Land Commission Act',
+        section: '49',
+        subSection: '1'
+      },
+      legislationDescription:
+        'Inspection to verify compliance with regulatory requirements',
+      location: 'West Coast',
+      outcomeDescription: 'Alleged Non-Compliance - Notice of Contravention; Alleged Contravention: 20 (1) Non-farm use of land without authority',
+      sourceSystemRef: 'alc-csv'
+    });
+  });
+});

--- a/api/src/importers/alc/utils/csv-utils.js
+++ b/api/src/importers/alc/utils/csv-utils.js
@@ -1,0 +1,39 @@
+const MiscConstants = require('../../../utils/constants/misc');
+
+/**
+ * Derives the outcome description string.
+ *
+ * @param {*} csvRow
+ * @returns {string} the outcome description string.
+ */
+exports.getOutcomeDescription = function(csvRow) {
+  if (!csvRow) {
+    return null;
+  }
+
+  const complianceStatus = csvRow['compliance status'];
+  const ceAction = csvRow['c&e actions'];
+  const section = csvRow['section'];
+
+  if (complianceStatus === 'Alleged Non-Compliance' && section) {
+    return  `${complianceStatus} - ${ceAction}; Alleged Contravention: ${section}`
+  }
+
+  return `${complianceStatus} - ${ceAction}`;
+};
+
+/**
+ * Derives the issued to entity type.
+ *
+ * @param {*} csvRow
+ * @returns {string} the entity type.
+ */
+exports.getEntityType = function(csvRow) {
+  if (!csvRow) {
+    return null;
+  }
+
+  if (csvRow['inspection property owner']) return MiscConstants.IssuedToEntityTypes.Company;
+
+  return MiscConstants.IssuedToEntityTypes.Individual;
+};

--- a/api/src/importers/alc/utils/csv-utils.test.js
+++ b/api/src/importers/alc/utils/csv-utils.test.js
@@ -1,0 +1,57 @@
+const CsvUtils = require('./csv-utils');
+const MiscConstants = require('../../../utils/constants/misc');
+
+describe('getEntityType', () => {
+  it('returns null if null csvRow paramter provided ', async () => {
+    const result = await CsvUtils.getEntityType(null);
+
+    expect(result).toBe(null);
+  });
+
+  it('returns "Company" if csvRow "Inspection Property Owner" is not empty', async () => {
+    const result = await CsvUtils.getEntityType({ 'inspection property owner': 'test' });
+
+    expect(result).toEqual(MiscConstants.IssuedToEntityTypes.Company);
+  });
+
+  it('returns "Individual" if csvRow "Inspection Property Owner" is empty', async () => {
+    const result = await CsvUtils.getEntityType({ 'inspection property owner': '' });
+
+    expect(result).toEqual(MiscConstants.IssuedToEntityTypes.Individual);
+  });
+
+  it('returns "Individual" if csvRow "Inspection Property Owner', async () => {
+    const result = await CsvUtils.getEntityType({ 'inspection property owner': null });
+
+    expect(result).toEqual(MiscConstants.IssuedToEntityTypes.Individual);
+  });
+});
+
+describe('getOutcomeDescription', () => {
+  it('returns null if null csvRow paramter provided ', async () => {
+    const result = await CsvUtils.getOutcomeDescription(null);
+
+    expect(result).toBe(null);
+  });  
+
+  it('returns expected contraventions if csvRow "compliance status" is "Alleged Non-Compliance" and section not empty', async () => {
+    const result = await CsvUtils.getOutcomeDescription({
+      'compliance status': 'Alleged Non-Compliance',
+      'c&e actions': 'Notice of Contravention',
+      'section': '20 (1) Non-farm use of land without authority'
+    });
+
+    expect(result).toEqual(
+      'Alleged Non-Compliance - Notice of Contravention; Alleged Contravention: 20 (1) Non-farm use of land without authority'
+    );
+  });
+
+  it('returns expected contraventions if csvRow "compliance status" is not "Alleged Non-Compliance"', async () => {
+    const result = await CsvUtils.getOutcomeDescription({
+      'compliance status': 'Compliant',
+      'c&e actions': 'No Action'
+    });
+
+    expect(result).toEqual('Compliant - No Action');
+  });
+});

--- a/api/src/models/lng/inspection-lng.js
+++ b/api/src/models/lng/inspection-lng.js
@@ -7,6 +7,7 @@ module.exports = require('../../utils/model-schema-generator')(
     _epicProjectId: { type: 'ObjectId', default: null, index: true },
     _sourceRefId: { type: 'ObjectId', default: null, index: true },
     _sourceRefNrisId: { type: Number, default: null, index: true },
+    _sourceRefStringId: { type: String, default: null, index: true },
     _epicMilestoneId: { type: 'ObjectId', default: null, index: true },
     _master: { type: 'ObjectId', default: null, index: true },
 

--- a/api/src/models/master/inspection.js
+++ b/api/src/models/master/inspection.js
@@ -12,6 +12,7 @@ module.exports = require('../../utils/model-schema-generator')(
     _epicMilestoneId: { type: 'ObjectId', default: null, index: true },
     _sourceRefOgcInspectionId: { type: String, default: null, index: true },
     _sourceRefOgcDeficiencyId: { type: String, default: null, index: true },
+    _sourceRefStringId: { type: String, default: null, index: true },
     mineGuid: { type: String, default: null, index: true },
 
     read: [{ type: String, trim: true, default: 'sysadmin' }],

--- a/api/src/models/nrced/inspection-nrced.js
+++ b/api/src/models/nrced/inspection-nrced.js
@@ -9,6 +9,7 @@ module.exports = require('../../utils/model-schema-generator')(
     _sourceRefNrisId: { type: Number, default: null, index: true },
     _sourceRefAgriMisId: { type: String, default: null, index: true },
     _sourceRefAgriCmdbId: { type: String, default: null, index: true },
+    _sourceRefStringId: { type: String, default: null, index: true },
     _epicMilestoneId: { type: 'ObjectId', default: null, index: true },
     _master: { type: 'ObjectId', default: null, index: true },
 

--- a/api/src/tasks/import-task.js
+++ b/api/src/tasks/import-task.js
@@ -242,6 +242,12 @@ function getDataSourceConfig(dataSourceType) {
     }
   }
 
+  if (dataSourceType === 'alc-csv') {
+    return {
+      dataSourceLabel: 'alc-csv',
+      dataSourceClass: require('../importers/alc/datasource')
+    }
+  }
 
   // dataSourceType will match the name of a directory for the given
   // integration in /src/integrations/<dataSourceType>/


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-11

This PR adds the ALC Inspection CSV import.  Test file is in Jira ticket

Note:  I decided to use a field called `_sourceRefStringId` instead of something like `_sourceRefAlcInspectionId` for tracking source system IDs.  This is because as we add more import sources, the number of these unique `_sourceRef<system>Id` is starting to get out of hand.  The purpose of `_sourceRefStringId` field is have it be used across all importers instead of creating an unique field for each importer.

The reason `_sourceRefId` isn't used for this is because it is of type `ObjectId` in the models and won't store other types