### PR TITLE
NRPT-699: publish names if source system is nris-epd

### DIFF
--- a/api/materialized_views/search/redactedRecordSubset.js
+++ b/api/materialized_views/search/redactedRecordSubset.js
@@ -20,7 +20,11 @@ async function update(defaultLog) {
   ];
 
   const redactCondition = {
-    $lt: ['$issuedToAge', 19]
+    $and: [
+      { $lt: ['$issuedToAge', 19] },
+      { $ne: [{ $arrayElemAt: ['$fullRecord.sourceSystemRef', 0] }, 'nris-epd']}
+    ]
+
   };
 
   const issuedToRedaction = [


### PR DESCRIPTION
- [NRPT-699](https://bcmines.atlassian.net/browse/NRPT-699)

To test:

Run redacted materialized view: `{"taskType":"updateMaterializedView", "materializedViewSubset":"redactedRecordSubset"}`

Query for Environment Management Act inspections issued to individuals 
`http://localhost:3000/api/public/search?dataset=InspectionNRCED&pageNum=0&pageSize=100&sortBy=-dateIssued&or[issuedTo.type]=Individual&or[issuedTo.type]=IndividualCombined&or[legislation.act]=Environmental%20Management%20Act`

Results should have unredacted issuedTo fields