### PR TITLE
Add info to LNG homepage

### DIFF
--- a/.github/workflows/FrontEnd-Lint-Test.yml
+++ b/.github/workflows/FrontEnd-Lint-Test.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/angular/projects/public-lng/src/app/home/home.component.html
+++ b/angular/projects/public-lng/src/app/home/home.component.html
@@ -5,6 +5,12 @@
         <div id="home-content">
           <div id="left-column" class="content">
             <div id="overview">
+              <div role="alert" aria-live="polite" aria-atomic="true" class="alert alert-primary mb-3">
+                <h3>ATTENTION:</h3>
+                <p><strong>You have reached the location of the former LNG Regulatory Interface. Please note all authorizations,
+                      compliance updates and other regulatory matters are found by visiting the <a href="https://www.bcogc.ca">BC Oil and Gas Commission</a>
+                      and the <a href="https://www.projects.eao.gov.bc.ca/">BC Environmental Assessment Office’s Epic site</a></strong></p>
+              </div>
               <h3>OVERVIEW</h3>
               <p>
                 British Columbia has been the location of natural gas exploration and production for more than 50 years.


### PR DESCRIPTION
Adding redirect info to LNG mainpage.
Downgraded ubuntu to run Github Actions tests.