### PR TITLE
[NRPTI-1112] Add outcome description values to CSV outputs in NRCED

### DIFF
--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
@@ -1,0 +1,56 @@
+import { RecordUtils } from './record-utils';
+import moment from 'moment';
+
+const mockData = [
+  {
+    recordType: 'testRecord',
+    dateIssued: '2023-10-11',
+    issuedTo: {
+      type: 'Company',
+      companyName: 'This company doesnt exist'
+    },
+    summary: 'In summary, this is a test',
+    issuingAgency: 'testCode',
+    legislation: {
+      act: '1',
+      regulation: '2',
+      section: '3',
+      subSection: '4',
+      paragraph: '5',
+      legislationDescription: 'This sounds serious'
+    },
+    offence: 'None',
+    penalties: '',
+    projectName: 'Test Project',
+    location: 'BC',
+    centroid: ['1', '2'],
+    outcomeDescription: 'The outcome was a success, hooray!'
+  }
+];
+const expectedOutput = `Record Type,Issued On,Issued To,Summary,Issuing Agency,Legislation Act,Regulation,Section,Sub Section,Paragraph,Description,Offence,Penalties,Site/Project,Location,Latitude,Longitude,Outcome Description
+"testRecord","2023-10-11","Company",This company doesnt exist,"In summary, this is a test","testCode","1","2","3","4","5","This sounds serious","None","","BC","1","2","The outcome was a success, hooray!"`;
+
+describe('RecordUtils', () => {
+  describe('exportToCsv', () => {
+    it('should call the download function with the expected data', () => {
+      // Defining mocks
+      const urlMock = window.URL.createObjectURL(new Blob([expectedOutput], { type: 'text/plain' }));
+
+      // Defining spies
+      const downloadSpy = jasmine.createSpyObj('a', ['click']);
+      spyOn(moment.prototype, 'format').and.returnValue('this-is-the-time');
+      spyOn(document, 'createElement').and.returnValue(downloadSpy);
+      spyOn(window.URL, 'createObjectURL').and.returnValue(urlMock);
+
+      // Executing export function
+      RecordUtils.exportToCsv(mockData);
+
+      // Ensuring expected output
+      expect(document.createElement).toHaveBeenCalledTimes(1);
+      expect(document.createElement).toHaveBeenCalledWith('a');
+
+      expect(downloadSpy.href).toBe(urlMock);
+      expect(downloadSpy.download).toContain('nrced-export-this-is-the-time.csv');
+    });
+  });
+});

--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
@@ -33,14 +33,11 @@ const expectedOutput = `Record Type,Issued On,Issued To,Summary,Issuing Agency,L
 describe('RecordUtils', () => {
   describe('exportToCsv', () => {
     it('should call the download function with the expected data', () => {
-      // Defining mocks
-      const urlMock = window.URL.createObjectURL(new Blob([expectedOutput], { type: 'text/plain' }));
-
       // Defining spies
       const downloadSpy = jasmine.createSpyObj('a', ['click']);
       spyOn(moment.prototype, 'format').and.returnValue('this-is-the-time');
       spyOn(document, 'createElement').and.returnValue(downloadSpy);
-      spyOn(window.URL, 'createObjectURL').and.returnValue(urlMock);
+      spyOn(window.URL, 'createObjectURL').and.callThrough();
 
       // Executing export function
       RecordUtils.exportToCsv(mockData);
@@ -49,7 +46,7 @@ describe('RecordUtils', () => {
       expect(document.createElement).toHaveBeenCalledTimes(1);
       expect(document.createElement).toHaveBeenCalledWith('a');
 
-      expect(downloadSpy.href).toBe(urlMock);
+      expect(window.URL.createObjectURL).toHaveBeenCalledWith(new Blob([expectedOutput], { type: 'text/plain' }))
       expect(downloadSpy.download).toContain('nrced-export-this-is-the-time.csv');
     });
   });

--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.spec.ts
@@ -39,14 +39,15 @@ describe('RecordUtils', () => {
       spyOn(document, 'createElement').and.returnValue(downloadSpy);
       spyOn(window.URL, 'createObjectURL').and.callThrough();
 
-      // Executing export function
+      // Executing exportToCsv function
       RecordUtils.exportToCsv(mockData);
 
-      // Ensuring expected output
+      // Ensuring expected behaviour
       expect(document.createElement).toHaveBeenCalledTimes(1);
       expect(document.createElement).toHaveBeenCalledWith('a');
 
       expect(window.URL.createObjectURL).toHaveBeenCalledWith(new Blob([expectedOutput], { type: 'text/plain' }))
+      expect(downloadSpy.href).toBeDefined()
       expect(downloadSpy.download).toContain('nrced-export-this-is-the-time.csv');
     });
   });

--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
@@ -119,7 +119,8 @@ export class RecordUtils {
       'Site/Project',
       'Location',
       'Latitude',
-      'Longitude'
+      'Longitude',
+      'Outcome Description'
     ];
 
     let output = '';
@@ -144,7 +145,7 @@ export class RecordUtils {
       line.push(escapeCsvString(row['summary']));
       line.push(escapeCsvString(Utils.displayNameFull(row['issuingAgency'])));
 
-      const legislation = (Array.isArray(row['legislation'])) ? row['legislation'][0] : row['legislation'];
+      const legislation = Array.isArray(row['legislation']) ? row['legislation'][0] : row['legislation'];
 
       if (legislation) {
         line.push(escapeCsvString(legislation['act']));
@@ -177,6 +178,8 @@ export class RecordUtils {
       } else {
         line = line.concat(['', '']);
       }
+
+      line.push(escapeCsvString(row['outcomeDescription']));
 
       output += `${line.join(',')}\n`;
     }


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Adds outcomeDescription field to ALL CSV files
- Includes testing
