### PR TITLE
NRPT-800: Adding unlistedMine to NRCED records

### DIFF
--- a/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/administrative-penalty-nrced.ts
@@ -12,6 +12,8 @@ import { RecordModel } from '../record-model-abstract';
 export class AdministrativePenaltyNRCED extends RecordModel {
   _epicProjectId: string;
   _epicMilestoneId: string;
+  unlistedMine: string;
+  unlistedMineType: string;
 
   dateIssued: Date;
   issuingAgency: string;
@@ -33,6 +35,8 @@ export class AdministrativePenaltyNRCED extends RecordModel {
 
     this._epicProjectId = (obj && obj._epicProjectId) || '';
     this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
+    this.unlistedMine = (obj && obj.unlistedMine) || '';
+    this.unlistedMineType = (obj && obj.unlistedMineType) || '';
 
     this.dateIssued = (obj && obj.dateIssued) || null;
     this.issuingAgency = (obj && obj.issuingAgency) || '';

--- a/angular/projects/common/src/app/models/nrced/court-conviction-nrced.ts
+++ b/angular/projects/common/src/app/models/nrced/court-conviction-nrced.ts
@@ -12,6 +12,8 @@ import { RecordModel } from '../record-model-abstract';
 export class CourtConvictionNRCED extends RecordModel {
   _epicProjectId: string;
   _epicMilestoneId: string;
+  unlistedMine: string;
+  unlistedMineType: string;
 
   recordSubtype: string;
   dateIssued: Date;
@@ -31,6 +33,9 @@ export class CourtConvictionNRCED extends RecordModel {
     super(obj);
 
     this._schemaName = 'CourtConvictionNRCED';
+
+    this.unlistedMine = (obj && obj.unlistedMine) || '';
+    this.unlistedMineType = (obj && obj.unlistedMineType) || '';
 
     this.recordSubtype = (obj && obj.recordSubtype) || null;
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.html
@@ -47,7 +47,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Site/Project</label>
-            <span class="grid-item-value__col" [innerHtml]="( data && data.projectName ) || '-' | projectLink"></span>
+            <span class="grid-item-value__col" [innerHtml]="siteName | projectLink"></span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>

--- a/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/administrative-penalties/administrative-penalty-detail/administrative-penalty-detail.component.ts
@@ -50,8 +50,8 @@ export class AdministrativePenaltyDetailComponent implements OnInit, OnChanges, 
     if (this.data) {
       if (this.data.projectName) {
         this.siteName = this.data.projectName;
-      } else if (this.data._master && this.data._master.unlistedMine) {
-        this.siteName = this.data._master.unlistedMine;
+      } else if (this.data.unlistedMine) {
+        this.siteName = this.data.unlistedMine;
       } else {
         this.siteName = '-';
       }

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.html
@@ -47,7 +47,7 @@
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Site/Project</label>
-            <span class="grid-item-value__col" [innerHtml]="(data && data.projectName) || '-' | projectLink"></span>
+            <span class="grid-item-value__col" [innerHtml]="siteName | projectLink"></span>
           </div>
           <div class="grid-item__row">
             <label class="grid-item-name">Lat/Long</label>

--- a/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.ts
+++ b/angular/projects/public-nrpti/src/app/records/court-convictions/court-conviction-detail/court-conviction-detail.component.ts
@@ -19,6 +19,7 @@ export class CourtConvictionDetailComponent implements OnInit, OnDestroy {
 
   public loading = true;
   public activeTab = 'detail';
+  public siteName = '-';
 
   constructor(
     public route: ActivatedRoute,
@@ -33,6 +34,7 @@ export class CourtConvictionDetailComponent implements OnInit, OnDestroy {
 
       // populate documents
       this.getDocuments();
+      this.setProjectName();
 
       this.loading = false;
       this._changeDetectionRef.detectChanges();
@@ -82,6 +84,19 @@ export class CourtConvictionDetailComponent implements OnInit, OnDestroy {
         });
       });
   }
+
+  setProjectName() {
+    if (this.data) {
+      if (this.data.projectName) {
+        this.siteName = this.data.projectName;
+      } else if (this.data.unlistedMine) {
+        this.siteName = this.data.unlistedMine;
+      } else {
+        this.siteName = '-';
+      }
+    }
+  }
+
 
   activateTab(tabLabel: string): void {
     this.activeTab = tabLabel;

--- a/api/migrations/20210825181937-unlistedMinesInNRCED.js
+++ b/api/migrations/20210825181937-unlistedMinesInNRCED.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// list all collections that require this migration
+const collections = ['nrpti', 'redacted_record_subset']
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) { };
+
+exports.up = async function (db) {
+  console.log('**** Adding unlistedMine fields to NRCED flavour records ****');
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+
+  for (let collection of collections) {
+
+    try {
+      let currentCollection = await mClient.collection(collection);
+
+      console.log(`Collection: ${collection}`);
+
+
+      // ensure all NRCED flavours of AdministrativePenalty and CourtConviction have unlistedMine & unlistedMineType fields
+
+      await currentCollection.updateMany(
+        {
+          $and: [
+            {
+              $or: [
+                { _schemaName: 'AdministrativePenaltyNRCED' },
+                { _schemaName: 'CourtConvictionNRCED' }
+              ]
+            },
+            {
+              unlistedMine: { $exists: false }
+            }
+          ]
+        },
+        {
+          $set: { unlistedMine: '' }
+        }
+      )
+
+      await currentCollection.updateMany(
+        {
+          $and: [
+            {
+              $or: [
+                { _schemaName: 'AdministrativePenaltyNRCED' },
+                { _schemaName: 'CourtConvictionNRCED' }
+              ]
+            },
+            {
+              unlistedMineType: { $exists: false }
+            }
+          ]
+        },
+        {
+          $set: { unlistedMineType: '' }
+        }
+      )
+
+    } catch (err) {
+      console.log(`Error adding unlistedMine fields (${collection}): ${err}`);
+    }
+  }
+
+  console.log(`**** Finished adding unlistedMine fields to NRCED flavour records ****`);
+  mClient.close();
+
+  return null;
+}
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -429,6 +429,8 @@ exports.createNRCED = function(args, res, next, incomingObj) {
   incomingObj.centroid && (administrativePenaltyNRCED.centroid = incomingObj.centroid);
   incomingObj.penalties && (administrativePenaltyNRCED.penalties = incomingObj.penalties);
   incomingObj.documents && (administrativePenaltyNRCED.documents = incomingObj.documents);
+  incomingObj.unlistedMine && (administrativePenaltyNRCED.unlistedMine = incomingObj.unlistedMine);
+  incomingObj.unlistedMineType && (administrativePenaltyNRCED.unlistedMineType = incomingObj.unlistedMineType);
 
   // set flavour data
   incomingObj.summary && (administrativePenaltyNRCED.summary = incomingObj.summary);

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -427,6 +427,8 @@ exports.createNRCED = function(args, res, next, incomingObj) {
   incomingObj.centroid && (courtConvictionNRCED.centroid = incomingObj.centroid);
   incomingObj.penalties && (courtConvictionNRCED.penalties = incomingObj.penalties);
   incomingObj.documents && (courtConvictionNRCED.documents = incomingObj.documents);
+  incomingObj.unlistedMine && (courtConvictionNRCED.unlistedMine = incomingObj.unlistedMine);
+  incomingObj.unlistedMineType && (courtConvictionNRCED.unlistedMineType = incomingObj.unlistedMineType);
 
   // set flavour data
   incomingObj.summary && (courtConvictionNRCED.summary = incomingObj.summary);

--- a/api/src/models/nrced/administrativePenalty-nrced.js
+++ b/api/src/models/nrced/administrativePenalty-nrced.js
@@ -40,6 +40,8 @@ module.exports = require('../../utils/model-schema-generator')(
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],
+    unlistedMine: {type: String, default: ''},
+    unlistedMineType: {type: String, default: ''},
     penalties: [
       {
         type: { type: String, default: '' },

--- a/api/src/models/nrced/courtConviction-nrced.js
+++ b/api/src/models/nrced/courtConviction-nrced.js
@@ -43,6 +43,8 @@ module.exports = require('../../utils/model-schema-generator')(
     projectName: { type: String, default: '' },
     location: { type: String, default: '' },
     centroid: [{ type: Number, default: 0.0 }],
+    unlistedMine: {type: String, default: ''},
+    unlistedMineType: {type: String, default: ''},
     penalties: [
       {
         type: { type: String, default: '' },


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-800

For AdministrativePenalty and CourtConviction NRCED flavours. Currently there are no records with `unlistedMine` or `unlistedMineType` records that are published to NRCED, so a migration was done only to ensure `AdministrativePenaltyNRCED` and `CourtConvictionNRCED` have blank `unlistedMine` and `unlistedMineType` fields. Publishing records to NRCED after this PR is merged will update the fields accordingly.