### PR TITLE
NRPT-654: implement ENV-EPD role controls in api and nrpti frontend

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -36,6 +36,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
   // Pick lists
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -139,11 +140,10 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.ADMINISTRATIVE_PENALTY;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -162,7 +162,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -383,7 +383,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
       (administrativePenalty['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
       ));
-    this.myForm.controls.issuingAgency.dirty &&
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
       (administrativePenalty['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (administrativePenalty['author'] = this.myForm.controls.author.value);
 

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -35,6 +35,7 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
   // Pick lists
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -140,11 +141,10 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.ADMINISTRATIVE_SANCTION;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -163,7 +163,7 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -384,7 +384,7 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
       (administrativeSanction['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
       ));
-    this.myForm.controls.issuingAgency.dirty &&
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
       (administrativeSanction['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (administrativeSanction['author'] = this.myForm.controls.author.value);
 

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -35,6 +35,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
   public courtConvictionSubtypes = Picklists.courtConvictionSubtypePicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -136,11 +137,10 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.COURT_CONVICTION;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -163,7 +163,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -359,7 +359,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
       (courtConviction['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
       (courtConviction['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
-    this.myForm.controls.issuingAgency.dirty &&
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
       (courtConviction['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (courtConviction['author'] = this.myForm.controls.author.value);
 

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -36,6 +36,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
   public outcomeStatuses = Picklists.outcomeStatusPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -140,11 +141,10 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.INSPECTION;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -163,7 +163,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -329,7 +329,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     this.myForm.controls.recordName.dirty && (inspection['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (inspection['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
-    this.myForm.controls.issuingAgency.dirty &&
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
       (inspection['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (inspection['author'] = this.myForm.controls.author.value);
 

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -37,6 +37,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
   public outcomeStatuses = Picklists.outcomeStatusPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -141,11 +142,10 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.ORDER;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -168,7 +168,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -337,7 +337,8 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     this.myForm.controls.recordSubtype.dirty && (order['recordSubtype'] = this.myForm.controls.recordSubtype.value);
     this.myForm.controls.dateIssued.dirty &&
       (order['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
-    this.myForm.controls.issuingAgency.dirty && (order['issuingAgency'] = this.myForm.controls.issuingAgency.value);
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
+      (order['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (order['author'] = this.myForm.controls.author.value);
 
     if (

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.spec.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.spec.ts
@@ -21,7 +21,7 @@ describe('PermitAddEditComponent', () => {
   const mockLocation = jasmine.createSpyObj('Location', ['go']);
   const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
   const mockActivatedRoute = new ActivatedRouteStub();
-  const mockFactoryService = jasmine.createSpyObj('FactoryService', ['userInLngRole', 'userInBcmiRole', 'userInNrcedRole', 'userOnlyInLimitedRole', 'userInRole']);
+  const mockFactoryService = jasmine.createSpyObj('FactoryService', ['userInLngRole', 'userInBcmiRole', 'userInNrcedRole', 'userOnlyInLimitedRole', 'userInRole', 'isFlavourEditEnabled']);
   mockFactoryService.userInLngRole.and.returnValue(true);
   mockFactoryService.userInBcmiRole.and.returnValue(true);
   mockFactoryService.userInNrcedRole.and.returnValue(true);

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -35,6 +35,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
   // Pick lists
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -138,11 +139,10 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.RESTORATIVE_JUSTICE;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -161,7 +161,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -381,7 +381,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
       (restorativeJustice['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(
         this.myForm.get('dateIssued').value
       ));
-    this.myForm.controls.issuingAgency.dirty &&
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
       (restorativeJustice['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (restorativeJustice['author'] = this.myForm.controls.author.value);
 

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -35,6 +35,7 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
   // Pick lists
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -138,11 +139,10 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.TICKET;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -161,7 +161,7 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -379,7 +379,8 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     this.myForm.controls.recordName.dirty && (ticket['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (ticket['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
-    this.myForm.controls.issuingAgency.dirty && (ticket['issuingAgency'] = this.myForm.controls.issuingAgency.value);
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency)
+      && (ticket['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (ticket['author'] = this.myForm.controls.author.value);
 
     if (

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -36,6 +36,7 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
   public authors = Picklists.authorPicklist;
   public outcomeStatuses = Picklists.outcomeStatusPicklist;
+  private defaultAgency = '';
 
   // Documents
   public documents = [];
@@ -139,11 +140,10 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
   private buildForm() {
     const flavourEditRequiredRoles = Constants.FlavourEditRequiredRoles.WARNING;
 
-    let defaultAgency = '';
     for (const role of Constants.ApplicationLimitedRoles) {
       if (this.factoryService.userOnlyInLimitedRole(role)) {
         this.agencies = Constants.RoleAgencyPickList[role];
-        defaultAgency = this.agencies[0];
+        this.defaultAgency = this.agencies[0];
       }
     }
 
@@ -162,7 +162,7 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       issuingAgency: new FormControl({
-        value: (this.currentRecord && this.currentRecord.issuingAgency) || defaultAgency,
+        value: (this.currentRecord && this.currentRecord.issuingAgency) || this.defaultAgency,
         disabled: (this.currentRecord && this.currentRecord.sourceSystemRef !== 'nrpti')
       }),
       author: new FormControl({
@@ -311,7 +311,8 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     this.myForm.controls.recordName.dirty && (warning['recordName'] = this.myForm.controls.recordName.value);
     this.myForm.controls.dateIssued.dirty &&
       (warning['dateIssued'] = this.utils.convertFormGroupNGBDateToJSDate(this.myForm.get('dateIssued').value));
-    this.myForm.controls.issuingAgency.dirty && (warning['issuingAgency'] = this.myForm.controls.issuingAgency.value);
+    (this.myForm.controls.issuingAgency.dirty || this.defaultAgency) &&
+      (warning['issuingAgency'] = this.myForm.controls.issuingAgency.value);
     this.myForm.controls.author.dirty && (warning['author'] = this.myForm.controls.author.value);
 
     if (

--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -174,12 +174,14 @@ export class KeycloakService {
       inBaseAdminRole(roles) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_WF);
+      roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.ADMINISTRATIVE_SANCTION] =
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.AGREEMENT] = inBaseAdminRole(roles);
 
@@ -194,7 +196,8 @@ export class KeycloakService {
     this.menus[recordTypes.COURT_CONVICTION] =
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.CORRESPONDENCE] = inBaseAdminRole(roles);
 
@@ -203,7 +206,8 @@ export class KeycloakService {
     this.menus[recordTypes.INSPECTION] =
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.MANAGEMENT_PLAN] = inBaseAdminRole(roles);
 
@@ -211,14 +215,18 @@ export class KeycloakService {
       inBaseAdminRole(roles) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_WF)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
-    this.menus[recordTypes.PERMIT] = inBaseAdminRole(roles);
+    this.menus[recordTypes.PERMIT] =
+      inBaseAdminRole(roles)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.RESTORATIVE_JUSTICE] =
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.REPORT] = inBaseAdminRole(roles);
 
@@ -226,11 +234,13 @@ export class KeycloakService {
 
     this.menus[recordTypes.TICKET] = inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.WARNING] = inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
   }
 
   isMenuEnabled(menuName) {

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -8,13 +8,15 @@ export class Constants {
     ADMIN_BCMI: 'admin:bcmi',
     ADMIN_WF: 'admin:wf',
     ADMIN_FLNRO: 'admin:flnro',
-    ADMIN_AGRI: 'admin:agri'
+    ADMIN_AGRI: 'admin:agri',
+    ADMIN_ENV_EPD: 'admin:env-epd'
   };
 
   public static readonly ApplicationLimitedRoles: string[] = [
     Constants.ApplicationRoles.ADMIN_WF,
     Constants.ApplicationRoles.ADMIN_FLNRO,
-    Constants.ApplicationRoles.ADMIN_AGRI
+    Constants.ApplicationRoles.ADMIN_AGRI,
+    Constants.ApplicationRoles.ADMIN_ENV_EPD
   ];
 
   // Datepicker is off by one so add one to the desired year.
@@ -59,25 +61,29 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     ADMINISTRATIVE_SANCTION: {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     AGREEMENT: {
@@ -104,11 +110,14 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
-      LNG: [Constants.ApplicationRoles.ADMIN_LNG,
+      LNG: [
+        Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     CORRESPONDENCE: {
@@ -123,12 +132,14 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     MANAGEMENT_PLAN: {
@@ -140,28 +151,33 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     PERMIT: {
-      NRCED: [Constants.ApplicationRoles.ADMIN_NRCED],
-      LNG: [Constants.ApplicationRoles.ADMIN_LNG]
+      NRCED: [Constants.ApplicationRoles.ADMIN_NRCED, Constants.ApplicationRoles.ADMIN_ENV_EPD],
+      LNG: [Constants.ApplicationRoles.ADMIN_LNG, Constants.ApplicationRoles.ADMIN_ENV_EPD]
     },
     RESTORATIVE_JUSTICE: {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
-      LNG: [Constants.ApplicationRoles.ADMIN_LNG,
+      LNG: [
+        Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     REPORT: {
@@ -176,24 +192,28 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     },
     WARNING: {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
-        Constants.ApplicationRoles.ADMIN_AGRI
+        Constants.ApplicationRoles.ADMIN_AGRI,
+        Constants.ApplicationRoles.ADMIN_ENV_EPD
       ]
     }
   };
@@ -205,7 +225,8 @@ export class Constants {
     ],
     [Constants.ApplicationRoles.ADMIN_AGRI]: [
       'Ministry of Agriculture'
-    ]
+    ],
+    [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Environmental Protection Division']
   };
 }
 

--- a/api/src/controllers/document-controller.js
+++ b/api/src/controllers/document-controller.js
@@ -14,7 +14,6 @@ const OBJ_STORE_URL = process.env.OBJECT_STORE_endpoint_url || 'nrs.objectstore.
 const ep = new AWS.Endpoint(OBJ_STORE_URL);
 const s3 = new AWS.S3({
   endpoint: ep,
-  sslEnabled: false,
   accessKeyId: process.env.OBJECT_STORE_user_account,
   secretAccessKey: process.env.OBJECT_STORE_password,
   signatureVersion: 'v4',

--- a/api/src/controllers/document-controller.js
+++ b/api/src/controllers/document-controller.js
@@ -14,6 +14,7 @@ const OBJ_STORE_URL = process.env.OBJECT_STORE_endpoint_url || 'nrs.objectstore.
 const ep = new AWS.Endpoint(OBJ_STORE_URL);
 const s3 = new AWS.S3({
   endpoint: ep,
+  sslEnabled: false,
   accessKeyId: process.env.OBJECT_STORE_user_account,
   secretAccessKey: process.env.OBJECT_STORE_password,
   signatureVersion: 'v4',

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -6,7 +6,12 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_WF, utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_WF,
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -6,7 +6,12 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_WF, utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_WF,
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -268,6 +268,15 @@ exports.createLNG = function (args, res, next, incomingObj) {
   incomingObj.sourceDateUpdated && (permitLNG.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (permitLNG.sourceSystemRef = incomingObj.sourceSystemRef);
 
+  // Add limited-admin(such as admin:wf) read/write roles if user is a limited-admin user
+  if (args) {
+    postUtils.setAdditionalRoleOnRecord(
+      permitLNG,
+      args.swagger.params.auth_payload.realm_access.roles,
+      ADDITIONAL_ROLES
+    );
+  }
+
   return permitLNG;
 };
 
@@ -286,7 +295,7 @@ exports.createBCMI = function (args, res, next, incomingObj) {
     [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_BCMI, ...ADDITIONAL_ROLES],
     args.swagger.params.auth_payload.realm_access.roles)
   ) {
-    throw new Error('Missing valid user role.');
+      throw new Error('Missing valid user role.');
   }
 
   let PermitBCMI = mongoose.model('PermitBCMI');
@@ -366,6 +375,15 @@ exports.createBCMI = function (args, res, next, incomingObj) {
   incomingObj.sourceDateAdded && (permitBCMI.sourceDateAdded = incomingObj.sourceDateAdded);
   incomingObj.sourceDateUpdated && (permitBCMI.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (permitBCMI.sourceSystemRef = incomingObj.sourceSystemRef);
+
+  // Add limited-admin(such as admin:wf) read/write roles if user is a limited-admin user
+  if (args) {
+    postUtils.setAdditionalRoleOnRecord(
+      permitBCMI,
+      args.swagger.params.auth_payload.realm_access.roles,
+      ADDITIONAL_ROLES
+    );
+  }
 
   return permitBCMI;
 };

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -149,14 +149,14 @@ exports.createMaster = function (args, res, next, incomingObj, flavourIds) {
   incomingObj.isLngPublished && (permit.isLngPublished = incomingObj.isLngPublished);
   incomingObj.isBcmiPublished && (permit.isBcmiPublished = incomingObj.isBcmiPublished);
 
- // Add limited-admin(such as admin:wf) read/write roles if user is a limited-admin user
- if (args) {
-  postUtils.setAdditionalRoleOnRecord(
-    permit,
-    args.swagger.params.auth_payload.realm_access.roles,
-    ADDITIONAL_ROLES
-  );
-}
+  // Add limited-admin(such as admin:wf) read/write roles if user is a limited-admin user
+  if (args) {
+    postUtils.setAdditionalRoleOnRecord(
+      permit,
+      args.swagger.params.auth_payload.realm_access.roles,
+      ADDITIONAL_ROLES
+    );
+  }
 
   return permit;
 };

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -6,7 +6,7 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -373,6 +373,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - in: query
           name: _id
@@ -613,6 +614,7 @@ paths:
         - admin:bcmi
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: task
           in: body
@@ -667,6 +669,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: recordId
           in: path
@@ -723,6 +726,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: recordId
           in: path
@@ -785,6 +789,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: recordId
           in: path
@@ -835,6 +840,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - in: body
           name: data
@@ -867,6 +873,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - in: body
           name: data
@@ -930,6 +937,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       consumes:
         - multipart/form-data
       parameters:
@@ -1004,6 +1012,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: recordId
           in: path
@@ -1059,6 +1068,7 @@ paths:
         - admin:wf
         - admin:flnro
         - admin:agri
+        - admin:env-epd
       parameters:
         - name: docId
           in: path

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -2,12 +2,15 @@ exports.SYSTEM_USER = 'SYSTEM_USER';
 
 const ApplicationRoles = {
   ADMIN: 'sysadmin',
-  ADMIN_NRCED: 'admin:nrced',
-  ADMIN_LNG: 'admin:lng',
-  ADMIN_BCMI: 'admin:bcmi',
-  ADMIN_WF: 'admin:wf',
-  ADMIN_FLNRO: 'admin:flnro',
   ADMIN_AGRI: 'admin:agri',
+  ADMIN_BCMI: 'admin:bcmi',
+  ADMIN_ENV_EPD: 'admin:env-epd',
+  ADMIN_FLNRO: 'admin:flnro',
+  ADMIN_LNG: 'admin:lng',
+  ADMIN_NRCED: 'admin:nrced',
+  ADMIN_WF: 'admin:wf',
+
+
   PUBLIC: 'public'
 };
 
@@ -23,7 +26,8 @@ exports.ApplicationAdminRoles = [
 exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_WF,
   ApplicationRoles.ADMIN_FLNRO,
-  ApplicationRoles.ADMIN_AGRI
+  ApplicationRoles.ADMIN_AGRI,
+  ApplicationRoles.ADMIN_ENV_EPD
 ]
 
 exports.KeycloakDefaultRoles = {
@@ -135,7 +139,7 @@ exports.COURT_CONVICTION_PENALTY_TYPES = [
 
 exports.PENALTY_VALUE_TYPES = ['Years', 'Months', 'Days', 'Dollars', 'Hours', 'Other'];
 
-exports.AUTHORIZED_PUBLISH_AGENCIES = [  
+exports.AUTHORIZED_PUBLISH_AGENCIES = [
   'BC Parks',
   'Climate Action Secretariat',
   'Conservation Officer Service',

--- a/api/src/utils/post-utils.test.js
+++ b/api/src/utils/post-utils.test.js
@@ -116,7 +116,7 @@ describe('PostUtils', () => {
   });
 
   test('setAdditionalRoleOnRecord alters record correctly if user one of the limited admins', async () => {
-    const limitedAdmins = [utils.ApplicationRoles.ADMIN_WF, utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI];
+    const limitedAdmins = utils.ApplicationLimitedAdminRoles;
 
     for (const role of limitedAdmins) {
       const record = {


### PR DESCRIPTION
Role controls for ENV-EPD role, includes necessary api and front-end updates.
- API: [NRPT-654](https://bcmines.atlassian.net/browse/NRPT-654)
- UI: [NRPT-353](https://bcmines.atlassian.net/browse/NRPT-353)

Assign yourself only the `admin:env-epd` role

POST to `/api/record` to test api record creation:

`{
    "orders": [
        {
            "recordName": "ENV EPD Role Test",
            "recordSubtype": "None",
            "issuingAgency": "Environmental Protection Division",
            "author": "BC Government",
            "issuedTo": {
                "type": "Individual",
                "companyName": null,
                "firstName": "Test",
                "middleName": "Middle",
                "lastName": "Name",
                "fullName": null,
                "dateOfBirth": null
            },
            "OrderNRCED": {
                "summary": "NRCED Summary",
                "addRole": "public"
            },
            "OrderLNG": {
                "description": "LNG Summary",
                "addRole": "public"
            }
        }
    ]
}`

Verify success and record read/write issuedTo read/write have **admin:env-epd** role

Create a document in the record:
`form-data
fileName: test-file-name.pdf
upfile: browse to your file`

Verify success document record has **admin:env-epd** role

To verify redaction, you can create a record in NRPTI from another user role and set the individual age to under 19. Then as the **admin:env-epd** role view the records list page and verify redaction (and vice versa for the roles).

