### PR TITLE
1060 new issuing agency

### DIFF
--- a/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
+++ b/angular/projects/admin-nrpti/src/app/services/keycloak.service.ts
@@ -184,7 +184,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.ADMINISTRATIVE_SANCTION] =
       inBaseAdminRole(roles) ||
@@ -194,7 +195,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.AGREEMENT] = inBaseAdminRole(roles);
 
@@ -214,7 +216,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.CORRESPONDENCE] = inBaseAdminRole(roles);
 
@@ -228,7 +231,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.MANAGEMENT_PLAN] = inBaseAdminRole(roles);
 
@@ -241,9 +245,13 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
-    this.menus[recordTypes.PERMIT] = inBaseAdminRole(roles) || roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD);
+    this.menus[recordTypes.PERMIT] =
+      inBaseAdminRole(roles) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.RESTORATIVE_JUSTICE] =
       inBaseAdminRole(roles) ||
@@ -253,7 +261,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.REPORT] = inBaseAdminRole(roles);
 
@@ -267,7 +276,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
 
     this.menus[recordTypes.WARNING] =
       inBaseAdminRole(roles) ||
@@ -277,7 +287,8 @@ export class KeycloakService {
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_EPD) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_COS) ||
       roles.includes(Constants.ApplicationRoles.ADMIN_ENV_BCPARKS) ||
-      roles.includes(Constants.ApplicationRoles.ADMIN_ALC);
+      roles.includes(Constants.ApplicationRoles.ADMIN_ALC) ||
+      roles.includes(Constants.ApplicationRoles.ADMIN_WLRS);
   }
 
   isMenuEnabled(menuName) {

--- a/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
+++ b/angular/projects/admin-nrpti/src/app/utils/constants/misc.ts
@@ -20,7 +20,8 @@ export class Constants {
     ADMIN_ENV_EPD: 'admin:env-epd',
     ADMIN_ENV_COS: 'admin:env-cos',
     ADMIN_ENV_BCPARKS: 'admin:env-bcparks',
-    ADMIN_ALC: 'admin:alc'
+    ADMIN_ALC: 'admin:alc',
+    ADMIN_WLRS: 'admin:wlrs'
   };
 
   public static readonly ApplicationLimitedRoles: string[] = [
@@ -31,7 +32,8 @@ export class Constants {
     Constants.ApplicationRoles.ADMIN_ENV_EPD,
     Constants.ApplicationRoles.ADMIN_ENV_COS,
     Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-    Constants.ApplicationRoles.ADMIN_ALC
+    Constants.ApplicationRoles.ADMIN_ALC,
+    Constants.ApplicationRoles.ADMIN_WLRS
   ];
 
   // Datepicker is off by one so add one to the desired year.
@@ -82,7 +84,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -93,7 +96,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       BCMI: [Constants.ApplicationRoles.ADMIN_LNG, Constants.ApplicationRoles.ADMIN_BCMI]
     },
@@ -106,7 +110,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -116,7 +121,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     },
     AGREEMENT: {
@@ -148,7 +154,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -158,7 +165,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       BCMI: [Constants.ApplicationRoles.ADMIN_BCMI]
     },
@@ -179,7 +187,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -189,7 +198,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     },
     MANAGEMENT_PLAN: {
@@ -206,7 +216,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -217,7 +228,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     },
     PERMIT: {
@@ -233,7 +245,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -243,7 +256,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     },
     REPORT: {
@@ -263,7 +277,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -273,7 +288,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     },
     WARNING: {
@@ -285,7 +301,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ],
       LNG: [
         Constants.ApplicationRoles.ADMIN_LNG,
@@ -295,7 +312,8 @@ export class Constants {
         Constants.ApplicationRoles.ADMIN_ENV_EPD,
         Constants.ApplicationRoles.ADMIN_ENV_COS,
         Constants.ApplicationRoles.ADMIN_ENV_BCPARKS,
-        Constants.ApplicationRoles.ADMIN_ALC
+        Constants.ApplicationRoles.ADMIN_ALC,
+        Constants.ApplicationRoles.ADMIN_WLRS
       ]
     }
   };
