### PR TITLE
NRPT-653 Add ENV-COS role and fix flavourId bug

### DIFF
--- a/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import-csv/import-csv.component.ts
@@ -27,6 +27,7 @@ const DEFAULT_CSV_TYPES = {
 
 const ROLE_DATA_SOURCES = {
   [Constants.ApplicationRoles.ADMIN_FLNRO]: ['coors-csv'],
+  [Constants.ApplicationRoles.ADMIN_ENV_COS]: ['coors-csv'],
   [Constants.ApplicationRoles.ADMIN_FLNR_NRO]: ['era-csv', 'nris-flnr-csv'],
   [Constants.ApplicationRoles.ADMIN_AGRI]: ['agri-cmdb-csv', 'agri-mis-csv'],
   [Constants.ApplicationRoles.ADMIN_ALC]: ['alc-csv']

--- a/angular/projects/admin-nrpti/src/app/import/import.component.ts
+++ b/angular/projects/admin-nrpti/src/app/import/import.component.ts
@@ -105,7 +105,8 @@ export class ImportComponent implements OnInit, OnDestroy {
       this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_FLNRO) ||
       this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_AGRI) ||
-      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC)
+      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ALC) ||
+      this.factoryService.userOnlyInLimitedRole(Constants.ApplicationRoles.ADMIN_ENV_COS)
     ) {
       this.showSourceSystem = false;
     }

--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -150,6 +150,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_BCMI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
@@ -179,6 +180,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.ADMINISTRATIVE_SANCTION] =
@@ -187,6 +189,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.AGREEMENT] = inBaseAdminRole(roles);
@@ -205,6 +208,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.CORRESPONDENCE] = inBaseAdminRole(roles);
@@ -217,6 +221,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.MANAGEMENT_PLAN] = inBaseAdminRole(roles);
@@ -228,6 +233,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_WF) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.PERMIT] = inBaseAdminRole(roles) || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
@@ -238,6 +244,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.REPORT] = inBaseAdminRole(roles);
@@ -250,6 +257,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
 
     this.menus[recordTypes.WARNING] =
@@ -258,6 +266,7 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_FLNR_NRO) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_AGRI) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
   }
 

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -11,6 +11,7 @@ export class Constants {
     ADMIN_FLNR_NRO: 'admin:flnr-nro',
     ADMIN_AGRI: 'admin:agri',
     ADMIN_ENV_EPD: 'admin:env-epd',
+    ADMIN_ENV_COS: 'admin:env-cos',
     ADMIN_ALC: 'admin:alc'
   };
 
@@ -20,6 +21,7 @@ export class Constants {
     Constants.ApplicationRoles.ADMIN_FLNR_NRO,
     Constants.ApplicationRoles.ADMIN_AGRI,
     Constants.ApplicationRoles.ADMIN_ENV_EPD,
+    Constants.ApplicationRoles.ADMIN_ENV_COS,
     Constants.ApplicationRoles.ADMIN_ALC
   ];
 
@@ -68,6 +70,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -77,6 +80,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -87,6 +91,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -95,6 +100,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -125,6 +131,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -133,6 +140,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -151,6 +159,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -159,6 +168,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -174,6 +184,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -183,6 +194,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -197,6 +209,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -205,6 +218,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -223,6 +237,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -231,6 +246,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     },
@@ -241,6 +257,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ],
       LNG: [
@@ -249,6 +266,7 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_FLNR_NRO,
         Constants.ApplicationRoles.ADMIN_AGRI,
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
+        Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ALC
       ]
     }
