### PR TITLE
NRPT-813 Fixing error preventing NRPTI record add/edit

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-penalties/administrative-penalty-add-edit/administrative-penalty-add-edit.component.ts
@@ -534,12 +534,9 @@ export class AdministrativePenaltyAddEditComponent implements OnInit, OnDestroy 
     }
 
     this.myForm.controls.location.dirty && (administrativePenalty['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    administrativePenalty['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (administrativePenalty['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!administrativePenalty['centroid'][0] || !administrativePenalty['centroid'][1]) {
-      administrativePenalty['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/administrative-sanctions/administrative-sanction-add-edit/administrative-sanction-add-edit.component.ts
@@ -446,15 +446,12 @@ export class AdministrativeSanctionAddEditComponent implements OnInit, OnDestroy
     }
 
     this.myForm.controls.location.dirty && (administrativeSanction['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    administrativeSanction['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (administrativeSanction['centroid'] = [
         this.myForm.controls.longitude.value,
         this.myForm.controls.latitude.value
       ]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!administrativeSanction['centroid'][0] || !administrativeSanction['centroid'][1]) {
-      administrativeSanction['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/annual-reports/annual-report-add-edit/annual-report-add-edit.component.ts
@@ -202,7 +202,7 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
    * @returns {FormGroup[]} array of legislations FormGroup elements
    * @memberof AnnualReportAddEditComponent
    */
-   getLegislationsFormGroups(): FormGroup[] {
+  getLegislationsFormGroups(): FormGroup[] {
     if (!this.currentRecord || !this.currentRecord.legislation || !this.currentRecord.legislation.length) {
       return [];
     }
@@ -248,7 +248,7 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
    * @returns {object[]} array of legislations objects
    * @memberof AnnualReportAddEditComponent
    */
-   parseLegislationsFormGroups(): object[] {
+  parseLegislationsFormGroups(): object[] {
     const legislationsFormArray = this.myForm.get('legislations');
 
     if (!legislationsFormArray || !legislationsFormArray.value || !legislationsFormArray.value.length) {
@@ -328,12 +328,9 @@ export class AnnualReportAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (annualReport['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    annualReport['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (annualReport['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!annualReport['centroid'][0] || !annualReport['centroid'][1]) {
-      annualReport['centroid'] = [];
     }
 
     // BCMI flavour

--- a/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificate-amendments/certificate-amendments-add-edit/certificate-amendments-add-edit.component.ts
@@ -372,12 +372,9 @@ export class CertificateAmendmentAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (certificateAmendment['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    certificateAmendment['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (certificateAmendment['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!certificateAmendment['centroid'][0] || !certificateAmendment['centroid'][1]) {
-      certificateAmendment['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/certificates/certificate-add-edit/certificate-add-edit.component.ts
@@ -286,12 +286,9 @@ export class CertificateAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (certificate['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    certificate['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (certificate['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!certificate['centroid'][0] || !certificate['centroid'][1]) {
-      certificate['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/construction-plans/construction-plan-add-edit/construction-plan-add-edit.component.ts
@@ -50,7 +50,7 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
     private loadingScreenService: LoadingScreenService,
     private utils: Utils,
     private _changeDetectionRef: ChangeDetectorRef
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
@@ -211,12 +211,9 @@ export class ConstructionPlanAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (constructionPlan['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    constructionPlan['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (constructionPlan['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!constructionPlan['centroid'][0] || !constructionPlan['centroid'][1]) {
-      constructionPlan['centroid'] = [];
     }
 
     // LNG flavour

--- a/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/correspondences/correspondence-add-edit/correspondence-add-edit.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { FormGroup, FormControl, FormArray} from '@angular/forms';
+import { FormGroup, FormControl, FormArray } from '@angular/forms';
 import { Picklists, EpicProjectIds } from '../../../../../../common/src/app/utils/record-constants';
 import { FactoryService } from '../../../services/factory.service';
 import { Utils } from 'nrpti-angular-components';
@@ -367,12 +367,9 @@ export class CorrespondenceAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (correspondence['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    correspondence['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (correspondence['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!correspondence['centroid'][0] || !correspondence['centroid'][1]) {
-      correspondence['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/court-convictions/court-conviction-add-edit/court-conviction-add-edit.component.ts
@@ -57,7 +57,7 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
     protected _changeDetectionRef: ChangeDetectorRef,
     // @ts-ignore used by record-association component
     protected storeService: StoreService
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
@@ -516,12 +516,9 @@ export class CourtConvictionAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (courtConviction['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    courtConviction['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (courtConviction['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!courtConviction['centroid'][0] || !courtConviction['centroid'][1]) {
-      courtConviction['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/dam-safety-inspections/dam-safety-inspection-add-edit/dam-safety-inspection-add-edit.component.ts
@@ -369,12 +369,9 @@ export class DamSafetyInspectionAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (damSafetyInspection['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    damSafetyInspection['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (damSafetyInspection['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!damSafetyInspection['centroid'][0] || !damSafetyInspection['centroid'][1]) {
-      damSafetyInspection['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/inspections/inspection-add-edit/inspection-add-edit.component.ts
@@ -216,7 +216,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
           ((this.nrcedFlavour && this.nrcedFlavour.summary) ||
             (!this.nrcedFlavour && this.currentRecord.description))) ||
           '',
-          disabled: !this.factoryService.isFlavourEditEnabled(flavourEditRequiredRoles.NRCED)
+        disabled: !this.factoryService.isFlavourEditEnabled(flavourEditRequiredRoles.NRCED)
       }),
       publishNrced: new FormControl({
         value: (this.currentRecord && this.nrcedFlavour && this.nrcedFlavour.read.includes('public')) || false,
@@ -227,7 +227,7 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
       lngDescription: new FormControl({
         value: (this.currentRecord &&
           ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
-        '',
+          '',
         disabled: !this.factoryService.isFlavourEditEnabled(flavourEditRequiredRoles.LNG)
       }),
       publishLng: new FormControl({
@@ -398,12 +398,9 @@ export class InspectionAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (inspection['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    inspection['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (inspection['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!inspection['centroid'][0] || !inspection['centroid'][1]) {
-      inspection['centroid'] = [];
     }
 
     this.myForm.controls.outcomeStatus.dirty &&

--- a/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/management-plans/management-plan-add-edit/management-plan-add-edit.component.ts
@@ -50,7 +50,7 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
     private loadingScreenService: LoadingScreenService,
     private utils: Utils,
     private _changeDetectionRef: ChangeDetectorRef
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.route.data.pipe(takeUntil(this.ngUnsubscribe)).subscribe((res: any) => {
@@ -146,7 +146,7 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
         // default to using the master description if the flavour record does not exist
         (this.currentRecord &&
           ((this.lngFlavour && this.lngFlavour.description) || (!this.lngFlavour && this.currentRecord.description))) ||
-          ''
+        ''
       ),
       publishLng: new FormControl({
         value: (this.currentRecord && this.lngFlavour && this.lngFlavour.read.includes('public')) || false,
@@ -212,12 +212,9 @@ export class ManagementPlanAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (managementPlan['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    managementPlan['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (managementPlan['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!managementPlan['centroid'][0] || !managementPlan['centroid'][1]) {
-      managementPlan['centroid'] = [];
     }
 
     // LNG flavour

--- a/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/orders/order-add-edit/order-add-edit.component.ts
@@ -221,7 +221,7 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
           ((this.nrcedFlavour && this.nrcedFlavour.summary) ||
             (!this.nrcedFlavour && this.currentRecord.description))) ||
           '',
-          disabled: !this.factoryService.isFlavourEditEnabled(flavourEditRequiredRoles.NRCED)
+        disabled: !this.factoryService.isFlavourEditEnabled(flavourEditRequiredRoles.NRCED)
       }),
       publishNrced: new FormControl({
         value: (this.currentRecord && this.nrcedFlavour && this.nrcedFlavour.read.includes('public')) || false,
@@ -406,12 +406,9 @@ export class OrderAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (order['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    order['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (order['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!order['centroid'][0] || !order['centroid'][1]) {
-      order['centroid'] = [];
     }
 
     this.myForm.controls.outcomeStatus.dirty && (order['outcomeStatus'] = this.myForm.controls.outcomeStatus.value);

--- a/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/permits/permit-add-edit/permit-add-edit.component.ts
@@ -287,12 +287,9 @@ export class PermitAddEditComponent implements OnInit, OnDestroy {
       (permit['issuingAgency'] = this.myForm.controls.issuingAgency.value);
 
     this.myForm.controls.location.dirty && (permit['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    permit['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (permit['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!permit['centroid'][0] || !permit['centroid'][1]) {
-      permit['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/reports/report-add-edit/report-add-edit.component.ts
@@ -229,7 +229,7 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
    * @returns {FormGroup[]} array of legislations FormGroup elements
    * @memberof ReportAddEditComponent
    */
-   getLegislationsFormGroups(): FormGroup[] {
+  getLegislationsFormGroups(): FormGroup[] {
     if (!this.currentRecord || !this.currentRecord.legislation || !this.currentRecord.legislation.length) {
       return [];
     }
@@ -369,12 +369,9 @@ export class ReportAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (report['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    report['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (report['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!report['centroid'][0] || !report['centroid'][1]) {
-      report['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/restorative-justices/restorative-justice-add-edit/restorative-justice-add-edit.component.ts
@@ -447,14 +447,10 @@ export class RestorativeJusticeAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (restorativeJustice['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    restorativeJustice['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (restorativeJustice['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!restorativeJustice['centroid'][0] || !restorativeJustice['centroid'][1]) {
-      restorativeJustice['centroid'] = [];
     }
-
     // tslint:disable-next-line:max-line-length
     this.myForm.get('legislations').dirty && (restorativeJustice['legislation'] = this.parseLegislationsFormGroups());
 

--- a/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/self-reports/self-report-add-edit/self-report-add-edit.component.ts
@@ -281,12 +281,9 @@ export class SelfReportAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (selfReport['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    selfReport['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (selfReport['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!selfReport['centroid'][0] || !selfReport['centroid'][1]) {
-      selfReport['centroid'] = [];
     }
 
     // LNG flavour

--- a/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/tickets/ticket-add-edit/ticket-add-edit.component.ts
@@ -444,12 +444,9 @@ export class TicketAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (ticket['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    ticket['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (ticket['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!ticket['centroid'][0] || !ticket['centroid'][1]) {
-      ticket['centroid'] = [];
     }
 
     // tslint:disable-next-line:max-line-length

--- a/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
+++ b/angular/projects/admin-nrpti/src/app/records/warnings/warning-add-edit/warning-add-edit.component.ts
@@ -375,12 +375,9 @@ export class WarningAddEditComponent implements OnInit, OnDestroy {
     }
 
     this.myForm.controls.location.dirty && (warning['location'] = this.myForm.controls.location.value);
-    (this.myForm.controls.latitude.dirty || this.myForm.controls.longitude.dirty) &&
+    warning['centroid'] = [];
+    if (this.myForm.controls.latitude.value && this.myForm.controls.longitude.value) {
       (warning['centroid'] = [this.myForm.controls.longitude.value, this.myForm.controls.latitude.value]);
-
-    // Properly unset centroid if lon/lat are deleted
-    if (!warning['centroid'][0] || !warning['centroid'][1]) {
-      warning['centroid'] = [];
     }
 
     this.myForm.controls.outcomeStatus.dirty && (warning['outcomeStatus'] = this.myForm.controls.outcomeStatus.value);


### PR DESCRIPTION
Error when checking value of `centroid[ latitude, longitude ]` fields. Both `latitude` and `longitude` must be valid before creating `centroid[]`, otherwise `centroid = [ undefined, undefined]`
