### PR TITLE
fix issuing agency, add check for water sus act

### DIFF
--- a/api/src/importers/coors/utils/csv-utils.js
+++ b/api/src/importers/coors/utils/csv-utils.js
@@ -38,12 +38,24 @@ exports.getIssuingAgency = function(csvRow) {
     return null;
   }
 
-
   // csv import specific business logic, see https://bcmines.atlassian.net/browse/NRPT-78
   if (caseNum.toLowerCase().startsWith('p-')) {
     return MiscConstants.CoorsCsvIssuingAgencies.BC_Parks;
   }
+  
+  let act = '';
+  if (csvRow['act']) {
+    act = csvRow['act'];
+  } else {
+    return null;
+  }
 
+  // Act == Water Sustainability Act, in which case Issuing Agency = BC Energy Regulator
+  if (act.toLowerCase() == 'water sustainability act') {
+    return MiscConstants.CoorsCsvIssuingAgencies.Water_Sustainability_Act;
+  }
+
+  // Otherwise the issuing agency defaults to Conservation Officer Service
   return MiscConstants.CoorsCsvIssuingAgencies.Conservation_Officer_Service;
 };
 

--- a/api/src/utils/constants/misc.js
+++ b/api/src/utils/constants/misc.js
@@ -27,7 +27,7 @@ const ApplicationAgencies = {
   AGENCY_EMLI: 'Ministry of Energy Mines and Low Carbon Innovation',
   AGENCY_ENV: 'Ministry of Environment and Climate Change Strategy',
   AGENCY_ENV_BCPARKS: 'BC Parks',
-  AGENCY_OGC: 'BC Energy Regulator',
+  AGENCY_OGC: 'Conservation Officer Service',
   AGENCY_ENV_EPD: 'Ministry of Environment and Climate Change Strategy',
   AGENCY_LNG: 'LNG Secretariat',
   AGENCY_AGRI: 'Ministry of Agriculture and Food',


### PR DESCRIPTION
Changelog:
* Revert update to issuingAgency for Conservation Officer Service (no longer shows BC Energy Regulator)
* Check COORS import (Court Convictions and Tickets only) for "Water Sustainability Act" to apply the proper issuing Agency (BC Energy Regulator)