### PR TITLE
 NRPT-658 / NRPT-605: Create Role: ALC - API and Front-end

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
@@ -62,6 +62,14 @@ export class ImportCSVComponent implements OnInit {
         'cmdb-csv': ['Inspection'],
         'mis-csv': ['Inspection']
       };
+    } else if (this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC)) {
+      this.dataSourceTypes = [
+        { displayName: 'AGRI-ALC', value: 'alc-csv' }
+      ];
+
+      this.csvTypes = {
+        'alc-csv': ['Inspection']
+      };
     }
   }
 

--- a/angular/projects/admin-nrpti/src/app/import/import.component.html
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.html
@@ -3,7 +3,7 @@
     <h4>Import from Source System</h4>
 
     <div class="row">
-      <div class="col-md-3 mb-3">
+      <div *ngIf="showSourceSystemEPIC" class="col-md-3 mb-3">
         <label>Import from EPIC</label>
         <div>
           <button
@@ -21,7 +21,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 mb-3">
+      <div *ngIf="showSourceSystemNRIS" class="col-md-3 mb-3">
         <label>Import from NRIS</label>
         <div>
           <button
@@ -39,7 +39,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 mb-3">
+      <div *ngIf="showSourceSystemCORE" class="col-md-3 mb-3">
         <label>Import from CORE</label>
         <div>
           <button
@@ -57,7 +57,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 mb-3">
+      <div *ngIf="showSourceSystemBCOGC" class="col-md-3 mb-3">
         <label>Import from BCOGC</label>
         <div>
           <button

--- a/angular/projects/admin-nrpti/src/app/import/import.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.ts
@@ -26,6 +26,10 @@ export class ImportComponent implements OnInit, OnDestroy {
 
   public loading = true;
   public showSourceSystem = true;
+  public showSourceSystemEPIC = true;
+  public showSourceSystemNRIS = true;
+  public showSourceSystemCORE = true;
+  public showSourceSystemBCOGC = true;
   public showAlert = { epic: false, 'nris-epd': false, core: false, bcogc: false };
   public tableData: TableObject = new TableObject({ component: ImportTableRowsComponent });
   public tableColumns: IColumnObject[] = [
@@ -102,6 +106,13 @@ export class ImportComponent implements OnInit, OnDestroy {
       this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_AGRI)
       ) {
       this.showSourceSystem = false;
+    } else {
+      if (this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC)) {
+        this.showSourceSystemEPIC = false;
+        this.showSourceSystemNRIS = true;
+        this.showSourceSystemCORE = false;
+        this.showSourceSystemBCOGC = false;
+      }
     }
   }
 

--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -149,7 +149,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_NRCED) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_BCMI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI);
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[Constants.Menus.COMMUNICATIONS] =
       roles.includes(Constants.ApplicationRoles.ADMIN) ||
@@ -175,13 +176,15 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.ADMINISTRATIVE_SANCTION] =
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.AGREEMENT] = inBaseAdminRole(roles);
 
@@ -197,7 +200,8 @@ export class KeycloakService {
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.CORRESPONDENCE] = inBaseAdminRole(roles);
 
@@ -207,7 +211,8 @@ export class KeycloakService {
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.MANAGEMENT_PLAN] = inBaseAdminRole(roles);
 
@@ -216,7 +221,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_WF)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.PERMIT] =
       inBaseAdminRole(roles)
@@ -226,7 +232,8 @@ export class KeycloakService {
       inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.REPORT] = inBaseAdminRole(roles);
 
@@ -235,12 +242,14 @@ export class KeycloakService {
     this.menus[recordTypes.TICKET] = inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.WARNING] = inBaseAdminRole(roles)
       || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
       || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
