### PR TITLE
 [HOTFIX][NRPTI-1161]** Hotfix to import all mines from core

### DIFF
--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -269,11 +269,11 @@ class CoreDataSource {
     const { records: permits } = await integrationUtils.getRecords(url, getAuthHeader(this.client_token));
 
     // First, any mines with 'X' as their second character are considered exploratory. Remove them.
-    const nonExploratoryPermits = permits.filter(permit => permit.permit_no[1].toLowerCase() !== 'x');
+    // const nonExploratoryPermits = permits.filter(permit => permit.permit_no[1].toLowerCase() !== 'x');
 
     // Second, mine must not be historical which is indicated by an authorized year of '9999' on the latest amendment.
     let validPermit;
-    for (const permit of nonExploratoryPermits) {
+    for (const permit of permits) {
       // Confirm that the most recent amendment is not historical, which is always the first index.
       // If 'null' then it is considered valid.
       // Otherwise, if the status is O, it's valid. (date 9999 check removed)


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Hotfix to the CORE importer to import all mines regardless of permits
- This will import permits even if they're exploratory permits
