### PR TITLE
NRPT-659 Add FLNR-NRO role and other role fixes

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.ts
@@ -103,16 +103,11 @@ export class ImportComponent implements OnInit, OnDestroy {
   private disableSourceSystem() {
     if (
       this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_FLNRO) ||
-      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_AGRI)
-      ) {
+      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC)
+    ) {
       this.showSourceSystem = false;
-    } else {
-      if (this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC)) {
-        this.showSourceSystemEPIC = false;
-        this.showSourceSystemNRIS = true;
-        this.showSourceSystemCORE = false;
-        this.showSourceSystemBCOGC = false;
-      }
     }
   }
 

--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -149,6 +149,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_NRCED) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_BCMI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
@@ -174,17 +175,19 @@ export class KeycloakService {
     this.menus[recordTypes.ADMINISTRATIVE_PENALTY] =
       inBaseAdminRole(roles) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.ADMINISTRATIVE_SANCTION] =
-      inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.AGREEMENT] = inBaseAdminRole(roles);
 
@@ -197,59 +200,65 @@ export class KeycloakService {
     this.menus[recordTypes.CONSTRUCTION_PLAN] = inBaseAdminRole(roles);
 
     this.menus[recordTypes.COURT_CONVICTION] =
-      inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.CORRESPONDENCE] = inBaseAdminRole(roles);
 
     this.menus[recordTypes.DAM_SAFETY_INSPECTION] = inBaseAdminRole(roles);
 
     this.menus[recordTypes.INSPECTION] =
-      inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.MANAGEMENT_PLAN] = inBaseAdminRole(roles);
 
     this.menus[recordTypes.ORDER] =
       inBaseAdminRole(roles) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_WF)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
-    this.menus[recordTypes.PERMIT] =
-      inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+    this.menus[recordTypes.PERMIT] = inBaseAdminRole(roles) || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
 
     this.menus[recordTypes.RESTORATIVE_JUSTICE] =
-      inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.REPORT] = inBaseAdminRole(roles);
 
     this.menus[recordTypes.COMPLIANCE_SELF_REPORT] = inBaseAdminRole(roles);
 
-    this.menus[recordTypes.TICKET] = inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+    this.menus[recordTypes.TICKET] =
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
-    this.menus[recordTypes.WARNING] = inBaseAdminRole(roles)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_AGRI)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD)
-      || roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+    this.menus[recordTypes.WARNING] =
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
   }
 
   isMenuEnabled(menuName) {

--- a/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
@@ -466,19 +466,19 @@ export class CsvConstants {
       }
     }
 
