### PR TITLE
NRPT-697: added name redaction on issuingAgency and made datepicker years scrollable

### DIFF
--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.html
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.html
@@ -54,15 +54,17 @@
             <lib-date-picker
               [control]="myForm.controls.startDate"
               [isValidate]="true"
-              [reset]="resetDates">
-            </lib-date-picker>
+              [reset]="resetDates"
+              [minDate]="datepickerMinDate">
+              </lib-date-picker>
           </div>
           <div class="label-pair">
             <label for="endDate">End Date</label>
             <lib-date-picker
               [control]="myForm.controls.endDate"
               [isValidate]="true"
-              [reset]="resetDates">
+              [reset]="resetDates"
+              [minDate]="datepickerMinDate">
             </lib-date-picker>
           </div>
         </div>

--- a/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
+++ b/angular/projects/admin-nrpti/src/app/communications/communications.component.ts
@@ -8,6 +8,7 @@ import { CommunicationsPackage } from '../../../../common/src/app/models/master/
 import { MapInfo } from './../../../../common/src/app/models/master/common-models/map-info';
 import { FactoryService } from '../services/factory.service';
 import { DatePickerComponent, LoadingScreenService, Utils } from 'nrpti-angular-components';
+import { Constants } from '../utils/constants/misc';
 
 @Component({
   selector: 'communications-add',
@@ -39,6 +40,8 @@ export class CommunicationsComponent implements OnInit, OnDestroy {
     ' alignright alignjustify | bullist numlist outdent indent |' +
     ' removeformat | help' ]
   };
+
+  public datepickerMinDate = Constants.DatepickerMinDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-edit/mines-records-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-edit/mines-records-edit.component.html
@@ -60,7 +60,9 @@
           <lib-date-picker
             [control]="myForm.controls.recordDate"
             [isValidate]="true"
-            [isDisabled]="disableEdit">
+            [isDisabled]="disableEdit"
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/mines/mines-records-edit/mines-records-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/mines/mines-records-edit/mines-records-edit.component.ts
@@ -10,6 +10,7 @@ import { DialogService } from 'ng2-bootstrap-modal';
 import moment from 'moment';
 import { ConfirmComponent } from '../../confirm/confirm.component';
 import { takeUntil, catchError } from 'rxjs/operators';
+import { Constants } from '../../utils/constants/misc';
 
 @Component({
   selector: 'app-mines-records-edit',
@@ -52,6 +53,9 @@ export class MinesRecordsEditComponent implements OnInit {
 
   // record add edit state
   public recordState = null;
+
+  public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/news/news-add-edit/news-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/news/news-add-edit/news-add-edit.component.html
@@ -17,7 +17,8 @@
         <label class="font-weight-bold" for="date">Date:</label>
         <lib-date-picker
           [control]="myForm.controls.date"
-          [isValidate]="true">
+          [isValidate]="true"
+          [minDate]="datepickerMinDate">
         </lib-date-picker>
       </div>
       <div class="label-pair mr-5 mt-4">

--- a/angular/projects/admin-nrpti/src/app/news/news-add-edit/news-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/news/news-add-edit/news-add-edit.component.ts
@@ -8,6 +8,7 @@ import { Utils } from 'nrpti-angular-components';
 import { LoadingScreenService } from 'nrpti-angular-components';
 import { News } from '../../../../../common/src/app/models/master/common-models/news';
 import { FactoryService } from '../../services/factory.service';
+import { Constants } from '../../utils/constants/misc';
 
 @Component({
   selector: 'app-news-add-edit',
@@ -29,6 +30,8 @@ export class NewsAddEditComponent implements OnInit, OnDestroy {
   public lngFlavour = null;
   public lngPublishSubtext = 'Not published';
   public nrcedPublishSubtext = 'Not published';
+
+  public datepickerMinDate = Constants.DatepickerMinDate;
 
   // Pick lists
   public projects = [{

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -44,6 +44,7 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -43,6 +43,7 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/agreements/agreement-add-edit/agreement-add-edit.component.ts
@@ -35,6 +35,7 @@ export class AgreementAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
@@ -34,6 +34,7 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   // Documents
   public documents = [];

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
@@ -37,6 +37,7 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   // Documents
   public documents = [];

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -35,6 +35,7 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
   public agencies = Picklists.agencyPicklist;
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   // Documents
   public documents = [];

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -38,6 +38,7 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
@@ -41,6 +41,7 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -43,6 +43,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     private route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
@@ -41,6 +41,7 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -44,6 +44,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -38,6 +38,7 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -45,6 +45,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.html
@@ -45,6 +45,7 @@
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
             [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate"
             [isDisabled]="disableEdit">
           </lib-date-picker>
         </div>

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -42,6 +42,7 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
   public disableEdit = false;
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
@@ -41,6 +41,7 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -43,6 +43,7 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -40,6 +40,7 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -43,6 +43,7 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.html
@@ -38,7 +38,8 @@
           <lib-date-picker
             [control]="myForm.controls.dateIssued"
             [isValidate]="true"
-            [minDate]="datepickerMinDate">
+            [minDate]="datepickerMinDate"
+            [maxDate]="datepickerMaxDate">
           </lib-date-picker>
         </div>
         <div class="label-pair">

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -44,6 +44,7 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
   public documentsToDelete = [];
 
   public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(
     public route: ActivatedRoute,

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -29,8 +29,6 @@ export class Constants {
 
   // Datepicker is off by one so add one to the desired year.
   public static readonly DatepickerMinDate = new Date('1901');
-
-  // Need to set max date or the scroll wont work.
   public static readonly DatepickerMaxDate = new Date();
 
   public static readonly Menus: any = {

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -30,6 +30,9 @@ export class Constants {
   // Datepicker is off by one so add one to the desired year.
   public static readonly DatepickerMinDate = new Date('1901');
 
+  // Need to set max date or the scroll wont work.
+  public static readonly DatepickerMaxDate = new Date();
+
   public static readonly Menus: any = {
     ALL_MINES: 'All Mines',
     ALL_RECORDS: 'All Records',

--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.html
@@ -49,7 +49,9 @@
         <label for="dateOfBirth">Date of Birth</label>
         <lib-date-picker
           [control]="formGroup.controls.dateOfBirth"
-          [isValidate]="true">
+          [isValidate]="true"
+          [minDate]="datepickerMinDate"
+          [maxDate]="datepickerMaxDate">
         </lib-date-picker>
       </div>
     </ng-container>

--- a/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.ts
+++ b/angular/projects/common/src/app/entity/entity-add-edit/entity-add-edit.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, ChangeDetectorRef, SimpleChanges, OnChanges } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Picklists } from '../../utils/record-constants';
+import { Picklists, Constants } from '../../utils/record-constants';
 import { ENTITY_TYPE } from '../../models/master/common-models/entity';
 
 @Component({
@@ -19,6 +19,9 @@ export class EntityAddEditComponent implements OnInit, OnChanges {
   public UIType: ENTITY_TYPE = null;
 
   public anonymousText = '';
+
+  public datepickerMinDate = Constants.DatepickerMinDate;
+  public datepickerMaxDate = Constants.DatepickerMaxDate;
 
   constructor(public _changeDetectionRef: ChangeDetectorRef) {}
 

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -24,8 +24,6 @@ export class Constants {
 
   // Datepicker is off by one so add one to the desired year.
   public static readonly DatepickerMinDate = new Date('1901');
-
-  // Need to set max date or the scroll wont work.
   public static readonly DatepickerMaxDate = new Date();
 
 }

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -20,6 +20,15 @@ export class SearchSubsets {
   public static readonly recordName = 'Record Name';
 }
 
+export class Constants {
+
+  // Datepicker is off by one so add one to the desired year.
+  public static readonly DatepickerMinDate = new Date('1901');
+
+  // Need to set max date or the scroll wont work.
+  public static readonly DatepickerMaxDate = new Date();
+
+}
 /**
  * Schema lists for search.
  *

--- a/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.html
+++ b/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.html
@@ -25,12 +25,14 @@
               id="dateIssuedStartFilter"
               [control]="formGroup.get('dateIssuedStart')"
               [reset]="resetControls"
+              [minDate]="datepickerMinDate"
             ></lib-date-picker>
             <span class="date-separator align-self-center">To</span>
             <lib-date-picker
               id="dateIssuedEndFilter"
               [control]="formGroup.get('dateIssuedEnd')"
               [reset]="resetControls"
+              [minDate]="datepickerMinDate"
             ></lib-date-picker>
           </div>
         </div>

--- a/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/records-list/search-filters/search-filters.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ChangeDetectorRef, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormGroup } from '@angular/forms';
-import { Picklists } from '../../../../../../common/src/app/utils/record-constants';
+import { Picklists, Constants } from '../../../../../../common/src/app/utils/record-constants';
 import { IMutliSelectOption } from '../../../../../../common/src/app/autocomplete-multi-select/autocomplete-multi-select.component';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -49,6 +49,8 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   public activityTypeCount = 0;
   public actCount = 0;
   public regulationCount = 0;
+
+  public datepickerMinDate = Constants.DatepickerMinDate;
 
   constructor(public router: Router, public route: ActivatedRoute, private _changeDetectionRef: ChangeDetectorRef) {}
 

--- a/api/migrations/20210309170828-redactPublicNames.js
+++ b/api/migrations/20210309170828-redactPublicNames.js
@@ -36,15 +36,7 @@ exports.up = async function(db) {
       ...RecordTypeEnum.BCMI_SCHEMA_NAMES
     ];
 
-    const noPublishIssuingAgencies = [
-      'BC Wildfire Service',
-      'Ministry of Agriculture',
-      'Agricultural Land Commission',
-      'Ministry of Forests, Lands, and Natural Resource Operations',
-      'Natural Resource Officers',
-      'BC Oil and Gas Commission',
-      'Ministry of Energy, Mines and Low Carbon Innovation'
-    ]
+    const authorizedPublishAgencies = RecordTypeEnum.AUTHORIZED_PUBLISH_AGENCIES;
 
     const allRecords = await nrpti
     .find({
@@ -55,7 +47,7 @@ exports.up = async function(db) {
     const promises = allRecords.map(async (record) => {
 
       if ( record.issuingAgency
-        && noPublishIssuingAgencies.includes(record.issuingAgency)
+        && !authorizedPublishAgencies.includes(record.issuingAgency)
         && record.issuedTo
         && record.issuedTo.type === 'Individual'
         && record.issuedTo.read.includes('public') )

--- a/api/migrations/20210309170828-redactPublicNames.js
+++ b/api/migrations/20210309170828-redactPublicNames.js
@@ -1,0 +1,100 @@
+'use strict';
+
+let dbm;
+let type;
+let seed;
+
+const RecordTypeEnum = require('../src/utils/constants/misc');
+
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+
+    console.log('**** Started redacting individuals names ****');
+
+    const nrpti = await mClient.collection('nrpti');
+
+    const recordSchemas = [
+      ...RecordTypeEnum.MASTER_SCHEMA_NAMES,
+      ...RecordTypeEnum.LNG_SCHEMA_NAMES,
+      ...RecordTypeEnum.NRCED_SCHEMA_NAMES,
+      ...RecordTypeEnum.BCMI_SCHEMA_NAMES
+    ];
+
+    const noPublishIssuingAgencies = [
+      'BC Wildfire Service',
+      'Ministry of Agriculture',
+      'Agricultural Land Commission',
+      'Ministry of Forests, Lands, and Natural Resource Operations',
+      'Natural Resource Officers',
+      'BC Oil and Gas Commission',
+      'Ministry of Energy, Mines and Low Carbon Innovation'
+    ]
+
+    const allRecords = await nrpti
+    .find({
+      _schemaName: { $in: recordSchemas },
+    })
+    .toArray();
+
+    const promises = allRecords.map(async (record) => {
+
+      if ( record.issuingAgency
+        && noPublishIssuingAgencies.includes(record.issuingAgency)
+        && record.issuedTo
+        && record.issuedTo.type === 'Individual'
+        && record.issuedTo.read.includes('public') )
+      {
+
+        let newReadArray = [];
+        record.issuedTo.read.forEach(role => {
+          if (role !== 'public') {
+            newReadArray.push(role);
+          }
+        });
+
+        let redactedIssuedTo = record.issuedTo;
+        redactedIssuedTo.read = newReadArray;
+
+        return await nrpti.updateOne(
+          { _id: record._id },
+          { $set: { issuedTo: redactedIssuedTo }}
+        );
+      }
+    });
+
+    await Promise.all(promises);
+
+    console.log('**** Finished redacting individuals names ****');
+
+  } catch (error) {
+    console.error(`Migration did not complete. Error processing: ${error.message}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -13,6 +13,7 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
+  utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -13,7 +13,6 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_AGRI,
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
-  utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
   utils.ApplicationRoles.ADMIN_ALC
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;

--- a/api/src/controllers/put/administrative-penalty.js
+++ b/api/src/controllers/put/administrative-penalty.js
@@ -73,7 +73,7 @@ exports.editRecord = async function (args, res, next, incomingObj, overridePutPa
  */
 exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   delete incomingObj._id;
-  
+
   // Reject any changes to master permissions
   delete incomingObj.read;
   delete incomingObj.write;
@@ -200,7 +200,7 @@ exports.editLNG = function (args, res, next, incomingObj) {
  */
 exports.editNRCED = function (args, res, next, incomingObj) {
   delete incomingObj._id;
-  
+
   // Reject any changes to permissions
   // Publishing must be done via addRole or removeRole
   delete incomingObj.read;

--- a/api/src/controllers/put/inspection.js
+++ b/api/src/controllers/put/inspection.js
@@ -96,7 +96,7 @@ exports.editMaster = function (args, res, next, incomingObj, flavourIds) {
   const dotNotatedObj = PutUtils.getDotNotation(sanitizedObj);
 
   const updateObj = { $set: dotNotatedObj };
-  
+
   if (flavourIds && flavourIds.length) {
     updateObj.$set = {...updateObj.$set };
     updateObj.$addToSet = { _flavourRecords: flavourIds.map(id => new ObjectID(id)) };

--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -8,8 +8,6 @@ const constants = require('./constants/misc');
  *
  * @param {*} updateObj
  * @param {*} sanitizedObj
- * @param {*} flavourId
- * @param {*} schemaName
  * @returns updateObj
  */
 exports.applyBusinessLogicOnPut = function(updateObj, sanitizedObj) {
@@ -75,7 +73,7 @@ function isRecordConsideredAnonymous(record) {
   // if we don't have an 'issuedTo' attribute on the doc, it should not be
   // considered anonymous. Some record types do not include an issuedTo section
   // by default.
-  let isAnonymous = isIssuedToConsideredAnonymous(record.issuedTo, record.issuingAgency);
+  let isAnonymous = record.issuedTo ? isIssuedToConsideredAnonymous(record.issuedTo, record.issuingAgency) : false;
 
   if (record.sourceSystemRef && record.sourceSystemRef.toLowerCase() === 'ocers-csv') {
     // records imported from OCERS are not anonymous
@@ -98,19 +96,18 @@ exports.isRecordConsideredAnonymous = isRecordConsideredAnonymous;
  * A records issuedTo sub-object is considered anonymous if the following are true:
  * - The issuedTo.type indicates a person (Individual, IndividualCombined) AND
  * - The issuedTo.dateOfBirth is null OR the issuedTo.dateOfBirth indicates the person is less than 19 years of age. OR
- * - The user requesting publish does not have an application role with legislative authority to publish names ()
+ * - The issuingAgency does not have legislative authority to publish names
  *
  * Note: If insufficient information is provided, must assume anonymous.
  *
  * @param {*} issuedTo
  * @param {*} issuingAgency
- * @param {*} isNewRecord
  * @returns true if the issuedTo is considered anonymous, false otherwise.
  */
 function isIssuedToConsideredAnonymous(issuedTo, issuingAgency) {
   if (!issuedTo) {
     // can't determine if issuedTo is anonymous or not as it doesn't exist
-    // If we assume anonymous, then any record type that doesn't use issuedTo or issuingAgency
+    // If we assume anonymous, then any record type that doesn't use issuedTo
     // can never be published, so this must return false.
 
     return false;

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -25,17 +25,6 @@ exports.ApplicationAdminRoles = [
   ApplicationRoles.ADMIN_BCMI
 ];
 
-/**
- * TODO: add the following roles when created:
- *  - "Climate Action Secretariat"
- *  - "BC Parks"
- */
-exports.ApplicationRolesCanPublishNames = [
-  ApplicationRoles.ADMIN,
-  ApplicationRoles.ADMIN_ENV_EPD,
-  ApplicationRoles.ADMIN_ENV_COS
-];
-
 exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_WF,
   ApplicationRoles.ADMIN_FLNRO,

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -5,7 +5,7 @@ const ApplicationRoles = {
   ADMIN_AGRI: 'admin:agri',
   ADMIN_BCMI: 'admin:bcmi',
   ADMIN_ENV_EPD: 'admin:env-epd',
-  ADMIN_ENV_BCPARKS: 'admin:env-bcparks',  
+  ADMIN_ENV_BCPARKS: 'admin:env-bcparks',
   ADMIN_ENV_COS: 'admin:env-cos',
   ADMIN_FLNRO: 'admin:flnro',
   ADMIN_FLNR_NRO: 'admin:flnr-nro',
@@ -25,12 +25,23 @@ exports.ApplicationAdminRoles = [
   ApplicationRoles.ADMIN_BCMI
 ];
 
+/**
+ * TODO: add the following roles when created:
+ *  - "Climate Action Secretariat"
+ *  - "BC Parks"
+ */
+exports.ApplicationRolesCanPublishNames = [
+  ApplicationRoles.ADMIN,
+  ApplicationRoles.ADMIN_ENV_EPD,
+  ApplicationRoles.ADMIN_ENV_COS
+];
+
 exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_WF,
   ApplicationRoles.ADMIN_FLNRO,
   ApplicationRoles.ADMIN_FLNR_NRO,
   ApplicationRoles.ADMIN_AGRI,
-  ApplicationRoles.ADMIN_ENV_EPD,  
+  ApplicationRoles.ADMIN_ENV_EPD,
   ApplicationRoles.ADMIN_ENV_COS,
   ApplicationRoles.ADMIN_ENV_BCPARKS,
   ApplicationRoles.ADMIN_ALC

--- a/api/src/utils/put-utils.js
+++ b/api/src/utils/put-utils.js
@@ -170,13 +170,38 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
         entry[0].includes('BCMI') && (incomingObj.isBcmiPublished = false);
       }
 
-      if (flavourIncomingObj[entry[0]]._id) {
+      const flavourId = flavourIncomingObj[entry[0]]._id;
+
+      if (flavourId) {
+        //
+        const flavourRecordModel = mongoose.model(entry[0]);
+
+        const flavourExistingObject = await flavourRecordModel
+          .findOne({
+            _id: new ObjectId(flavourId)
+          });
+
+        const flavourExistingJSONObject = flavourExistingObject.toJSON();
+
+        // check if this object has issuingAgency and issuedTo to avoid adding null values to objects that don't have these fields
+        if (flavourExistingJSONObject.issuingAgency || flavourIncomingObj.issuingAgency) {
+          flavourIncomingObj.issuingAgency = flavourIncomingObj.issuingAgency ? flavourIncomingObj.issuingAgency : flavourExistingJSONObject.issuingAgency;
+        }
+
+        if (flavourExistingJSONObject.issuedTo || flavourIncomingObj.issuedTo) {
+          flavourIncomingObj.issuedTo = flavourIncomingObj.issuedTo ? flavourIncomingObj.issuedTo : flavourExistingJSONObject.issuedTo;
+          
+          // Reject any changes to permissions
+          // Must be decided through the business logic manager
+          delete flavourIncomingObj.issuedTo.read;
+          delete flavourIncomingObj.issuedTo.write;
+        }
+
         let flavourUpdateObj = entry[1](args, res, next, { ...flavourIncomingObj, ...flavourIncomingObj[entry[0]] });
         const Model = mongoose.model(entry[0]);
         flavourUpdateObj._master = new ObjectId(masterId);
 
         // Set flavour objectIds
-        const flavourId = flavourIncomingObj[entry[0]]._id;
         flavourIds.push(flavourId);
 
         promises.push(
@@ -362,7 +387,7 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
                               },
                               { new: true });
   }
- 
+
   let savedDocuments = null;
   try {
     savedDocuments = await BusinessLogicManager.updateDocumentRoles(

--- a/api/src/utils/put-utils.js
+++ b/api/src/utils/put-utils.js
@@ -173,7 +173,8 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
       const flavourId = flavourIncomingObj[entry[0]]._id;
 
       if (flavourId) {
-        //
+        // Grab the existing flavour object to get the issuingAgency and issuedTo if
+        // they don't exist in the flavourIncomingObj
         const flavourRecordModel = mongoose.model(entry[0]);
 
         const flavourExistingObject = await flavourRecordModel
@@ -190,7 +191,7 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
 
         if (flavourExistingJSONObject.issuedTo || flavourIncomingObj.issuedTo) {
           flavourIncomingObj.issuedTo = flavourIncomingObj.issuedTo ? flavourIncomingObj.issuedTo : flavourExistingJSONObject.issuedTo;
-          
+
           // Reject any changes to permissions
           // Must be decided through the business logic manager
           delete flavourIncomingObj.issuedTo.read;

--- a/api/src/utils/put-utils.js
+++ b/api/src/utils/put-utils.js
@@ -182,7 +182,7 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
             _id: new ObjectId(flavourId)
           });
 
-        const flavourExistingJSONObject = flavourExistingObject.toJSON();
+        const flavourExistingJSONObject = flavourExistingObject.toObject();
 
         // check if this object has issuingAgency and issuedTo to avoid adding null values to objects that don't have these fields
         if (flavourExistingJSONObject.issuingAgency || flavourIncomingObj.issuingAgency) {


### PR DESCRIPTION
[NRPT-697](https://bcmines.atlassian.net/browse/NRPT-697): this is a recreation of the last PR to cleanup the commits 

To test switch your role to admin:nrced or admin:lng only and create a record with issued to type individual, age over 19 and publish to NRCED or LNG. Verify that the created records have public in the base read, but not in the issued to read.

for the following issuing agencies you should see public in the issuedTo read array if the other age requirements are met:

`
exports.AUTHORIZED_PUBLISH_AGENCIES = [
  'BC Parks',
  'Climate Action Secretariat',
  'Conservation Officer Service (COS)',
  'EAO',
  'Environmental Protection Division'
];
`

Any edits should apply the correct roles to the issuedTo read array as well.

To test the migration, you can use:

`
db.nrpti.find({ issuingAgency: {$in: ["BC Oil and Gas Commission","Ministry of Energy, Mines and Low Carbon Innovation","Natural Resource Officers","Ministry of Forests, Lands, and Natural Resource Operations","Agricultural Land Commission","Ministry of Agriculture","BC Wildfire Service"]}, "issuedTo.type": "Individual","issuedTo.read": { $all: ["public"] }} ).pretty()
`

and then there should be none after you run the migration.

I also updated all of the datepickers to at least minDate vars. I checked with Kyle that dateIssued should not be able to be set in the future so added maxDate to those ones as well as the birthday datepickers.

Most of the datepickers are in admin nrpti, but there is one in public nrced 
