### PR TITLE
NRPT-795 certificate details page autopopulate

### DIFF
--- a/angular/projects/common/src/app/models/bcmi/certificate-bcmi.ts
+++ b/angular/projects/common/src/app/models/bcmi/certificate-bcmi.ts
@@ -3,7 +3,7 @@ import { Entity } from '../master/common-models/entity';
 import { RecordModel } from '../record-model-abstract';
 
 /**
- * Certificate Amendment BCMI data model.
+ * Certificate BCMI data model.
  *
  * @export
  * @class CertificateBCMI
@@ -28,6 +28,7 @@ export class CertificateBCMI extends RecordModel {
 
     this._epicProjectId = (obj && obj._epicProjectId) || '';
     this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
+    this._sourceRefId = (obj && obj._sourceRefId) || '';
 
     this.recordSubtype = (obj && obj.recordSubtype) || '';
     this.dateIssued = (obj && obj.dateIssued) || null;

--- a/angular/projects/common/src/app/models/bcmi/certificate-bcmi.ts
+++ b/angular/projects/common/src/app/models/bcmi/certificate-bcmi.ts
@@ -1,0 +1,45 @@
+import { Legislation } from '../master/common-models/legislation';
+import { Entity } from '../master/common-models/entity';
+import { RecordModel } from '../record-model-abstract';
+
+/**
+ * Certificate Amendment BCMI data model.
+ *
+ * @export
+ * @class CertificateBCMI
+ */
+export class CertificateBCMI extends RecordModel {
+  _epicProjectId: string;
+  _epicMilestoneId: string;
+  recordSubtype: string;
+  issuedTo: Entity;
+  dateIssued: Date;
+  issuingAgency: string;
+  legislation: Legislation[];
+  documents: object[];
+  description: string;
+  datePublished: Date;
+  publishedBy: string;
+
+  constructor(obj?: any) {
+    super(obj);
+
+    this._schemaName = 'CertificateBCMI';
+
+    this._epicProjectId = (obj && obj._epicProjectId) || '';
+    this._epicMilestoneId = (obj && obj._epicMilestoneId) || '';
+
+    this.recordSubtype = (obj && obj.recordSubtype) || '';
+    this.dateIssued = (obj && obj.dateIssued) || null;
+    this.issuingAgency = (obj && obj.issuingAgency) || '';
+    this.issuedTo = (obj && obj.issuedTo) || '';
+    this.legislation = (obj && obj.legislation && obj.legislation.length &&
+      obj.legislation.map(legislation => new Legislation(legislation))) || null;
+    this.documents = (obj && obj.documents) || [];
+
+    this.description = (obj && obj.description) || null;
+
+    this.datePublished = (obj && obj.datePublished) || null;
+    this.publishedBy = (obj && obj.publishedBy) || '';
+  }
+}

--- a/angular/projects/common/src/app/models/bcmi/index.ts
+++ b/angular/projects/common/src/app/models/bcmi/index.ts
@@ -1,5 +1,6 @@
 export * from './mine';
 export * from './collection-bcmi';
+export * from './certificate-bcmi';
 export * from './certificate-amendment-bcmi';
 export * from './dam-safety-inspection-bcmi';
 export * from './annual-report-bcmi';


### PR DESCRIPTION
This bug was caused by `records-utils` searching for the model `Certificate BCMI` in the common/src/app/models/bcmi directory, but the model did not exist, causing a syntax error. A model for this record type has been created and now the certificate details page will populate.