### PR TITLE
NRPT-694: fixed time zone for CMDB

### DIFF
--- a/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/csv-constants.ts
@@ -432,7 +432,7 @@ export class CsvConstants {
    * @type {IDateField[]}
    * @memberof CsvConstants
    */
-  public static readonly cmdbInspectionsCsvDateFields: IDateField[] = [{ field: 'Date', format: 'MM/DD/YYYY' }];
+  public static readonly cmdbInspectionsCsvDateFields: IDateField[] = [{ field: 'Date Issued', format: 'MM/DD/YYYY' }];
 
   /**
    * Get the array of required csv headers for the provided dataSourceType and recordType.


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-694

After a lot of investigation and confusion as to the source of this issue,  I realized that there are different time offsets for daylight savings, so the -7 offset is correct for dates between ~ March and ~ November. To be specific the offset during daylight savings will be -7 and the rest of the time it will be -8, so the moment library is setting the offset correctly for CSV imports as far as I can tell. Because the CSV imports do  not run nightly like the other integrations, we don't have to worry about server side UTC time zone mixups. I did find one bug to fix the time zone on the CMDB CSV import,  and that is the only change in this PR. If I'm missing something drastic here please let me know.