### PR TITLE
NOBUG: Fixing 3.47 days expiry => 5 minutes, as the comment suggests.

### DIFF
--- a/api/src/controllers/document-controller.js
+++ b/api/src/controllers/document-controller.js
@@ -540,7 +540,7 @@ async function getS3SignedURL(s3Key) {
   return s3.getSignedUrl('getObject', {
     Bucket: process.env.OBJECT_STORE_bucket_name,
     Key: s3Key,
-    Expires: 300000 // 5 minutes
+    Expires: 300 // 5 minutes
   });
 }
 


### PR DESCRIPTION
Drive-by code review.  The comment says the expiry is for 5 minutes, but the call to `getSignedURL` takes `seconds` as a parameter.