### PR TITLE
NRPT-783 Fix $set and $addToSet conflict on _flavourRecords on PUT

### DIFF
--- a/api/src/utils/put-utils.js
+++ b/api/src/utils/put-utils.js
@@ -253,6 +253,10 @@ exports.editRecordWithFlavours = async function (args, res, next, incomingObj, e
     }
   }
 
+  // Remove _flavourRecords from updateObject.  New flavours are added through flavourIds.
+  // This is to prevent update object having _flavourRecords in both $set and $addToSet
+  delete incomingObj._flavourRecords;
+
   const MasterModel = mongoose.model(masterSchemaName);
   const updateMasterObj = editMaster(args, res, next, incomingObj, flavourIds);
 


### PR DESCRIPTION
This PR fixes issue when the update object for PUT contains `_flavourRecords` in both `$set` and `$addToSet`.  `_flavourRecords` is not required in `$set` because newly created flavour IDs are added via `flavourIds` parameter in `editMaster`

https://bcmines.atlassian.net/browse/NRPT-783