### PR TITLE
[TASK][NRPTI-1223] add two tests for work around act name changes

### DIFF
--- a/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
+++ b/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { LegislationListDetailComponent } from './legislation-list-detail.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ActivatedRouteStub } from '../../spec/spec-utils';
 import { GlobalModule } from 'nrpti-angular-components';
+import { Legislation } from '../../models/master/common-models/legislation';
 
 describe('LegislationListDetailComponent', () => {
   let component: LegislationListDetailComponent;
@@ -14,7 +15,7 @@ describe('LegislationListDetailComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [GlobalModule],
+      imports: [GlobalModule, HttpClientTestingModule],
       declarations: [LegislationListDetailComponent],
       providers: [
         { provide: ActivatedRoute, useValue: activedRouteStub },
@@ -31,5 +32,14 @@ describe('LegislationListDetailComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display an actCode when the backend cannot return the legislation code map', async () =>{
+    const testActCode = "ACT_103";
+    const testLegislation = new Legislation({"act":testActCode});
+    component.data = [testLegislation];
+    fixture.detectChanges();
+    let gridEl = fixture.nativeElement.querySelector(".grid-item-value");
+    expect(gridEl.textContent).toContain(testActCode);
   });
 });

--- a/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
+++ b/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
@@ -37,9 +37,11 @@ describe('LegislationListDetailComponent', () => {
   it('should display an actCode when the backend cannot return the legislation code map', async () => {
     const testActCode = 'ACT_103';
     const testLegislation = new Legislation({ act: testActCode });
-    component.data = [testLegislation];
+
+    component.data = [testLegislation];//populates the component with legislation data, which will then be parsed by buildLegislationString() and added as a grid item
     fixture.detectChanges();
     const gridEl = fixture.nativeElement.querySelector('.grid-item-value');
+
     expect(gridEl.textContent).toContain(testActCode);
   });
 });

--- a/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
+++ b/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
@@ -38,7 +38,8 @@ describe('LegislationListDetailComponent', () => {
     const testActCode = 'ACT_103';
     const testLegislation = new Legislation({ act: testActCode });
 
-    component.data = [testLegislation];//populates the component with legislation data, which will then be parsed by buildLegislationString() and added as a grid item
+    // populates the component with legislation data, which will then be parsed by buildLegislationString() and added as a grid item
+    component.data = [testLegislation];
     fixture.detectChanges();
     const gridEl = fixture.nativeElement.querySelector('.grid-item-value');
 

--- a/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
+++ b/angular/projects/common/src/app/legislation/legislation-list-detail-public/legislation-list-detail.component.spec.ts
@@ -34,12 +34,12 @@ describe('LegislationListDetailComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display an actCode when the backend cannot return the legislation code map', async () =>{
-    const testActCode = "ACT_103";
-    const testLegislation = new Legislation({"act":testActCode});
+  it('should display an actCode when the backend cannot return the legislation code map', async () => {
+    const testActCode = 'ACT_103';
+    const testLegislation = new Legislation({ act: testActCode });
     component.data = [testLegislation];
     fixture.detectChanges();
-    let gridEl = fixture.nativeElement.querySelector(".grid-item-value");
+    const gridEl = fixture.nativeElement.querySelector('.grid-item-value');
     expect(gridEl.textContent).toContain(testActCode);
   });
 });

--- a/angular/projects/public-nrpti/src/app/services/acts.service.spec.ts
+++ b/angular/projects/public-nrpti/src/app/services/acts.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActService } from './acts.service';
+import { ConfigService } from 'nrpti-angular-components';
+
+describe('ApiService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ActService, ConfigService],
+      imports: [HttpClientTestingModule]
+    });
+  });
+
+  it('should be created', () => {
+    const service = TestBed.get(ActService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/angular/projects/public-nrpti/src/app/services/acts.service.ts
+++ b/angular/projects/public-nrpti/src/app/services/acts.service.ts
@@ -2,7 +2,6 @@
  * @description This service provides methods to fetch and store issuing agencies.
  * @class ApplicationAgencyService
  */
-
 import { Injectable } from '@angular/core';
 import { ConfigService } from 'nrpti-angular-components';
 import { Observable } from 'rxjs';
@@ -10,7 +9,7 @@ import { HttpClient } from '@angular/common/http';
 
 /**
  * @class
- * @description Service for managing issuing agencies.
+ * @description Service for serving up-to-date map of actCode to actName and regulations.
  */
 @Injectable({
   providedIn: 'root'
@@ -27,7 +26,7 @@ export class ActService {
   constructor(private configService: ConfigService, public http: HttpClient) {}
 
   /**
-   * Initialize the service by setting the API endpoint and refreshing agencies.
+   * Initialize the service by setting the API endpoint and refreshing acts.
    * @async
    */
   async init() {
@@ -35,8 +34,8 @@ export class ActService {
     await this.refreshAct().toPromise();
   }
   /**
-   * Refresh the list of agencies from the API.
-   * @returns {Observable<void>} An observable that completes when agencies are refreshed.
+   * Refresh the map of actCodes from the API.
+   * @returns {Observable<void>} An observable that completes when acts are refreshed.
    */
   refreshAct(): Observable<void> {
     return new Observable<void>(observer => {
@@ -58,8 +57,8 @@ export class ActService {
     });
   }
   /**
-   * Get the list of agencies.
-   * @returns {Object} A dictionary of agency codes and names.
+   * Get the list of acts and regualtions mapped to an actCode.
+   * @returns {Object} A dictionary of act codes, names, and regulations.
    */
   getAllActsAndRegulations() {
     return this.actsRegulationsData;

--- a/api/src/tests/controllers/acts-regulations-controller.test.js
+++ b/api/src/tests/controllers/acts-regulations-controller.test.js
@@ -1,0 +1,17 @@
+const actsRegulationsController = require('../../controllers/acts-regulations-controller');
+
+describe('parseTitleFromXML', () => {
+    const testTitle = 'Act Name';
+    const testXMLWithActName = '<act:act><act:title>' + testTitle + '</act:title></act:act>';
+    const testXMLWithoutActName = '<act:act></act:act>';
+
+    it('returns null if act:title field is not found', () => {
+        const result = actsRegulationsController.parseTitleFromXML(testXMLWithoutActName);
+        expect(result).toEqual(null);
+    });
+
+    it('returns Act title if act:title field is present', () => {
+        const result = actsRegulationsController.parseTitleFromXML(testXMLWithActName);
+        expect(result).toEqual(testTitle);
+    });
+});


### PR DESCRIPTION
This ticket was created as a learning opportunity around testing in NRPTI. A test case has been created in both the frontend and backend. As well, one of the tests brought to light an uncaught bug in the error handling for a method (parseTitleFromXML). that bug has been corrected as part of this work.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- legislation-list-detail component: added test that, if backend API is unavailable, instead of translating an actCode, it returns the same actCode
- acts.service: added boilerplate test that checks for creation
   - also fixed some copy-paste errors in the comments for this service
- acts-regulations-controller: made parseTitleFromXML function exported for testing. Added test for positive and negative cases for title being present. Updated function with improved error handling due to bug identified by test.
