### PR TITLE
NOBUG: removed publicGet and protectedGet from map-info-controller

### DIFF
--- a/api/src/controllers/map-info-controller.js
+++ b/api/src/controllers/map-info-controller.js
@@ -3,73 +3,12 @@ const queryActions = require('../utils/query-actions');
 const queryUtils = require('../utils/query-utils');
 const { ApplicationRoles } = require('../utils/constants/misc');
 const Post = require('../controllers/post/post');
-const Get = require('../controllers/get/get');
 const Delete = require('../controllers/delete/delete');
 const PutUtils = require('../utils/put-utils');
 const { mapLayerInfo: MapLayerInfo } = require('../models/index');
 
 exports.protectedOptions = function(args, res, next) {
   res.status(200).send();
-};
-
-exports.publicGet = async function(args, res, next) {
-  let mapInfoId = null;
-  let errorMsg = null;
-  if (args.swagger.params.mapInfoId && args.swagger.params.mapInfoId.value) {
-    mapInfoId = args.swagger.params.mapInfoId.value;
-  } else {
-    errorMsg = `publicGet - you must provide an id to get`;
-    defaultLog.info(errorMsg);
-    return queryActions.sendResponse(res, 400, errorMsg);
-  }
-
-  let obj = null;
-  try {
-    obj = await Get.findById(mapInfoId);
-  } catch (error) {
-    errorMsg = `publicGet - error getting map info: ${mapInfoId}`;
-    defaultLog.info(errorMsg);
-    defaultLog.debug(error);
-    return queryActions.sendResponse(res, 400, errorMsg);
-  }
-
-  if (!obj) {
-    errorMsg = `protectedGet - map info not found: ${mapInfoId}`;
-    defaultLog.info(errorMsg);
-    return queryActions.sendResponse(res, 404, errorMsg);
-  }
-
-  return queryActions.sendResponse(res, 200, obj);
-};
-
-exports.protectedGet = async function(args, res, next) {
-  let mapInfoId = null;
-  let errorMsg = null;
-  if (args.swagger.params.mapInfoId && args.swagger.params.mapInfoId.value) {
-    mapInfoId = args.swagger.params.mapInfoId.value;
-  } else {
-    errorMsg = `protectedGet - you must provide an id to get`;
-    defaultLog.info(errorMsg);
-    return queryActions.sendResponse(res, 400, errorMsg);
-  }
-
-  let obj = null;
-  try {
-    obj = await Get.findById(mapInfoId);
-  } catch (error) {
-    errorMsg = `protectedGet - error getting map info: ${mapInfoId}`;
-    defaultLog.info(errorMsg);
-    defaultLog.debug(error);
-    return queryActions.sendResponse(res, 400, errorMsg);
-  }
-
-  if (!obj) {
-    errorMsg = `protectedGet - map info not found: ${mapInfoId}`;
-    defaultLog.info(errorMsg);
-    return queryActions.sendResponse(res, 404, errorMsg);
-  }
-
-  return queryActions.sendResponse(res, 200, obj);
 };
 
 async function getMapLayerInfoSegment(segment) {

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -1900,30 +1900,6 @@ paths:
           description: 'Access Denied'
           schema:
             $ref: '#/definitions/Error'
-    get:
-      tags:
-        - map-info
-      summary: 'Get map info'
-      operationId: protectedGet
-      description: "Get a map info via _id."
-      security:
-        - Bearer: []
-      x-security-scopes:
-        - sysadmin
-        - admin:lng
-      parameters:
-        - name: mapInfoId
-          in: path
-          description: '_id of map info to get'
-          required: true
-          type: string
-      responses:
-        '200':
-          description: 'Success'
-        '403':
-          description: 'Access Denied'
-          schema:
-            $ref: '#/definitions/Error'
     put:
       tags:
         - map-info
@@ -1969,27 +1945,6 @@ paths:
         - name: mapInfoId
           in: path
           description: '_id of map info to delete'
-          required: true
-          type: string
-      responses:
-        '200':
-          description: 'Success'
-        '403':
-          description: 'Access Denied'
-          schema:
-            $ref: '#/definitions/Error'
-  /public/map-info/{mapInfoId}:
-    x-swagger-router-controller: map-info-controller
-    get:
-      tags:
-        - map-info
-      summary: 'Get map info'
-      operationId: publicGet
-      description: "Get a map info via _id."
-      parameters:
-        - name: mapInfoId
-          in: path
-          description: '_id of map info to get'
           required: true
           type: string
       responses:

--- a/api/test/tests/controllers/map-info-controller.test.js
+++ b/api/test/tests/controllers/map-info-controller.test.js
@@ -104,59 +104,6 @@ describe('Map-Info Controller Testing', () => {
       });
   });
 
-  test('Protectd get returns 404 with invalid id', async done => {
-    const roles = ['sysadmin'];
-    const invalidId = new ObjectId();
-    app.get(endpoint, (req, res) => {
-      const params = test_util.buildParams(req.query);
-      const paramsWithValues = test_util.createSwaggerParams(params, roles, testUser);
-      return mapInfo.protectedGet(paramsWithValues, res, next);
-    });
-
-    request(app)
-      .get(endpoint)
-      .query(qs.stringify({ mapInfoId: invalidId.toString() }))
-      .expect(404)
-      .end((err, res) => {
-        if (err) {
-          console.log(err);
-          return done(err);
-        }
-        expect(res.body).toMatch('protectedGet - map info not found: ');
-        return done();
-      });
-  });
-
-  test('Protectd get returns 200 with valid id', async done => {
-    const roles = ['sysadmin'];
-    app.get(endpoint, (req, res) => {
-      const params = test_util.buildParams(req.query);
-      const paramsWithValues = test_util.createSwaggerParams(params, roles, testUser);
-      return mapInfo.protectedGet(paramsWithValues, res, next);
-    });
-
-    request(app)
-      .get(endpoint)
-      .query(qs.stringify({ mapInfoId: testObjectId.toString() }))
-      .expect(200)
-      .end((err, res) => {
-        if (err) {
-          console.log(err);
-          return done(err);
-        }
-
-        expect(res.body._schemaName).toMatch('MapLayerInfo');
-        expect(res.body.location).toMatch(testObj.location);
-        expect(res.body.length).toMatch(testObj.length);
-        expect(res.body.description).toMatch(testObj.description);
-        expect(res.body.segment).toMatch(testObj.segment);
-        expect(res.body.read).toContain(ApplicationRoles.ADMIN);
-        expect(res.body.read).toContain(ApplicationRoles.ADMIN_LNG);
-        expect(res.body.read).toContain(ApplicationRoles.PUBLIC);
-        return done();
-      });
-  });
-
   test('Protectd put returns 200 and updates record values', async done => {
     const roles = ['sysadmin'];
     const updateObj = {


### PR DESCRIPTION
In the `map-info-controller`, `publicGet` and `protectedGet` were hardwired to a `findById` function that, if provided with the `_id`,  of any record, returned that record regardless of user role, record redaction or token authentication. Though it would be difficult for someone to obtain the `_id` of a sensitive record, they would be able to access that record easily if they hit these endpoints. 

`publicGet` and `protectedGet` are yet unused by any services in this project, so this PR removes them from `map-info-controller` and the swagger routes. 