+      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
   }
 
   isMenuEnabled(menuName) {

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -9,14 +9,16 @@ export class Constants {
     ADMIN_WF: 'admin:wf',
     ADMIN_FLNRO: 'admin:flnro',
     ADMIN_AGRI: 'admin:agri',
-    ADMIN_ENV_EPD: 'admin:env-epd'
+    ADMIN_ENV_EPD: 'admin:env-epd',
+    ADMIN_ALC: 'admin:alc'
   };
 
   public static readonly ApplicationLimitedRoles: string[] = [
     Constants.ApplicationRoles.ADMIN_WF,
     Constants.ApplicationRoles.ADMIN_FLNRO,
     Constants.ApplicationRoles.ADMIN_AGRI,
-    Constants.ApplicationRoles.ADMIN_ENV_EPD
+    Constants.ApplicationRoles.ADMIN_ENV_EPD,
+    Constants.ApplicationRoles.ADMIN_ALC
   ];
 
   // Datepicker is off by one so add one to the desired year.
@@ -62,14 +64,16 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     ADMINISTRATIVE_SANCTION: {
@@ -77,13 +81,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     AGREEMENT: {
@@ -111,13 +117,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     CORRESPONDENCE: {
@@ -133,13 +141,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     MANAGEMENT_PLAN: {
@@ -152,14 +162,16 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     PERMIT: {
@@ -171,13 +183,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     REPORT: {
@@ -193,13 +207,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
     WARNING: {
@@ -207,13 +223,15 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
-        Constants.ApplicationRoles.ADMIN_ENV_EPD
+        Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ALC
       ]
     }
   };
@@ -226,7 +244,10 @@ export class Constants {
     [Constants.ApplicationRoles.ADMIN_AGRI]: [
       'Ministry of Agriculture'
     ],
-    [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Environmental Protection Division']
+    [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Environmental Protection Division'],
+    [Constants.ApplicationRoles.ADMIN_ALC]: [
+      'Agriculture Land Commission C&E division'
+    ]
   };
 }
 

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -10,7 +10,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_WF,
   utils.ApplicationRoles.ADMIN_FLNRO,
   utils.ApplicationRoles.ADMIN_AGRI,
-  utils.ApplicationRoles.ADMIN_ENV_EPD
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -10,7 +10,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_WF,
   utils.ApplicationRoles.ADMIN_FLNRO,
   utils.ApplicationRoles.ADMIN_AGRI,
-  utils.ApplicationRoles.ADMIN_ENV_EPD
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -6,7 +6,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO, utils.ApplicationRoles.ADMIN_AGRI, utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
+                          utils.ApplicationRoles.ADMIN_AGRI,
+                          utils.ApplicationRoles.ADMIN_ENV_EPD,
+                          utils.ApplicationRoles.ADMIN_ALC];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -374,6 +374,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - in: query
           name: _id
@@ -615,6 +616,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: task
           in: body
@@ -670,6 +672,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: recordId
           in: path
@@ -727,6 +730,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: recordId
           in: path
@@ -790,6 +794,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: recordId
           in: path
@@ -841,6 +846,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - in: body
           name: data
@@ -874,6 +880,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - in: body
           name: data
@@ -938,6 +945,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       consumes:
         - multipart/form-data
       parameters:
@@ -1013,6 +1021,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: recordId
           in: path
@@ -1069,6 +1078,7 @@ paths:
         - admin:flnro
         - admin:agri
         - admin:env-epd
+        - admin:alc
       parameters:
         - name: docId
           in: path

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -9,8 +9,8 @@ const ApplicationRoles = {
   ADMIN_LNG: 'admin:lng',
   ADMIN_NRCED: 'admin:nrced',
   ADMIN_WF: 'admin:wf',
-
-
+  ADMIN_AGRI: 'admin:agri',
+  ADMIN_ALC: 'admin:alc',
   PUBLIC: 'public'
 };
 
@@ -27,7 +27,8 @@ exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_WF,
   ApplicationRoles.ADMIN_FLNRO,
   ApplicationRoles.ADMIN_AGRI,
-  ApplicationRoles.ADMIN_ENV_EPD
+  ApplicationRoles.ADMIN_ENV_EPD,
+  ApplicationRoles.ADMIN_ALC
 ]
 
 exports.KeycloakDefaultRoles = {

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -9,7 +9,6 @@ const ApplicationRoles = {
   ADMIN_LNG: 'admin:lng',
   ADMIN_NRCED: 'admin:nrced',
   ADMIN_WF: 'admin:wf',
-  ADMIN_AGRI: 'admin:agri',
   ADMIN_ALC: 'admin:alc',
   PUBLIC: 'public'
 };


### PR DESCRIPTION
Create admin:alc record:

```
POST http://localhost:3000/api/record
{
    "orders": [
        {
            "recordName": "ALC Role Test",
            "recordSubtype": "None",
            "issuingAgency": "Ministry of Agriculture",
            "author": "BC Government",
            "issuedTo": {
                "type": "Individual",
                "companyName": null,
                "firstName": "Test",
                "middleName": "Middle",
                "lastName": "Name",
                "fullName": null,
                "dateOfBirth": null
            },
            "OrderNRCED": {
                "summary": "NRCED Summary",
                "addRole": "public"
            },
            "OrderLNG": {
                "description": "LNG Summary",
                "addRole": "public"
            }
        }
    ]
}
```
Verify success and record read/write issuedTo read/write have admin:alc role

Create a document in the record:

```POST http://localhost:3000/api/record/{record_id}/document
form-data
fileName: test-file-name.pdf
upfile: browse to your file
```
Verify success document record has admin:alc role

To verify redaction, you can create a record in NRPTI from another user role and set the individual age to under 19. Then do a search using:

```
GET http://localhost:3000/api/search?dataset=Order,Inspection,Certificate,Permit,SelfReport,Agreement,RestorativeJustice,Ticket,AdministrativePenalty,AdministrativeSanction,Warning,ConstructionPlan,ManagementPlan,CourtConviction,AnnualReport,CertificateAmendment,Correspondence,DamSafetyInspection,Report&pageNum=0&pageSize=25&sortBy=-dateAdded&fields=
```

NB: This also adds some granularity on showing/hiding the Import buttons at the top of the import page instead of an all-or-nothing approach.