@@ -310,7 +328,8 @@ export class Constants {
     [Constants.ApplicationRoles.ADMIN_ENV_EPD]: ['Ministry of Environment and Climate Change Strategy'],
     [Constants.ApplicationRoles.ADMIN_ENV_COS]: ['Conservation Officer Service'],
     [Constants.ApplicationRoles.ADMIN_ENV_BCPARKS]: ['BC Parks'],
-    [Constants.ApplicationRoles.ADMIN_ALC]: ['Agriculture Land Commission']
+    [Constants.ApplicationRoles.ADMIN_ALC]: ['Agriculture Land Commission'],
+    [Constants.ApplicationRoles.ADMIN_WLRS]: ['Ministry of Water, Land and Resource Stewardship']
   };
 
   public static readonly LngSectionPickList: string[] = [

--- a/angular/projects/common/src/app/utils/record-constants.ts
+++ b/angular/projects/common/src/app/utils/record-constants.ts
@@ -174,7 +174,8 @@ export class Picklists {
     'Ministry of Energy Mines and Low Carbon Innovation',
     'Ministry of Environment and Climate Change Strategy',
     'Ministry of Forests',
-    'Natural Resource Officers'
+    'Ministry of Water, Land and Resource Stewardship',
+    'Natural Resource Officers',
   ];
 
   public static readonly entityTypePicklist = ['Company', 'Individual'];

--- a/angular/projects/global/src/lib/utils/utils.ts
+++ b/angular/projects/global/src/lib/utils/utils.ts
@@ -11,7 +11,8 @@ const ApplicationAgencies = {
   AGENCY_LNG: 'LNG Secretariat',
   AGENCY_AGRI: 'Ministry of Agriculture and Food',
   AGENCY_FLNRO: 'Ministry of Forests',
-  AGENCY_FLNR_NRO: 'Natural Resource Officers'
+  AGENCY_FLNR_NRO: 'Natural Resource Officers',
+  AGENCY_WLRS: 'Ministry of Water, Land and Resource Stewardship',
 };
 
 /**

--- a/api/migrations/20230713184323-addWLRSRole.js
+++ b/api/migrations/20230713184323-addWLRSRole.js
@@ -17,9 +17,9 @@ exports.setup = function (options, seedLink) {
 };
 
 exports.up = async function (db) {
-  // Add wildfire role to the read array and write array of records that issuing agency = BC Wildfire Service
-  // Add wildfire to issued to read if type is individual
-  console.log('**** Adding wildfire role ****');
+  // Add wlrs role to the read array and write array of records that issuing agency = Ministry of Water, Land and Resource Stewardship
+  // Add wlrs to issued to read if type is individual
+  console.log('**** Adding wlrs role ****');
   const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
   const nrpti = await mClient.collection('nrpti');
 
@@ -102,7 +102,7 @@ exports.up = async function (db) {
       { $addToSet: { read: 'admin:wlrs' } }
     );
   } catch (error) {
-    console.log('Error updating records read array with wildfire role');
+    console.log('Error updating records read array with wlrs role');
   }
 
   mClient.close();

--- a/api/migrations/20230713184323-addWLRSRole.js
+++ b/api/migrations/20230713184323-addWLRSRole.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+var ObjectId = require('mongodb').ObjectID
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  // Add wildfire role to the read array and write array of records that issuing agency = BC Wildfire Service
+  // Add wildfire to issued to read if type is individual
+  console.log('**** Adding wildfire role ****');
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+  const nrpti = await mClient.collection('nrpti');
+
+  const allRecordSchemaNames = [
+    'Order',
+    'Inspection',
+    'Certificate',
+    'Permit',
+    'SelfReport',
+    'Agreement',
+    'RestorativeJustice',
+    'Ticket',
+    'AdministrativePenalty',
+    'AdministrativeSanction',
+    'Warning',
+    'ConstructionPlan',
+    'ManagementPlan',
+    'CourtConviction',
+    'AnnualReport',
+    'CertificateAmendment',
+    'Correspondence',
+    'DamSafetyInspection',
+    'Report',
+    'ActivityLNG',
+    'AdministrativePenaltyLNG',
+    'AdministrativeSanctionLNG',
+    'AgreementLNG',
+    'CertificateLNG',
+    'CertificateAmendmentLNG',
+    'ConstructionPlanLNG',
+    'CourtConvictionLNG',
+    'InspectionLNG',
+    'ManagementPlanLNG',
+    'OrderLNG',
+    'PermitLNG',
+    'RestorativeJusticeLNG',
+    'SelfReportLNG',
+    'TicketLNG',
+    'WarningLNG',
+    'AnnualReportBCMI',
+    'CertificateBCMI',
+    'CertificateAmendmentBCMI',
+    'ConstructionPlanBCMI',
+    'CorrespondenceBCMI',
+    'DamSafetyInspectionBCMI',
+    'InspectionBCMI',
+    'ManagementPlanBCMI',
+    'OrderBCMI',
+    'PermitBCMI',
+    'ReportBCMI',
+    'OrderNRCED',
+    'InspectionNRCED',
+    'RestorativeJusticeNRCED',
+    'AdministrativePenaltyNRCED',
+    'AdministrativeSanctionNRCED',
+    'TicketNRCED',
+    'WarningNRCED',
+    'CourtConvictionNRCED',
+    'CorrespondenceNRCED',
+    'DamSafetyInspectionNRCED',
+    'ReportNRCED'
+  ];
+
+  try {
+    await nrpti.updateMany(
+      {
+        $and: [
+          {
+            _schemaName: {
+              $in: allRecordSchemaNames
+            }
+          },
+          {
+            read: {
+              $in: ['public']
+            }
+          }
+        ]
+      },
+      { $addToSet: { read: 'admin:wlrs' } }
+    );
+  } catch (error) {
+    console.log('Error updating records read array with wildfire role');
+  }
+
+  mClient.close();
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/src/controllers/post/administrative-penalty.js
+++ b/api/src/controllers/post/administrative-penalty.js
@@ -14,7 +14,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/administrative-sanction.js
+++ b/api/src/controllers/post/administrative-sanction.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/court-conviction.js
+++ b/api/src/controllers/post/court-conviction.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/order.js
+++ b/api/src/controllers/post/order.js
@@ -14,7 +14,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/permit.js
+++ b/api/src/controllers/post/permit.js
@@ -5,7 +5,10 @@ const { userHasValidRoles } = require('../../utils/auth-utils');
 const utils = require('../../utils/constants/misc');
 
 // Additional admin roles that can create this record, such as admin:wf or admin:flnro
-const ADDITIONAL_ROLES = [utils.ApplicationRoles.ADMIN_ENV_EPD];
+const ADDITIONAL_ROLES = [
+  utils.ApplicationRoles.ADMIN_ENV_EPD,
+  utils.ApplicationRoles.ADMIN_WLRS
+];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 
 /**

--- a/api/src/controllers/post/restorative-justice.js
+++ b/api/src/controllers/post/restorative-justice.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/ticket.js
+++ b/api/src/controllers/post/ticket.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/controllers/post/warning.js
+++ b/api/src/controllers/post/warning.js
@@ -13,7 +13,8 @@ const ADDITIONAL_ROLES = [
   utils.ApplicationRoles.ADMIN_ENV_EPD,
   utils.ApplicationRoles.ADMIN_ENV_COS,
   utils.ApplicationRoles.ADMIN_ENV_BCPARKS,
-  utils.ApplicationRoles.ADMIN_ALC
+  utils.ApplicationRoles.ADMIN_ALC,
+  utils.ApplicationRoles.ADMIN_WLRS
 ];
 exports.ADDITIONAL_ROLES = ADDITIONAL_ROLES;
 

--- a/api/src/swagger/swagger.yaml
+++ b/api/src/swagger/swagger.yaml
@@ -328,6 +328,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: app
           in: path
@@ -388,6 +389,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: app
           in: path
@@ -444,6 +446,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -497,6 +500,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -556,6 +560,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -609,6 +614,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -855,6 +861,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:flnro
         - admin:agri
         - admin:env-epd
@@ -912,6 +919,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -973,6 +981,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1040,6 +1049,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1095,6 +1105,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1132,6 +1143,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1200,6 +1212,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1279,6 +1292,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1339,6 +1353,7 @@ paths:
         - admin:lng
         - admin:nrced
         - admin:bcmi
+        - admin:wlrs
         - admin:wf
         - admin:flnro
         - admin:agri
@@ -1391,6 +1406,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: news
           in: body
@@ -1439,6 +1455,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: newsId
           in: path
@@ -1465,6 +1482,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: newsId
           in: path
@@ -1497,6 +1515,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: newsId
           in: path
@@ -1541,6 +1560,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mine
           in: body
@@ -1589,6 +1609,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mineId
           in: path
@@ -1615,6 +1636,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mineId
           in: path
@@ -1647,6 +1669,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mineId
           in: path
@@ -1694,6 +1717,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mineId
           in: path
@@ -1741,6 +1765,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: mineId
           in: path
@@ -1785,6 +1810,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: collection
           in: body
@@ -1833,6 +1859,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: collectionId
           in: path
@@ -1859,6 +1886,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: collectionId
           in: path
@@ -1891,6 +1919,7 @@ paths:
         - admin:nrced
         - admin:lng
         - admin:bcmi
+        - admin:wlrs
       parameters:
         - name: collectionId
           in: path
@@ -1933,6 +1962,7 @@ paths:
       x-security-scopes:
         - sysadmin
         - admin:lng
+        - admin:wlrs
       parameters:
         - name: mapInfo
           in: body
@@ -1979,6 +2009,7 @@ paths:
       x-security-scopes:
         - sysadmin
         - admin:lng
+        - admin:wlrs
       parameters:
         - name: mapInfoId
           in: path
@@ -2009,6 +2040,7 @@ paths:
       x-security-scopes:
         - sysadmin
         - admin:lng
+        - admin:wlrs
       parameters:
         - name: mapInfoId
           in: path

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -13,6 +13,7 @@ const ApplicationRoles = {
   ADMIN_NRCED: 'admin:nrced',
   ADMIN_WF: 'admin:wf',
   ADMIN_ALC: 'admin:alc',
+  ADMIN_WLRS: 'admin:wlrs',
   PUBLIC: 'public'
 };
 
@@ -31,7 +32,8 @@ const ApplicationAgencies = {
   AGENCY_LNG: 'LNG Secretariat',
   AGENCY_AGRI: 'Ministry of Agriculture and Food',
   AGENCY_FLNRO: 'Ministry of Forests',
-  AGENCY_FLNR_NRO: 'Natural Resource Officers'
+  AGENCY_FLNR_NRO: 'Natural Resource Officers',
+  AGENCY_WLRS: 'Ministry of Water, Land and Resource Stewardship'
 };
 
 exports.ApplicationAgencies = ApplicationAgencies;
@@ -51,7 +53,8 @@ exports.ApplicationLimitedAdminRoles = [
   ApplicationRoles.ADMIN_ENV_EPD,
   ApplicationRoles.ADMIN_ENV_COS,
   ApplicationRoles.ADMIN_ENV_BCPARKS,
-  ApplicationRoles.ADMIN_ALC
+  ApplicationRoles.ADMIN_ALC,
+  ApplicationRoles.ADMIN_WLRS
 ];
 
 exports.KeycloakDefaultRoles = {


### PR DESCRIPTION
- Add a new admin:wlrs role to NRPTI for the Ministry of Water, Land and Resource Stewardship (WLRS) users.
  - This allows users with the admin:wlrs role to create and view records records; records created with this role are only able to assign WLRS as the Issuing Agency.
  - By default, admin:wlrs roles can't see Entity information (personal information) unless they created the record.
  - Add a migration to update the roles in the db so admin:wlrs can read existing records.