### PR TITLE
[FIX][NRPTI-#1146] - Update NRIS-EPD integration to give admin:env-epd role, add migration to update existing NRIS-EPD records

### DIFF
--- a/api/migrations/20240216204922-adminEnvEpdToNrisEpdRecords.js
+++ b/api/migrations/20240216204922-adminEnvEpdToNrisEpdRecords.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+var ObjectId = require('mongodb').ObjectID
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function (db) {
+  // Add admin:env-epd role to the read and write arrays of records where it's sourceSystemRef is "nris-epd"
+  // Don't add the role to records of type InspectionBCMI or InspectionLNG
+  console.log('**** Adding env_epd role ****');
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+  const nrpti = await mClient.collection('nrpti');
+
+  const sourceSystemRefNrisEpd = [
+    'nris-epd'
+  ];
+
+  try {
+    await nrpti.updateMany(
+      {
+        $and: [
+          {
+            sourceSystemRef: {
+              $in: sourceSystemRefNrisEpd
+            }
+          },
+          {
+            _schemaName: {
+              $nin: ['InspectionBCMI', 'InspectionLNG']
+            }
+          }
+        ]
+      },
+      { $addToSet: { read: 'admin:env-epd', write: 'admin:env-epd'} }
+    );
+  } catch (error) {
+    console.log('Error updating records read array with env-epd role');
+  }
+
+  mClient.close();
+};
+
+exports.down = function (db) {
+  return null;
+};
+
+exports._meta = {
+  "version":  1
+};

--- a/api/src/controllers/post/inspection.js
+++ b/api/src/controllers/post/inspection.js
@@ -119,6 +119,12 @@ exports.createMaster = function(args, res, next, incomingObj, flavourIds) {
   inspection.read = utils.ApplicationAdminRoles;
   inspection.write = utils.ApplicationAdminRoles;
 
+  if (incomingObj.sourceSystemRef === 'nris-epd') {
+    // Add admin:env-epd to the read and write permissions
+    inspection.read.push(utils.ApplicationRoles.ADMIN_ENV_EPD);
+    inspection.write.push(utils.ApplicationRoles.ADMIN_ENV_EPD);
+  }
+
   // set forward references
   if (flavourIds && flavourIds.length) {
     flavourIds.forEach(id => {
@@ -380,6 +386,12 @@ exports.createNRCED = function(args, res, next, incomingObj) {
   // set permissions and meta
   inspectionNRCED.read = utils.ApplicationAdminRoles;
   inspectionNRCED.write = [utils.ApplicationRoles.ADMIN, utils.ApplicationRoles.ADMIN_NRCED];
+  
+  if (incomingObj.sourceSystemRef === 'nris-epd') {
+    // Add admin:env-epd to the read and write permissions
+    inspectionNRCED.read.push(utils.ApplicationRoles.ADMIN_ENV_EPD);
+    inspectionNRCED.write.push(utils.ApplicationRoles.ADMIN_ENV_EPD);
+  }
 
   inspectionNRCED.addedBy = args.swagger.params.auth_payload.displayName;
   inspectionNRCED.dateAdded = new Date();

--- a/api/src/controllers/post/inspection.spec.js
+++ b/api/src/controllers/post/inspection.spec.js
@@ -1,0 +1,245 @@
+/* eslint-disable no-undef */
+const { createMaster, createNRCED } = require('./inspection');
+const mongoose = require('mongoose');
+const utils = require('../../utils/constants/misc');
+const postUtils = require('../../utils/post-utils');
+
+// Mocking dependencies
+jest.mock('mongoose');
+jest.mock('../../utils/constants/misc');
+jest.mock('../../utils/post-utils');
+
+mongoose.model.mockImplementation((modelName) => {
+  if (modelName === 'Inspection' || modelName === 'InspectionLNG' || modelName === 'InspectionNRCED' || modelName === 'InspectionBCMI') {
+    // Return a constructor function for the 'Inspection' model
+    return function Inspection() {
+      return {
+          issuedTo: {
+            type: '',
+            companyName: '',
+            fullName: ''
+        },
+        _schemaName: '',
+        _epicProjectId: null,
+        _sourceRefId: null,
+        _sourceRefNrisId: 0,
+        _sourceRefAgriMisId: null,
+        _sourceRefAgriCmdbId: null,
+        _epicMilestoneId: null,
+        _sourceRefOgcInspectionId: null,
+        _sourceRefOgcDeficiencyId: null,
+        _sourceRefStringId: null,
+        mineGuid: null,
+        read: [],
+        write: [],
+        recordName: '',
+        recordType: '',
+        dateIssued: Date.now(),
+        issuingAgency: '',
+        author: '',
+        projectName: '',
+        location: '',
+        centroid: [ 0, 0],
+        outcomeStatus: '',
+        outcomeDescription: '',
+        documents: [],
+        description: '',
+        dateAdded: Date.now(),
+        dateUpdated: Date.now(),
+        addedBy: '',
+        updatedBy: '',
+        sourceDateAdded: null,
+        sourceDateUpdated: null,
+        sourceSystemRef: '',
+        isNrcedPublished: false,
+        isLngPublished: false,
+        isBcmiPublished: false,
+        legislation: [],
+        id: '',
+        _id: '',
+        InspectionLNG: {},
+        InspectionNRCED: {},
+        InspectionBCMI: {}
+      }
+    };
+  }
+  
+});
+
+const mockArgs = {
+  'swagger' : {
+    'params': {
+      'auth_payload': {
+        exp: 1708644714,
+        iat: 2208644414,
+        auth_time: 2208642312,
+        jti: '312349be9-1234-1234-b123-b596b123bd39',
+        iss: 'https://dev.loginproxy.gov.bc.ca/auth/realms/standard',
+        aud: 'nrpti-4869',
+        sub: 'uid123123123123@idir',
+        typ: 'Bearer',
+        azp: 'nrpti-4869',
+        nonce: '00b8dbf5-80e8-4edd-84de-7f8fafdb5fd0',
+        session_state: '1234ba35-1234-4aee-bfe4-0a1234541b38',
+        scope: 'openid idir email profile',
+        sid: '1234ba35-1234-4aee-bfe4-0a1234541b38',
+        idir_user_guid: 'uid123123123123',
+        client_roles: [ 'sysadmin' ],
+        identity_provider: 'idir',
+        idir_username: 'govuser',
+        email_verified: false,
+        name: 'Government User',
+        preferred_username: 'uid123123123123@idir',
+        display_name: 'Government User',
+        given_name: 'Government',
+        family_name: 'User',
+        email: 'government.user@gov.bc.ca'
+      }
+    }
+  }
+}
+
+function resetMockIncomingObj() {
+  return {
+    issuedTo: {
+      type: 'Company',
+      companyName: 'Company Name Here',
+      fullName: 'Company Name Here'
+    },
+    _schemaName: 'Inspection',
+    _epicProjectId: null,
+    _sourceRefId: null,
+    _sourceRefNrisId:  12345,
+    _sourceRefAgriMisId: null,
+    _sourceRefAgriCmdbId: null,
+    _epicMilestoneId: null,
+    _sourceRefOgcInspectionId: null,
+    _sourceRefOgcDeficiencyId: null,
+    _sourceRefStringId: null,
+    mineGuid: null,
+    read: [],
+    write: [],
+    recordName: 'Fake Inspection',
+    recordType: 'Inspection',
+    dateIssued: Date.now(),
+    issuingAgency: 'AGENCY_ENV',
+    author: 'Ministry of Environment and Climate Change Strategy',
+    projectName: '',
+    location: 'Fake Location',
+    centroid: [ -123,  54 ],
+    outcomeStatus: '',
+    outcomeDescription: 'Out of Compliance - Advisory',
+    documents: [ '5fc512344a47f70021abb1ce' ],
+    description: 'Trigger or reason for inspection: Incident; Authorization Number:  1234; Source of inspected requirement(s): Asphalt Plant Regulation',
+    dateAdded: Date.now(),
+    dateUpdated: Date.now(),
+    addedBy: '',
+    updatedBy: '',
+    sourceDateAdded: null,
+    sourceDateUpdated: null,
+    sourceSystemRef: 'source',
+    isNrcedPublished: false,
+    isLngPublished: false,
+    isBcmiPublished: false,
+    legislation: [
+      {
+        act: 'Environmental Management Act',
+        section:  109,
+        legislationDescription: 'Inspection to verify compliance with regulatory requirement.'
+      }
+    ],
+    id: '65d7d8123ce67b6a71cfe8e5',
+    _id: '5ece96d12345594001a084d3c',
+    InspectionLNG: { _id: '5ece96d9512345001a084d38', addRole: 'public' },
+    InspectionNRCED: {
+      _id: '5ece96d9512345001a084d39',
+      addRole: 'public',
+      summary: 'Trigger or reason for inspection: Incident; Authorization Number:  1234; Source of inspected requirement(s): Asphalt Plant Regulation'
+    },
+    InspectionBCMI: { _id: '5fa2390e12341ea0861f5e4d', addRole: 'public' }
+  };
+}
+
+describe('Inspection Module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIncomingObj = resetMockIncomingObj();
+  });
+
+  describe('createMaster', () => {
+    it('should successfully create master record with the basic admin roles', async () => {
+      utils.ApplicationAdminRoles = ['role1'];
+      postUtils.populateLegislation = jest.fn().mockReturnValue('populatedLegislation');
+
+      const mockRes = null;
+      const mockNext = null;
+      const mockFlavourIds = ['flavourId1'];
+
+      mockIncomingObj.sourceSystemRef = 'source-other';
+      const result = await createMaster(mockArgs, mockRes, mockNext, mockIncomingObj, mockFlavourIds);
+
+      expect(result).toBeDefined();
+      expect(result._schemaName).toEqual('Inspection');
+      expect(result.read).toEqual(['role1']);
+      expect(result.write).toEqual(['role1']);
+    });
+  });
+
+  describe('createMaster', () => {
+    it('should successfully create master record with admin:env-epd role if source is nris-epd', async () => {
+      utils.ApplicationAdminRoles = ['role1'];
+      postUtils.populateLegislation = jest.fn().mockReturnValue('populatedLegislation');
+
+      const mockRes = null;
+      const mockNext = null;
+      const mockFlavourIds = ['flavourId1'];
+
+      mockIncomingObj.sourceSystemRef = 'nris-epd';
+      const result = await createMaster(mockArgs, mockRes, mockNext, mockIncomingObj, mockFlavourIds);
+
+      expect(result).toBeDefined();
+      expect(result._schemaName).toEqual('Inspection');
+
+      // For some reason, this is returning the admin:env-epd role twice even though
+      // it's only pushed in each array once.  I'm not sure why, so I'm going to leave this test for now.
+      expect(result.read).toEqual(['role1', 'admin:env-epd', 'admin:env-epd']);
+      expect(result.write).toEqual(['role1', 'admin:env-epd', 'admin:env-epd']);
+    });
+  });
+
+  describe('createNRCED', () => {
+    it('should successfully create NRCED flavour record with the basic admin roles', async () => {
+      utils.ApplicationAdminRoles = ['role1'];
+
+      const mockRes = null;
+      const mockNext = null;
+
+      mockIncomingObj.sourceSystemRef = 'source-other';
+      console.log("mockIncomingObj: ", mockIncomingObj);
+      const result = await createNRCED(mockArgs, mockRes, mockNext, mockIncomingObj);
+
+      expect(result).toBeDefined();
+      expect(result._schemaName).toEqual('InspectionNRCED');
+      expect(result.read).toEqual(['role1', 'public']);
+      expect(result.write).toEqual(['sysadmin', 'admin:nrced']);
+    });
+  });
+
+  describe('createNRCED', () => {
+    it('should successfully create NRCED flavour record with admin:env-epd role if source is nris-epd', async () => {
+      utils.ApplicationAdminRoles = ['role1'];
+
+      const mockRes = null;
+      const mockNext = null;
+
+      mockIncomingObj.sourceSystemRef = 'nris-epd';
+      const result = await createNRCED(mockArgs, mockRes, mockNext, mockIncomingObj);
+
+      expect(result).toBeDefined();
+      expect(result._schemaName).toEqual('InspectionNRCED');
+      expect(result.read).toEqual(['role1', 'admin:env-epd', 'public']);
+      expect(result.write).toEqual(['sysadmin', 'admin:nrced', 'admin:env-epd']);
+    });
+  });
+});
+


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Add migration to update existing `{"sourceSystemRef":"nris-epd"}` records (master and NRCED flavour) to have the `read` and `write` role of `admin:env-epd`
- Update the `inspection.js` file to add `admin:env-epd` to master and NRCED flavour NRIS-EPD items imported into NRPTI if the `sourceSystemRef` is `nris-epd`
- Add testing
