### PR TITLE
Bug/nrpti 1091

### DIFF
--- a/api/database.json-sample
+++ b/api/database.json-sample
@@ -1,0 +1,8 @@
+{
+  "defaultEnv": "local",
+  "local": {
+    "driver": "mongodb",
+        "database": "dbname",
+        "host": "localhost"
+  }
+}

--- a/api/migrations/20230901215837-updateDeletedDocRecords.js
+++ b/api/migrations/20230901215837-updateDeletedDocRecords.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  console.log('**** Updating Records with Deleted Attachments ****');
+
+  // Collection Names
+  const collectionName = 'redacted_record_subset';
+  const nrptiCollectionName = 'nrpti';
+
+  const mClient = await db.connection.connect(db.connectionString, {
+    native_parser: true
+  });
+  
+
+  const collection = await mClient.collection(collectionName);
+  const nrptiCollection = await mClient.collection(nrptiCollectionName);
+
+  // Subquery to find _id values with schema 'Document' in both collections
+  const subquery = [
+    { _schemaName: 'Document' },
+    { _schemaName: 'Document' }
+  ];
+
+  Promise.all([
+    collection.find({ $or: subquery }, { _id: 1 }).toArray(),
+    nrptiCollection.find({ $or: subquery }, { _id: 1 }).toArray()
+  ])
+  .then(([collectionResults, nrptiResults]) => {
+    // Extract _id values from the subquery results
+    const validIds = [...new Set([...collectionResults, ...nrptiResults].map(item => item._id))];
+
+    // Update documents to an empty array where _id is not in validIds
+    const updateQuery = {
+      _id: { $nin: validIds }
+    };
+
+    const updateOperation = {
+      $set: {
+        documents: []
+      }
+    };
+
+    return collection.updateMany(updateQuery, updateOperation);
+  })
+  .then(updateResult => {
+    console.log(`Updated ${updateResult.modifiedCount} documents in the ${collectionName} collection.`);
+  })
+  .catch(err => {
+  });
+
+  mClient.close();
+
+}
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/migrations/20230901215837-updateDeletedDocRecords.js
+++ b/api/migrations/20230901215837-updateDeletedDocRecords.js
@@ -30,31 +30,35 @@ exports.up = async function(db) {
   
 
   const redactedCollection = await mClient.collection(redactedCollectionName);
-  const nrptiCollection = await mClient.collection(nrptiCollectionName);
+  //const nrptiCollection = await mClient.collection(nrptiCollectionName);
 
 
 
   // Subquery to find _id values with schema 'Document' in both collections
-  const subquery = [
-    { _schemaName: 'Document' },
-    { _schemaName: 'Document' }
-  ];
+  // const subquery = [
+  //   { _schemaName: 'Document' },
+  //   { _schemaName: 'Document' }
+  // ];
 
-  const collectionResults = await redactedCollection.find({ $or: subquery }, { _id: 1 }).toArray();
+  // const collectionResults = await redactedCollection.find({ $or: subquery }, { _id: 1 }).toArray();
 
-  const nrptiResults = await nrptiCollection.find({ $or: subquery }, { _id: 1 }).toArray();
+  // const nrptiResults = await nrptiCollection.find({ $or: subquery }, { _id: 1 }).toArray();
 
 
 
-    console.log('inthen>>>>>')
+    //console.log('inthen>>>>>')
     // Extract _id values from the subquery results
-  const validIds = [...new Set([...collectionResults, ...nrptiResults].map(item => item._id))];
+  //const validIds = [...new Set([...collectionResults, ...nrptiResults].map(item => item._id))];
 
   let redactedDocumentsIds =  await redactedCollection.find({_schemaName: 'Document'}).toArray();
   redactedDocumentsIds=redactedDocumentsIds.map(item => item._id);
 
-   console.log('validIds= ' + validIds.length)
+   //console.log('validIdsCount= ' + validIds.length)
 
+   console.log('redactedCount= ' + redactedDocumentsIds.length)
+
+   console.log('redacted1=' + redactedDocumentsIds[0]);
+   console.log('redacted2=' + redactedDocumentsIds[1]);
  
    const cursor =  redactedCollection.find({
       "documents": { "$exists": true, "$not": { "$size": 0 } }
@@ -66,16 +70,23 @@ let ct = 0;
   await cursor.forEach(record => {   
       if(!redactedDocumentsIds.includes(record['documents'][0]))
       {
-        console.log('in_if' + ct)
-        redactedCollection.updateOne(
-              {_id: record._id},
-              {$set: {documents: []}}
-            )
+       console.log('in_if' + ct + 'documentid=' + record['documents'][0])
+        // redactedCollection.updateOne(
+        //       {_id: record._id},
+        //       {$set: {documents: []}}
+        //     )
       }
        else{
-      console.log('in_else' + ct)
+     console.log('in_else' + ct)
     }
-    
+//     const foundElement = redactedDocumentsIds.some(item => item === record['documents'][0]);
+//     if (foundElement === undefined) {
+//   // Element not found
+//  // console.log('in_if' + ct + 'documentid=' + record['documents'][0])
+// }
+// else{
+//   console.log('in_else' + ct + 'documentid=' + record['documents'][0])
+// }
 ct++;
     
 


### PR DESCRIPTION
Changelog:
* Add a migration to remove any orphaned "documents" ObjectIDs from the `redacted_record_subset` collection 
  * These "documents" ObjectIDs do not correspond to an ObjectID in either the `nrpti` or `redacted` collections (they should exists as `{"_schemaName": "Document"}`)
  * This means the "Document" record has been deleted previously from the S3 bucket
  * An ObjectID in a record's "documents" array in `redacted` will _show_ on the NRCED frontend that a document (PDF, image, etc.) exists, but is unable to actually retrieve an existing document, which may prove confusing to the user.

Migration explanation:
  * The migration checks in the redacted collection for records that have a non-empty "documents" array and saves the corresponding "documents" ObjectIDs in a separate array
  * It matches the "documents" ObjectIDs to both the `nrpti` and `redacted_record_subset` collections, checking if a `{"_schemaName": "Document"}` exists
    * _If it exists, then the corresponding S3 link would still be available from this record_
  * Any non-matching ObjectIDs are noted in a separate array
  * We use MongoDB `$pull` to update the `redacted` collection's records to remove any of these non-matching ObjectIDs from their "documents" arrays.