### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Natural Resources Public Transparency Initiative monorepo.  This supports the LN
 ### ClamAV
 All documents uploaded to the NRPTI system are first checked by the ClamAV anti-virus service and rejected if they do not pass.  See [ClamAV BCGov Repo](https://github.com/bcgov/clamav) for more information.
 
+# Running it locally
+
+Please see the READMEs in the `angular/` and `api/` subdirectories.
+
 # VSCode Extensions
 
 A list of recommended/helpful VS Code extensions.

--- a/angular/README.md
+++ b/angular/README.md
@@ -10,18 +10,18 @@ Angular front-ends for the Natural Resources Public Transparency Interface (NRPT
 
 # Prerequisites
 
-| Technology | Version | Website                 | Description                               |
-| ---------- | ------- | ----------------------- | ----------------------------------------- |
-| node       | 10.x.x  | https://nodejs.org/en/  | JavaScript Runtime                        |
-| npm        | 6.x.x   | https://www.npmjs.com/  | Node Package Manager                      |
-| ng         | 7.x.x   | https://cli.angular.io/ | Angular CLI                               |
-| yarn       | latest  | https://yarnpkg.com/en/ | Package Manager (more efficient than npm) |
+| Technology | Version         | Website                 | Description                               |
+| ---------- | --------------- | ----------------------- | ----------------------------------------- |
+| node       | 10.x.x - 14.x.x | https://nodejs.org/en/  | JavaScript Runtime                        |
+| npm        | latest          | https://www.npmjs.com/  | Node Package Manager                      |
+| ng         | 7.x.x           | https://cli.angular.io/ | Angular CLI                               |
+| yarn       | latest          | https://yarnpkg.com/en/ | Package Manager (more efficient than npm) |
 
-_Note: This app also requires [bcgov/nrpti/api](https://github.com/bcgov/nrpti/api) to handle its requests and authentication._
+_Note: This app also requires [`bcgov/nrpti/api`](https://github.com/bcgov/NRPTI/tree/master/api) to handle its requests and authentication._
 
 ## Install [Node + NPM](https://nodejs.org/en/)
 
-_Note: Windows users can use [NVM Windows](https://github.com/coreybutler/nvm-windows) to install and manage multiple versions of Node+Npm._
+_Note: NVM can be used to install anad manage multiple versions of NodeJS and nvm ([Windows version]((https://github.com/coreybutler/nvm-windows)), [Unix / Linux / macOS version](https://github.com/nvm-sh/nvm))._
 
 ## Install [Angular CLI](https://cli.angular.io/)
 
@@ -33,7 +33,12 @@ npm install -g @angular/cli
 
 ## Install [Yarn](https://yarnpkg.com/lang/en/docs/install/#alternatives-tab)
 
+Newer versions of NodeJS (14.9.x and 16.9.x) come bundled with Yarn. To enable:
+```sh
+corepack enable
 ```
+Otherwise:
+```sh
 npm install -g yarn
 ```
 

--- a/angular/README.md
+++ b/angular/README.md
@@ -21,7 +21,7 @@ _Note: This app also requires [`bcgov/nrpti/api`](https://github.com/bcgov/NRPTI
 
 ## Install [Node + NPM](https://nodejs.org/en/)
 
-_Note: NVM can be used to install anad manage multiple versions of NodeJS and nvm ([Windows version]((https://github.com/coreybutler/nvm-windows)), [Unix / Linux / macOS version](https://github.com/nvm-sh/nvm))._
+_Note: NVM can be used to install and manage multiple versions of NodeJS and npm ([Windows version]((https://github.com/coreybutler/nvm-windows)), [Unix / Linux / macOS version](https://github.com/nvm-sh/nvm))._
 
 ## Install [Angular CLI](https://cli.angular.io/)
 

--- a/api/README.md
+++ b/api/README.md
@@ -6,24 +6,29 @@ API for the Natural Resources Public Transparency Interface (NRPTI).
 
 # Prerequisites
 
-| Technology | Version | Website                                     | Description                               |
-|------------|---------|---------------------------------------------|-------------------------------------------|
-| node       | 10.x.x  | https://nodejs.org/en/                      | JavaScript Runtime                        |
-| npm        | 6.x.x   | https://www.npmjs.com/                      | Node Package Manager                      |
-| yarn       | latest  | https://yarnpkg.com/en/                     | Package Manager (more efficient than npm) |
-| mongodb    | 3.4+    | https://docs.mongodb.com/v3.2/installation/ | NoSQL database                            |
+| Technology | Version         | Website                                     | Description                               |
+|------------|-----------------|---------------------------------------------|-------------------------------------------|
+| node       | 10.x.x - 14.x.x | https://nodejs.org/en/                      | JavaScript Runtime                        |
+| npm        | latest          | https://www.npmjs.com/                      | Node Package Manager                      |
+| yarn       | latest          | https://yarnpkg.com/en/                     | Package Manager (more efficient than npm) |
+| mongodb    | 3.4 - 3.6       | https://docs.mongodb.com/v3.6/installation/ | NoSQL database                            |
 
-## Install [Node + NPM](https://nodejs.org/en/)
+## Install [NodeJS](https://nodejs.org/download/release/latest-v14.x/)
 
-_Note: Windows users can use [NVM Windows](https://github.com/coreybutler/nvm-windows) to install and manage multiple versions of Node+Npm._
+_Note: NVM can be used to install anad manage multiple versions of NodeJS and npm ([Windows version]((https://github.com/coreybutler/nvm-windows)), [Unix / Linux / macOS version](https://github.com/nvm-sh/nvm))._
 
 ## Install [Yarn](https://yarnpkg.com/lang/en/docs/install/#alternatives-tab)
 
+Newer versions of NodeJS (14.9.x and 16.9.x) come bundled with Yarn. To enable:
+```sh
+corepack enable
 ```
+Otherwise:
+```sh
 npm install -g yarn
 ```
 
-## Install [MongoDB](https://docs.mongodb.com/v3.2/installation/)
+## Install [MongoDB](https://docs.mongodb.com/v3.6/installation/)
 
 ## Environment Variables
 
@@ -43,11 +48,12 @@ For Core
 ```
 yarn install
 ```
-2. Run the app
+2. Start MongoDB
+3. Run the app
 ```
 npm start
 ```
-3. Go to http://localhost:3000/api/docs to verify that the application is running.
+4. Go to http://localhost:3000/api/docs to verify that the application is running.
 
     _Note: To change the default port edit `swagger.yaml`._
 


### PR DESCRIPTION
The install instructions are mostly unchanged. However, prerequisite version numbers are now expressed as a range (instead of a minimum version), as newer versions will break the application. 

Links were also added/fixed as required.

`npm` was also rewritten to simply require the latest version, instead of a specific one - this allows for the use of `corepack`, which greatly simplifies installing Yarn.