### PR TITLE
NRPT-560 BCOGC Administrative Penalty display name

### DIFF
--- a/api/migrations/20210708211238-fixAdminPenaltyDisplayName.js
+++ b/api/migrations/20210708211238-fixAdminPenaltyDisplayName.js
@@ -4,9 +4,9 @@
   * We receive the dbmigrate dependency from dbmigrate initially.
   * This enables us to not have to rely on NODE_PATH.
   */
-exports.setup = function(options, seedLink) {};
+exports.setup = function (options, seedLink) { };
 
-exports.up = async function(db) {
+exports.up = async function (db) {
   console.log('**** Renaming BCOGC Administrative Penalty Display Names ****');
 
   const mClient = await db.connection.connect(db.connectionString, {
@@ -17,10 +17,12 @@ exports.up = async function(db) {
     const nrpti = await mClient.collection('nrpti');
 
     await nrpti.updateMany(
-      { $and: [
-        {_schemaName: 'AdministrativePenalty'},
-        {sourceSystemRef: 'bcogc'}
-    ]},
+      {
+        $and: [
+          { _schemaName: 'AdministrativePenalty' },
+          { sourceSystemRef: 'bcogc' }
+        ]
+      },
       { $set: { recordType: 'Administrative Penalty' } }
     );
 
@@ -34,7 +36,7 @@ exports.up = async function(db) {
   return null;
 };
 
-exports.down = function(db) {
+exports.down = function (db) {
   return null;
 };
 

--- a/api/migrations/20210708211238-fixAdminPenaltyDisplayName.js
+++ b/api/migrations/20210708211238-fixAdminPenaltyDisplayName.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {};
+
+exports.up = async function(db) {
+  console.log('**** Renaming BCOGC Administrative Penalty Display Names ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  try {
+    const nrpti = await mClient.collection('nrpti');
+
+    await nrpti.updateMany(
+      { $and: [
+        {_schemaName: 'AdministrativePenalty'},
+        {sourceSystemRef: 'bcogc'}
+    ]},
+      { $set: { recordType: 'Administrative Penalty' } }
+    );
+
+    console.log(`Finished renaming BCOGC Administrative Penalty Display Names`);
+  } catch (err) {
+    console.log(`Error renaming  BCOGC Administrative Penalty Display Names: ${err}`);
+  } finally {
+    mClient.close();
+  }
+
+  return null;
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/src/integrations/bcogc/administrative-penalties-utils.js
+++ b/api/src/integrations/bcogc/administrative-penalties-utils.js
@@ -37,7 +37,7 @@ class AdministrativePenalty extends BaseRecordUtils {
 
     const penalty = { ...super.transformRecord(csvRow) };
 
-    penalty['recordType'] = RECORD_TYPE.AdministrativePenalty._schemaName;
+    penalty['recordType'] = RECORD_TYPE.AdministrativePenalty.displayName;
     penalty['_sourceRefOgcPenaltyId'] = csvRow['Title'];
     penalty['author'] = 'BC Oil and Gas Commission';
     penalty['issuingAgency'] = 'BC Oil and Gas Commission';

--- a/api/src/integrations/bcogc/inspections-utils.js
+++ b/api/src/integrations/bcogc/inspections-utils.js
@@ -1,6 +1,7 @@
 const ObjectID = require('mongodb').ObjectID;
 const BaseRecordUtils = require('./base-record-utils');
 const CsvUtils = require('./utils/csv-utils');
+const RECORD_TYPE = require('../../utils/constants/record-type-enum');
 const moment = require('moment-timezone');
 const defaultLog = require('../../utils/logger')('bcogc-csv-orders-utils');
 

--- a/api/src/integrations/bcogc/inspections-utils.js
+++ b/api/src/integrations/bcogc/inspections-utils.js
@@ -42,7 +42,7 @@ class Inspections extends BaseRecordUtils {
     inspection['_sourceRefOgcInspectionId'] = csvRow['inspection number'] || null;
     inspection['_sourceRefOgcDeficiencyId'] = csvRow['deficiency objectid'] || null;
 
-    inspection['recordType'] = 'Inspection';
+    inspection['recordType'] = RECORD_TYPE.Inspection.displayName;
     try {
       inspection['dateIssued'] = csvRow['inspection date'] ? moment.tz(csvRow['inspection date'], "DD-MMM-YYYY", "America/Vancouver").toDate() : null;
     } catch (error) {

--- a/api/src/integrations/bcogc/orders-utils.js
+++ b/api/src/integrations/bcogc/orders-utils.js
@@ -38,7 +38,7 @@ class Orders extends BaseRecordUtils {
 
     const order = { ...super.transformRecord(csvRow) };
 
-    order['recordType'] = RECORD_TYPE.Order._schemaName;
+    order['recordType'] = RECORD_TYPE.Order.displayName;
     order['_sourceRefOgcOrderId'] = csvRow['Title'];
     order['author'] = 'BC Oil and Gas Commission';
     order['issuingAgency'] = 'BC Oil and Gas Commission';

--- a/api/src/integrations/bcogc/warnings-utils.js
+++ b/api/src/integrations/bcogc/warnings-utils.js
@@ -38,7 +38,7 @@ class Warning extends BaseRecordUtils {
 
     const warning = { ...super.transformRecord(csvRow) };
 
-    warning['recordType'] = RECORD_TYPE.Warning._schemaName;
+    warning['recordType'] = RECORD_TYPE.Warning.displayName;
     warning['_sourceRefOgcWarningId'] = csvRow['Title'];
     warning['author'] = 'BC Oil and Gas Commission';
     warning['issuingAgency'] = 'BC Oil and Gas Commission';


### PR DESCRIPTION
Issue appears to be limited to files imported from BCOGC. Importer was setting `recordType` equal to `_schemaName`, which has no spaces, so files were showing as having type 'AdministrativePenalty'. Changed `recordType` to equal `displayName` to so type is now 'Administrative Penalty'. Copied this change to other types for consistency, though no other types have spaces. Migration included to fix existing records.