@@ -262,9 +280,8 @@ export class Constants {
     [Constants.ApplicationRoles.ADMIN_FLNR_NRO]: ['Natural Resource Officers'],
     [Constants.ApplicationRoles.ADMIN_AGRI]: ['Ministry of Agriculture'],
     [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Environmental Protection Division'],
-    [Constants.ApplicationRoles.ADMIN_ALC]: [
-      'Agriculture Land Commission'
-    ]
+    [Constants.ApplicationRoles.ADMIN_ENV_COS]: ['Conservation Officer Service (COS)'],
+    [Constants.ApplicationRoles.ADMIN_ALC]: ['Agriculture Land Commission']
   };
 
   public static readonly LngSectionPickList: string[] = [

--- a/api/migrations/20210311223603-renameConservationOfficerService.js
+++ b/api/migrations/20210311223603-renameConservationOfficerService.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Renaming Conservation Officer Service issuing agency ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    await nrpti.updateMany(
+      {
+        issuingAgency: 'Conservation Officer Service'
+      },
+      { $set: { issuingAgency: 'Conservation Officer Service (COS)' } }
+    );
+
+    console.log(`Finished renaming Conservation Officer Service issuing agency`);
+  } catch (err) {
+    console.log(`Error renaming Conservation Officer Service issuing agency: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1
+};

--- a/api/migrations/20210311230347-addEnvCosRoleToCoorsCsv.js
+++ b/api/migrations/20210311230347-addEnvCosRoleToCoorsCsv.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { ApplicationRoles } = require('./../src/utils/constants/misc');
+
+const CSV_SOURCE_DEFAULT_ROLES = [
+  { source: 'coors-csv', role: ApplicationRoles.ADMIN_ENV_COS }
+];
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Updating CSV Import records permissions ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    for (const csvRole of CSV_SOURCE_DEFAULT_ROLES) {
+      await nrpti.updateMany(
+        {
+          sourceSystemRef: csvRole.source
+        },
+        {
+          $addToSet: {
+            read: csvRole.role,
+            write: csvRole.role,
+            ['issuedTo.read']: csvRole.role,
+            ['issuedTo.write']: csvRole.role
+          }
+        }
+      );
+    }
+
+    console.log(`Finished updating CSV Import records permissions`);
+  } catch (err) {
+    console.log(`Error updating CSV Import records permissions: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  version: 1
+};

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -12,6 +12,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -12,6 +12,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -11,6 +11,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_FLNR_NRO,
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/put/administrative-penalty.js
+++ b/api/src/controllers/put/administrative-penalty.js
@@ -97,7 +97,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/administrative-sanction.js
+++ b/api/src/controllers/put/administrative-sanction.js
@@ -97,7 +97,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/agreement.js
+++ b/api/src/controllers/put/agreement.js
@@ -82,7 +82,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/annual-report.js
+++ b/api/src/controllers/put/annual-report.js
@@ -83,7 +83,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/certificate-amendment.js
+++ b/api/src/controllers/put/certificate-amendment.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/certificate.js
+++ b/api/src/controllers/put/certificate.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/construction-plan.js
+++ b/api/src/controllers/put/construction-plan.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/correspondence.js
+++ b/api/src/controllers/put/correspondence.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/court-conviction.js
+++ b/api/src/controllers/put/court-conviction.js
@@ -97,7 +97,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/dam-safety-inspection.js
+++ b/api/src/controllers/put/dam-safety-inspection.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/inspection.js
+++ b/api/src/controllers/put/inspection.js
@@ -98,7 +98,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
   
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/management-plan.js
+++ b/api/src/controllers/put/management-plan.js
@@ -83,7 +83,8 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/order.js
+++ b/api/src/controllers/put/order.js
@@ -98,7 +98,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/permit.js
+++ b/api/src/controllers/put/permit.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/report.js
+++ b/api/src/controllers/put/report.js
@@ -84,7 +84,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/restorative-justice.js
+++ b/api/src/controllers/put/restorative-justice.js
@@ -97,7 +97,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/self-report.js
+++ b/api/src/controllers/put/self-report.js
@@ -82,7 +82,8 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj, $addToSet: {}, $pull: {} };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/ticket.js
+++ b/api/src/controllers/put/ticket.js
@@ -98,7 +98,8 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/controllers/put/warning.js
+++ b/api/src/controllers/put/warning.js
@@ -97,7 +97,8 @@ exports.editMaster = function(args, res, next, incomingObj, flavourIds) {
   const updateObj = { $set: dotNotatedObj };
 
   if (flavourIds && flavourIds.length) {
-    updateObj.$set = {...updateObj.$set, _flavourRecords: flavourIds.map(id => new ObjectID(id))};
+    updateObj.$set = {...updateObj.$set };
+    updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };
   }
 
   return updateObj;

--- a/api/src/importers/coors/utils/csv-utils.test.js
+++ b/api/src/importers/coors/utils/csv-utils.test.js
@@ -46,7 +46,7 @@ describe('getIssuingAgency', () => {
     expect(result).toEqual(MiscConstants.CoorsCsvIssuingAgencies.BC_Parks);
   });
 
-  it('returns "Conservation Officer Service" if csvRow "case_number" does not start with a "P-"', async () => {
+  it('returns "Conservation Officer Service (COS)" if csvRow "case_number" does not start with a "P-"', async () => {
     const result = await CsvUtils.getIssuingAgency({ case_number: '123123' });
 
     expect(result).toEqual(MiscConstants.CoorsCsvIssuingAgencies.Conservation_Officer_Service);

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -376,6 +376,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - in: query
           name: _id
@@ -619,6 +620,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: task
           in: body
@@ -676,6 +678,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: recordId
           in: path
@@ -735,6 +738,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: recordId
           in: path
@@ -800,6 +804,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: recordId
           in: path
@@ -853,6 +858,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - in: body
           name: data
@@ -888,6 +894,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - in: body
           name: data
@@ -954,6 +961,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       consumes:
         - multipart/form-data
       parameters:
@@ -1031,6 +1039,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: recordId
           in: path
@@ -1089,6 +1098,7 @@ paths:
         - admin:env-epd
         - admin:alc
         - admin:flnr-nro
+        - admin:env-cos
       parameters:
         - name: docId
           in: path

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -4,7 +4,8 @@ const ApplicationRoles = {
   ADMIN: 'sysadmin',
   ADMIN_AGRI: 'admin:agri',
   ADMIN_BCMI: 'admin:bcmi',
-  ADMIN_ENV_EPD: 'admin:env-epd',
+  ADMIN_ENV_EPD: 'admin:env-epd',  
+  ADMIN_ENV_COS: 'admin:env-cos',
   ADMIN_FLNRO: 'admin:flnro',
   ADMIN_FLNR_NRO: 'admin:flnr-nro',
   ADMIN_LNG: 'admin:lng',
@@ -28,7 +29,8 @@ exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_FLNRO,
   ApplicationRoles.ADMIN_FLNR_NRO,
   ApplicationRoles.ADMIN_AGRI,
-  ApplicationRoles.ADMIN_ENV_EPD,
+  ApplicationRoles.ADMIN_ENV_EPD,  
+  ApplicationRoles.ADMIN_ENV_COS,
   ApplicationRoles.ADMIN_ALC
 ];
 
@@ -45,7 +47,7 @@ exports.IssuedToEntityTypes = {
 
 exports.CoorsCsvIssuingAgencies = {
   BC_Parks: 'BC Parks',
-  Conservation_Officer_Service: 'Conservation Officer Service'
+  Conservation_Officer_Service: 'Conservation Officer Service (COS)'
 };
 
 exports.EpicProjectIds = {
@@ -144,14 +146,13 @@ exports.PENALTY_VALUE_TYPES = ['Years', 'Months', 'Days', 'Dollars', 'Hours', 'O
 exports.AUTHORIZED_PUBLISH_AGENCIES = [
   'BC Parks',
   'Climate Action Secretariat',
-  'Conservation Officer Service',
   'Conservation Officer Service (COS)',
   'EAO',
   'Environmental Protection Division'
 ];
 
 exports.CSV_SOURCE_DEFAULT_ROLES = {
-  'coors-csv': [ApplicationRoles.ADMIN_FLNRO],
+  'coors-csv': [ApplicationRoles.ADMIN_FLNRO, ApplicationRoles.ADMIN_ENV_COS],
   'era-csv': [ApplicationRoles.ADMIN_FLNR_NRO],
   'nris-flnr-csv': [ApplicationRoles.ADMIN_FLNR_NRO],
   'agri-cmdb-csv': [ApplicationRoles.ADMIN_AGRI],


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-653

This PR adds the ENV-COS role to API and frontend.  It also includes the following:

- Migration and code fixes to change `Conservation Officer Service` to `Conservation Officer Service (COS)`
- Migration to add ENV-COS role to COORS import records
- Fixed bug in record type Put controllers where new flavour Ids are not appended to the existing array, but instead overwrites it.

Create `admin:env-cos` record:
```
POST http://localhost:3000/api/record
{
    "orders": [
        {
            "recordName": "ENV-COS Role Test",
            "recordSubtype": "None",
            "issuingAgency": "Conservation Officer Service (COS)",
            "author": "BC Government",
            "issuedTo": {
                "type": "Individual",
                "companyName": null,
                "firstName": "Test",
                "middleName": "Middle",
                "lastName": "Name",
                "fullName": null,
                "dateOfBirth": null
            },
            "OrderNRCED": {
                "summary": "NRCED Summary",
                "addRole": "public"
            },
            "OrderLNG": {
                "description": "LNG Summary",
                "addRole": "public"
            }
        }
    ]
}
```
Verify success and record read/write issuedTo read/write have admin:env-cos role

Create a document in the record:
```
POST http://localhost:3000/api/record/{record_id}/document
form-data
fileName: test-file-name.pdf
upfile: browse to your file
```
Verify success document record has admin:env-cos role

To verify redaction, you can create a record in NRPTI from another user role and set the individual age to under 19.  Then do a search using:
```
GET http://localhost:3000/api/search?dataset=Order,Inspection,Certificate,Permit,SelfReport,Agreement,RestorativeJustice,Ticket,AdministrativePenalty,AdministrativeSanction,Warning,ConstructionPlan,ManagementPlan,CourtConviction,AnnualReport,CertificateAmendment,Correspondence,DamSafetyInspection,Report&pageNum=0&pageSize=25&sortBy=-dateAdded&fields=
```