### PR TITLE
[FIX][NRPTI-#1103] - Remove all "Fish and Seafood Act" Inspections from Collection

### DIFF
--- a/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
+++ b/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
+  const nrpti = mClient.collection('nrpti');
+
+  try {
+    console.log('Deleting all Inspections with Fish and Seafood Act legislation');
+    await nrpti.deleteMany({
+      $or: [
+        {"_schemaName":"Inspection", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }},
+        {"_schemaName":"InspectionNRCED", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }},
+        {"_schemaName":"InspectionBCMI", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }}
+      ]
+    });
+  } catch (err) {
+    console.log(`Error finding records: ${err}`);
+  } finally {
+    console.log('Closing connection');
+    mClient.close();
+  }
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
+++ b/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
@@ -18,49 +18,56 @@ exports.up = async function(db) {
   const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
   const nrpti = mClient.collection('nrpti');
   const redactedRecordSubset = mClient.collection('redacted_record_subset');
+  const isProduction = process.env.NODE_ENV === 'production';
 
+  console.log('current environment:', process.env.NODE_ENV);
   try {
-    console.log('Deleting all Inspections in nrpti collection with Fish and Seafood Act legislation');
-    await nrpti.deleteMany({
-      $or: [
-        {"_schemaName":"Inspection", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }},
-        {"_schemaName":"InspectionNRCED", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }},
-        {"_schemaName":"InspectionBCMI", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }}
-      ]
-    });
 
-    console.log('Deleting all Inspections in redacted_record_subset collection with Fish and Seafood Act legislation');
-    await redactedRecordSubset.deleteMany({
-      $or: [
-        {"_schemaName":"Inspection", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }},
-        {"_schemaName":"InspectionNRCED", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }},
-        {"_schemaName":"InspectionBCMI", "legislation": {
-          $elemMatch: {
-            "act": "Fish and Seafood Act"
-          }
-        }}
-      ]
-    });
+    // One-time deletion of all records with Fish and Seafood Act legislation
+    // Check if prod to avoid deletion in dev/test environments
+    if (isProduction) {
+      console.log('Deleting all Inspections in nrpti collection with Fish and Seafood Act legislation');
+      await nrpti.deleteMany({
+        $or: [
+          {"_schemaName":"Inspection", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }},
+          {"_schemaName":"InspectionNRCED", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }},
+          {"_schemaName":"InspectionBCMI", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }}
+        ]
+      });
+
+      console.log('Deleting all Inspections in redacted_record_subset collection with Fish and Seafood Act legislation');
+      await redactedRecordSubset.deleteMany({
+        $or: [
+          {"_schemaName":"Inspection", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }},
+          {"_schemaName":"InspectionNRCED", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }},
+          {"_schemaName":"InspectionBCMI", "legislation": {
+            $elemMatch: {
+              "act": "Fish and Seafood Act"
+            }
+          }}
+        ]
+      });
+    }
   } catch (err) {
     console.log(`Error finding records: ${err}`);
   } finally {

--- a/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
+++ b/api/migrations/20240226205826-removeErroneousFishAndSeafoodActRecords.js
@@ -17,10 +17,32 @@ exports.setup = function(options, seedLink) {
 exports.up = async function(db) {
   const mClient = await db.connection.connect(db.connectionString, { native_parser: true });
   const nrpti = mClient.collection('nrpti');
+  const redactedRecordSubset = mClient.collection('redacted_record_subset');
 
   try {
-    console.log('Deleting all Inspections with Fish and Seafood Act legislation');
+    console.log('Deleting all Inspections in nrpti collection with Fish and Seafood Act legislation');
     await nrpti.deleteMany({
+      $or: [
+        {"_schemaName":"Inspection", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }},
+        {"_schemaName":"InspectionNRCED", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }},
+        {"_schemaName":"InspectionBCMI", "legislation": {
+          $elemMatch: {
+            "act": "Fish and Seafood Act"
+          }
+        }}
+      ]
+    });
+
+    console.log('Deleting all Inspections in redacted_record_subset collection with Fish and Seafood Act legislation');
+    await redactedRecordSubset.deleteMany({
       $or: [
         {"_schemaName":"Inspection", "legislation": {
           $elemMatch: {


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Add migration to delete all Inspections with the legislative act "Fish and Seafood Act" on `nrpti` and `redacted_record_subset` collection.
- This will keep all non-Inspection records (Tickets, Administrative Penalties, etc.)