-    if (dataSourceType === 'flnr-csv') {
+    if (dataSourceType === 'nris-flnr-csv') {
       if (recordType === 'Inspection') {
         return this.flnrInspectionCsvRequiredHeaders;
       }
     }
 
-    if (dataSourceType === 'mis-csv') {
+    if (dataSourceType === 'agri-mis-csv') {
       if (recordType === 'Inspection') {
         return this.misInspectionCsvRequiredHeaders;
       }
     }
 
-    if (dataSourceType === 'cmdb-csv') {
+    if (dataSourceType === 'agri-cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionCsvRequiredHeaders;
       }
@@ -531,19 +531,19 @@ export class CsvConstants {
       }
     }
 
-    if (dataSourceType === 'flnr-csv') {
+    if (dataSourceType === 'nris-flnr-csv') {
       if (recordType === 'Inspection') {
-        return this.flnrInspectionCsvRequiredHeaders;
+        return this.flnrInspectionCsvRequiredFields;
       }
     }
 
-    if (dataSourceType === 'mis-csv') {
+    if (dataSourceType === 'agri-mis-csv') {
       if (recordType === 'Inspection') {
         return this.misInspectionCsvRequiredFields;
       }
     }
 
-    if (dataSourceType === 'cmdb-csv') {
+    if (dataSourceType === 'agri-cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionCsvRequiredFields;
       }
@@ -596,19 +596,19 @@ export class CsvConstants {
       }
     }
 
-    if (dataSourceType === 'flnr-csv') {
+    if (dataSourceType === 'nris-flnr-csv') {
       if (recordType === 'Inspection') {
         return this.flnrInspectionCsvRequiredFormats;
       }
     }
 
-    if (dataSourceType === 'mis-csv') {
+    if (dataSourceType === 'agri-mis-csv') {
       if (recordType === 'Inspection') {
         return this.misInspectionsCsvRequiredFormats;
       }
     }
 
-    if (dataSourceType === 'cmdb-csv') {
+    if (dataSourceType === 'agri-cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionsCsvRequiredFormats;
       }
@@ -661,19 +661,19 @@ export class CsvConstants {
       }
     }
 
-    if (dataSourceType === 'flnr-csv') {
+    if (dataSourceType === 'nris-flnr-csv') {
       if (recordType === 'Inspection') {
         return this.flnrInspectionCsvDateFields;
       }
     }
 
-    if (dataSourceType === 'mis-csv') {
+    if (dataSourceType === 'agri-mis-csv') {
       if (recordType === 'Inspection') {
         return this.misInspectionsCsvDateFields;
       }
     }
 
-    if (dataSourceType === 'cmdb-csv') {
+    if (dataSourceType === 'agri-cmdb-csv') {
       if (recordType === 'Inspection') {
         return this.cmdbInspectionsCsvDateFields;
       }

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -8,6 +8,7 @@ export class Constants {
     ADMIN_BCMI: 'admin:bcmi',
     ADMIN_WF: 'admin:wf',
     ADMIN_FLNRO: 'admin:flnro',
+    ADMIN_FLNR_NRO: 'admin:flnr-nro',
     ADMIN_AGRI: 'admin:agri',
     ADMIN_ENV_EPD: 'admin:env-epd',
     ADMIN_ALC: 'admin:alc'
@@ -16,6 +17,7 @@ export class Constants {
   public static readonly ApplicationLimitedRoles: string[] = [
     Constants.ApplicationRoles.ADMIN_WF,
     Constants.ApplicationRoles.ADMIN_FLNRO,
+    Constants.ApplicationRoles.ADMIN_FLNR_NRO,
     Constants.ApplicationRoles.ADMIN_AGRI,
     Constants.ApplicationRoles.ADMIN_ENV_EPD,
     Constants.ApplicationRoles.ADMIN_ALC
@@ -63,6 +65,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -71,6 +74,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -80,6 +84,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -87,6 +92,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -116,6 +122,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -123,6 +130,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -140,6 +148,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -147,6 +156,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -161,6 +171,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -169,6 +180,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_WF,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -182,6 +194,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -189,6 +202,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -206,6 +220,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -213,6 +228,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -222,6 +238,7 @@ export class Constants {
       NRCED: [
         Constants.ApplicationRoles.ADMIN_NRCED,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -229,6 +246,7 @@ export class Constants {
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
         Constants.ApplicationRoles.ADMIN_FLNRO,
+        Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ALC
@@ -241,9 +259,8 @@ export class Constants {
     [Constants.ApplicationRoles.ADMIN_FLNRO]: [
       'Ministry of Forests, Lands, Natural Resource Operations and Rural Development'
     ],
-    [Constants.ApplicationRoles.ADMIN_AGRI]: [
-      'Ministry of Agriculture'
-    ],
+    [Constants.ApplicationRoles.ADMIN_FLNR_NRO]: ['Natural Resource Officers'],
+    [Constants.ApplicationRoles.ADMIN_AGRI]: ['Ministry of Agriculture'],
     [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Environmental Protection Division'],
     [Constants.ApplicationRoles.ADMIN_ALC]: [
       'Agriculture Land Commission'

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -228,7 +228,7 @@ export class Picklists {
     'alc-csv',
     'bcogc',
     'core',
-    'coors-csv',    
+    'coors-csv',
     'epic',
     'era-csv',
     'lng-csv',
@@ -236,7 +236,7 @@ export class Picklists {
     'nris-epd',
     'nris-flnr-csv',
     'nrpti',
-    'ocers-csv',
+    'ocers-csv'
   ];
 
   public static readonly mineTypes = ['Coal', 'Metal', 'Industrial Mineral', 'Sand & Gravel'];
@@ -789,7 +789,7 @@ export class Picklists {
    * @memberof Picklists
    * @returns {string[]} sorted array of acts
    */
-  public static getAllActs = function (): string[] {
+  public static getAllActs = function(): string[] {
     return Object.keys(this.legislationActsMappedToRegulations).sort();
   };
 
@@ -800,7 +800,7 @@ export class Picklists {
    * @memberof Picklists
    * @returns {string[]} sorted array of regulations
    */
-  public static getAllRegulations = function (): string[] {
+  public static getAllRegulations = function(): string[] {
     const regulations = [];
 
     Object.keys(this.legislationActsMappedToRegulations).forEach(act =>
@@ -824,7 +824,7 @@ export class Picklists {
    * @memberof Picklists
    * @returns {{ [key: string]: string[] }}
    */
-  public static getLegislationRegulationsMappedToActs = function (): { [key: string]: string[] } {
+  public static getLegislationRegulationsMappedToActs = function(): { [key: string]: string[] } {
     const regulations = {};
 
     Object.keys(this.legislationActsMappedToRegulations).forEach(act =>
@@ -888,7 +888,7 @@ export class Picklists {
               description: 'Administrative penalty for determination of contravention'
             },
             d: {
-              description: 'Order for recovery of government\'s costs of fire control and other amounts',
+              description: "Order for recovery of government's costs of fire control and other amounts"
             }
           }
         },
@@ -904,7 +904,7 @@ export class Picklists {
               description: 'Administrative penalty in lieu of remediation costs'
             }
           }
-        },
+        }
       }
     },
     AdministrativeSanction: {
@@ -1930,7 +1930,7 @@ export class Picklists {
               description: 'Administrative penalty for determination of contravention'
             },
             d: {
-              description: 'Order for recovery of government\'s costs of fire control and other amounts',
+              description: "Order for recovery of government's costs of fire control and other amounts"
             }
           }
         },
@@ -3703,7 +3703,7 @@ export class Picklists {
         '6': {
           '1': {
             e: {
-              description: 'Import an animal transported in contravention of a foreign state\'s law'
+              description: "Import an animal transported in contravention of a foreign state's law"
             }
           },
           '2': {
@@ -4714,7 +4714,7 @@ export class Picklists {
    * @static
    * @returns {string} legislation description or null
    */
-  public static getLegislationDescription = function (recordType: string, legislation: Legislation): string {
+  public static getLegislationDescription = function(recordType: string, legislation: Legislation): string {
     if (!recordType || !legislation || !legislation.act || !legislation.section) {
       return null;
     }
@@ -4769,7 +4769,7 @@ export class Picklists {
    * @param {string[]} paths properties to descend, in order, through the object.
    * @returns the value found at the end of the path, or null
    */
-  public static traverseObject = function (obj: object, paths: string[]) {
+  public static traverseObject = function(obj: object, paths: string[]) {
     if (!obj || !paths || !paths.length) {
       return null;
     }

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -223,15 +223,18 @@ export class Picklists {
   };
 
   public static readonly sourceSystemRefPicklist = [
-    'agri-mis',
+    'agri-cmdb-csv',
+    'agri-mis-csv',
+    'alc-csv',
     'bcogc',
     'core',
-    'coors-csv',
+    'coors-csv',    
     'epic',
+    'era-csv',
     'lng-csv',
     'mem-admin',
     'nris-epd',
-    'nro-inspections-csv',
+    'nris-flnr-csv',
     'nrpti',
     'ocers-csv',
   ];

--- a/api/migrations/20210302190808-fixCsvImportRecordRoles.js
+++ b/api/migrations/20210302190808-fixCsvImportRecordRoles.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { ApplicationRoles } = require('./../src/utils/constants/misc');
+
+const CSV_SOURCE_DEFAULT_ROLES = [
+  { source: 'coors-csv', role: ApplicationRoles.ADMIN_FLNRO },
+  { source: 'era-csv', role: ApplicationRoles.ADMIN_FLNR_NRO },
+  { source: 'nris-flnr-csv', role: ApplicationRoles.ADMIN_FLNR_NRO },
+  { source: 'agri-cmdb-csv', role: ApplicationRoles.ADMIN_AGRI },
+  { source: 'agri-mis-csv', role: ApplicationRoles.ADMIN_AGRI },
+  { source: 'alc-csv', role: ApplicationRoles.ADMIN_ALC }
+];
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Updating CSV Import records permissions ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    await nrpti.updateMany(
+      {
+        sourceSystemRef: 'agri-mis'
+      },
+      { $set: { sourceSystemRef: 'agri-mis-csv' } }
+    );
+
+    await nrpti.updateMany(
+      {
+        sourceSystemRef: 'agri-cmdb'
+      },
+      { $set: { sourceSystemRef: 'agri-cmdb-csv' } }
+    );
+
+    await nrpti.updateMany(
+      {
+        sourceSystemRef: 'nro-inspections-csv'
+      },
+      { $set: { sourceSystemRef: 'nris-flnr-csv' } }
+    );
+
+    for (const csvRole of CSV_SOURCE_DEFAULT_ROLES) {
+      await nrpti.updateMany(
+        {
+          sourceSystemRef: csvRole.source
+        },
+        {
+          $addToSet: {
+            read: csvRole.role,
+            write: csvRole.role,
+            ['issuedTo.read']: csvRole.role,
+            ['issuedTo.write']: csvRole.role
+          }
+        }
+      );
+    }
+
+    console.log(`Finished updating CSV Import records permissions`);
+  } catch (err) {
+    console.log(`Error updating CSV Import records permissions: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1
+};

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -9,6 +9,7 @@ const utils = require('../../utils/constants/misc');
 const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_WF,
   utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ALC

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**
@@ -173,7 +176,7 @@ exports.createMaster = function(args, res, next, incomingObj, flavourIds) {
   incomingObj.sourceDateAdded && (administrativeSanction.sourceDateAdded = incomingObj.sourceDateAdded);
   incomingObj.sourceDateUpdated && (administrativeSanction.sourceDateUpdated = incomingObj.sourceDateUpdated);
   incomingObj.sourceSystemRef && (administrativeSanction.sourceSystemRef = incomingObj.sourceSystemRef);
-  incomingObj._sourceRefCoorsId && (administrativeSanction._sourceRefCoorsId = incomingObj._sourceRefCoorsId)
+  incomingObj._sourceRefCoorsId && (administrativeSanction._sourceRefCoorsId = incomingObj._sourceRefCoorsId);
   incomingObj.isNrcedPublished && (administrativeSanction.isNrcedPublished = incomingObj.isNrcedPublished);
   incomingObj.isLngPublished && (administrativeSanction.isLngPublished = incomingObj.isLngPublished);
 

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**
@@ -539,7 +542,7 @@ exports.createBCMI = function(args, res, next, incomingObj) {
   incomingObj._epicMilestoneId &&
     ObjectId.isValid(incomingObj._epicMilestoneId) &&
     (inspectionBCMI._epicMilestoneId = new ObjectId(incomingObj._epicMilestoneId));
-    incomingObj._sourceRefNrisId && (inspectionBCMI._sourceRefNrisId = incomingObj._sourceRefNrisId);
+  incomingObj._sourceRefNrisId && (inspectionBCMI._sourceRefNrisId = incomingObj._sourceRefNrisId);
   incomingObj.collectionId &&
     ObjectId.isValid(incomingObj.collectionId) &&
     (inspectionBCMI.collectionId = new ObjectId(incomingObj.collectionId));

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -9,6 +9,7 @@ const utils = require('../../utils/constants/misc');
 const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_WF,
   utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ALC

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -6,10 +6,13 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_FLNRO,
-                          utils.ApplicationRoles.ADMIN_AGRI,
-                          utils.ApplicationRoles.ADMIN_ENV_EPD,
-                          utils.ApplicationRoles.ADMIN_ALC];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_FLNRO,
+  utils.ApplicationRoles.ADMIN_FLNR_NRO,
+  utils.ApplicationRoles.ADMIN_AGRI,
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ALC
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/search.js
+++ b/api/src/controllers/search.js
@@ -273,7 +273,7 @@ const issuedToRedaction = function(roles) {
     $and: [
       { $eq: ['$skipRedact', false] },
       { $lt: ['$issuedToAge', 19] },
-      { $in: [{ $arrayElemAt: ['$fullRecord.sourceSystemRef', 0] }, ['nrpti', 'nro-inspections-csv']] }
+      { $in: [{ $arrayElemAt: ['$fullRecord.sourceSystemRef', 0] }, ['nrpti', 'nris-flnr-csv']] }
     ]
   };
 

--- a/api/src/importers/cmdb/base-record-utils.js
+++ b/api/src/importers/cmdb/base-record-utils.js
@@ -48,7 +48,7 @@ class BaseRecordUtils {
       _schemaName: this.recordType._schemaName,
       recordType: this.recordType.displayName,
 
-      sourceSystemRef: 'agri-cmdb'
+      sourceSystemRef: 'agri-cmdb-csv'
     };
   }
 

--- a/api/src/importers/cmdb/base-record-utils.test.js
+++ b/api/src/importers/cmdb/base-record-utils.test.js
@@ -28,7 +28,7 @@ describe('BaseRecordUtils', () => {
         _schemaName: 'Inspection',
         recordType: 'Inspection',
 
-        sourceSystemRef: 'agri-cmdb'
+        sourceSystemRef: 'agri-cmdb-csv'
       };
 
       const result = baseRecordUtils.transformRecord(csvRow, '');

--- a/api/src/importers/cmdb/inspection-utils.test.js
+++ b/api/src/importers/cmdb/inspection-utils.test.js
@@ -27,7 +27,7 @@ describe('transformRecord', () => {
       },
       description: descriptionString,
       outcomeDescription: '',
-      sourceSystemRef: 'agri-cmdb',
+      sourceSystemRef: 'agri-cmdb-csv',
       issuingAgency: 'Ministry of Agriculture',
       legislation: {
         act: 'Fish and Seafood Act',
@@ -73,7 +73,7 @@ describe('transformRecord', () => {
       location: 'Test Region',
       outcomeDescription: 'Compliance issue(s) identified under the following acts or regulations: FSLR-s.34',
 
-      sourceSystemRef: 'agri-cmdb'
+      sourceSystemRef: 'agri-cmdb-csv'
     });
   });
 });

--- a/api/src/importers/flnr/base-record-utils.js
+++ b/api/src/importers/flnr/base-record-utils.js
@@ -48,7 +48,7 @@ class BaseRecordUtils {
       _schemaName: this.recordType._schemaName,
       recordType: this.recordType.displayName,
 
-      sourceSystemRef: 'nro-inspections-csv'
+      sourceSystemRef: 'nris-flnr-csv'
     };
   }
 

--- a/api/src/importers/flnr/base-record-utils.test.js
+++ b/api/src/importers/flnr/base-record-utils.test.js
@@ -29,7 +29,7 @@ describe('BaseRecordUtils', () => {
         _schemaName: 'Inspection',
         recordType: 'Inspection',
 
-        sourceSystemRef: 'nro-inspections-csv'
+        sourceSystemRef: 'nris-flnr-csv'
       };
 
       const result = baseRecordUtils.transformRecord(csvRow);

--- a/api/src/importers/flnr/inspections-utils.test.js
+++ b/api/src/importers/flnr/inspections-utils.test.js
@@ -23,7 +23,7 @@ describe('transformRecord', () => {
       dateIssued: null,
       issuedTo: { dateOfBirth: null, firstName: '', lastName: '', middleName: '', type: 'Individual', companyName: '' },
       description: '-',
-      sourceSystemRef: 'nro-inspections-csv',
+      sourceSystemRef: 'nris-flnr-csv',
       issuingAgency: 'Natural Resource Officers',
       legislation: null,
       legislationDescription: 'Inspection to verify compliance with regulatory requirement',
@@ -71,7 +71,7 @@ describe('transformRecord', () => {
       _epicProjectId: ObjectID('588511d0aaecd9001b826192'),
       centroid: [-125, 50],
 
-      sourceSystemRef: 'nro-inspections-csv'
+      sourceSystemRef: 'nris-flnr-csv'
     });
   });
 });

--- a/api/src/importers/mis/base-record-utils.js
+++ b/api/src/importers/mis/base-record-utils.js
@@ -48,7 +48,7 @@ class BaseRecordUtils {
       _schemaName: this.recordType._schemaName,
       recordType: this.recordType.displayName,
 
-      sourceSystemRef: 'agri-mis'
+      sourceSystemRef: 'agri-mis-csv'
     };
   }
 

--- a/api/src/importers/mis/base-record-utils.test.js
+++ b/api/src/importers/mis/base-record-utils.test.js
@@ -28,7 +28,7 @@ describe('BaseRecordUtils', () => {
         _schemaName: 'Inspection',
         recordType: 'Inspection',
 
-        sourceSystemRef: 'agri-mis'
+        sourceSystemRef: 'agri-mis-csv'
       };
 
       const result = baseRecordUtils.transformRecord(csvRow);

--- a/api/src/importers/mis/inspection-utils.test.js
+++ b/api/src/importers/mis/inspection-utils.test.js
@@ -27,7 +27,7 @@ describe('transformRecord', () => {
       },
       description: descriptionString,
       outcomeDescription: '',
-      sourceSystemRef: 'agri-mis',
+      sourceSystemRef: 'agri-mis-csv',
       issuingAgency: 'Ministry of Agriculture',
       legislation: {
         act: 'Food Safety Act',
@@ -72,7 +72,7 @@ describe('transformRecord', () => {
       location: 'Test Region',
       outcomeDescription: 'Compliance issue - MR 123 Record Requirements',
 
-      sourceSystemRef: 'agri-mis'
+      sourceSystemRef: 'agri-mis-csv'
     });
   });
 });

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -375,6 +375,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - in: query
           name: _id
@@ -617,6 +618,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: task
           in: body
@@ -673,6 +675,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: recordId
           in: path
@@ -731,6 +734,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: recordId
           in: path
@@ -795,6 +799,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: recordId
           in: path
@@ -847,6 +852,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - in: body
           name: data
@@ -881,6 +887,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - in: body
           name: data
@@ -946,6 +953,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       consumes:
         - multipart/form-data
       parameters:
@@ -1022,6 +1030,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: recordId
           in: path
@@ -1079,6 +1088,7 @@ paths:
         - admin:agri
         - admin:env-epd
         - admin:alc
+        - admin:flnr-nro
       parameters:
         - name: docId
           in: path

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -6,6 +6,7 @@ const ApplicationRoles = {
   ADMIN_BCMI: 'admin:bcmi',
   ADMIN_ENV_EPD: 'admin:env-epd',
   ADMIN_FLNRO: 'admin:flnro',
+  ADMIN_FLNR_NRO: 'admin:flnr-nro',
   ADMIN_LNG: 'admin:lng',
   ADMIN_NRCED: 'admin:nrced',
   ADMIN_WF: 'admin:wf',
@@ -25,10 +26,11 @@ exports.ApplicationAdminRoles = [
 exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_WF,
   ApplicationRoles.ADMIN_FLNRO,
+  ApplicationRoles.ADMIN_FLNR_NRO,
   ApplicationRoles.ADMIN_AGRI,
   ApplicationRoles.ADMIN_ENV_EPD,
   ApplicationRoles.ADMIN_ALC
-]
+];
 
 exports.KeycloakDefaultRoles = {
   OFFLINE_ACCESS: 'offline_access',
@@ -145,5 +147,14 @@ exports.AUTHORIZED_PUBLISH_AGENCIES = [
   'Conservation Officer Service',
   'Conservation Officer Service (COS)',
   'EAO',
-  'Environmental Protection Division',
+  'Environmental Protection Division'
 ];
+
+exports.CSV_SOURCE_DEFAULT_ROLES = {
+  'coors-csv': [ApplicationRoles.ADMIN_FLNRO],
+  'era-csv': [ApplicationRoles.ADMIN_FLNR_NRO],
+  'nris-flnr-csv': [ApplicationRoles.ADMIN_FLNR_NRO],
+  'agri-cmdb-csv': [ApplicationRoles.ADMIN_AGRI],
+  'agri-mis-csv': [ApplicationRoles.ADMIN_AGRI],
+  'alc-csv': [ApplicationRoles.ADMIN_ALC]
+};


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-659

This PR also renamed some of the CSV `sourceSystemRef` values in order to standardize them between the frontend and backend.  A migration has been included to update existing data.


Create `admin:flnr-nro` record:
```
POST http://localhost:3000/api/record
{
    "orders": [
        {
            "recordName": "FLNR-NRO Role Test",
            "recordSubtype": "None",
            "issuingAgency": "Natural Resource Officers",
            "author": "BC Government",
            "issuedTo": {
                "type": "Individual",
                "companyName": null,
                "firstName": "Test",
                "middleName": "Middle",
                "lastName": "Name",
                "fullName": null,
                "dateOfBirth": null
            },
            "OrderNRCED": {
                "summary": "NRCED Summary",
                "addRole": "public"
            },
            "OrderLNG": {
                "description": "LNG Summary",
                "addRole": "public"
            }
        }
    ]
}
```
Verify success and record read/write issuedTo read/write have admin:flnr-nro role

Create a document in the record:
```
POST http://localhost:3000/api/record/{record_id}/document
form-data
fileName: test-file-name.pdf
upfile: browse to your file
```
Verify success document record has admin:flnr-nro role

To verify redaction, you can create a record in NRPTI from another user role and set the individual age to under 19.  Then do a search using:
```
GET http://localhost:3000/api/search?dataset=Order,Inspection,Certificate,Permit,SelfReport,Agreement,RestorativeJustice,Ticket,AdministrativePenalty,AdministrativeSanction,Warning,ConstructionPlan,ManagementPlan,CourtConviction,AnnualReport,CertificateAmendment,Correspondence,DamSafetyInspection,Report&pageNum=0&pageSize=25&sortBy=-dateAdded&fields=
```