### PR TITLE
[FIX][NRPTI-1226] added missing parameter to transformRecord calls in BCOGC integration utils tests

### DIFF
--- a/api/src/integrations/bcogc/administrative-penalties-utils.test.js
+++ b/api/src/integrations/bcogc/administrative-penalties-utils.test.js
@@ -98,7 +98,7 @@ describe('AdministrativePenalty', () => {
         description: ''
       });
   
-      const result = administrativePenalty.transformRecord(baseCsvRow);
+      const result = administrativePenalty.transformRecord(baseCsvRow, actName);
   
       expect(result).toEqual(expectedResult);
     });
@@ -112,7 +112,7 @@ describe('AdministrativePenalty', () => {
         description: 'Although a contravention occurred, a penalty was not assessed. See the attached document for additional details.'
       });
 
-      const result = administrativePenalty.transformRecord(baseCsvRow);
+      const result = administrativePenalty.transformRecord(baseCsvRow, actName);
   
       expect(result).toEqual(expectedResult);
     });
@@ -126,7 +126,7 @@ describe('AdministrativePenalty', () => {
         description: 'No contravention was found to have occurred, and no penalty was assessed. See the attached document for additional details.'
       });
 
-      const result = administrativePenalty.transformRecord(baseCsvRow);
+      const result = administrativePenalty.transformRecord(baseCsvRow, actName);
   
       expect(result).toEqual(expectedResult);
     });

--- a/api/src/integrations/bcogc/datasource.js
+++ b/api/src/integrations/bcogc/datasource.js
@@ -115,7 +115,7 @@ class OgcCsvDataSource {
       const recordTypeUtils = recordTypeConfig.getUtil(this.auth_payload, csvRow);
 
       // Perform any data transformations necessary to convert the csv row into a NRPTI record
-      const nrptiRecord = recordTypeUtils.transformRecord(csvRow, this.actName);
+      const nrptiRecord = recordTypeUtils.transformRecord(csvRow, this.actName || ENERGY_ACT_CODE);
 
       // Check if this record already exists
       const existingRecord = await recordTypeUtils.findExistingRecord(nrptiRecord);

--- a/api/src/integrations/bcogc/datasource.test.js
+++ b/api/src/integrations/bcogc/datasource.test.js
@@ -5,6 +5,7 @@ const BCOGC_INSPECTIONS_CSV_ENDPOINT = process.env.BCOGC_INSPECTIONS_CSV_ENDPOIN
 const BCOGC_ORDERS_CSV_ENDPOINT = process.env.BCOGC_ORDERS_CSV_ENDPOINT || 'https://www.bc-er.ca/data-reports/compliance-enforcement/reports/enforcement-order';
 const BCOGC_PENALTIES_CSV_ENDPOINT = process.env.BCOGC_PENALTIES_CSV_ENDPOINT || 'https://www.bc-er.ca/data-reports/compliance-enforcement/reports/contravention-decision';
 const BCOGC_WARNING_CSV_ENDPOINT = process.env.BCOGC_WARNING_CSV_ENDPOINT  || 'https://www.bc-er.ca/data-reports/compliance-enforcement/reports/warning-letter';
+const ENERGY_ACT_CODE = 'ACT_103' //unique code for Energy related activities that map to updated legislation names in the acts_regulations_mapping collection in the db
 
 describe('OgcCsvDataSource', () => {
   describe('constructor', () => {
@@ -147,7 +148,7 @@ describe('OgcCsvDataSource', () => {
 
       await dataSource.processRecord(csvRow, recordTypeConfig);
 
-      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow);
+      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow, ENERGY_ACT_CODE );
       expect(recordTypeUtils.findExistingRecord).toHaveBeenCalledWith({ transformed: true });
       expect(recordTypeUtils.createItem).toHaveBeenCalledWith({ transformed: true });
       expect(dataSource.status.itemsProcessed).toEqual(1);
@@ -179,7 +180,7 @@ describe('OgcCsvDataSource', () => {
 
       await dataSource.processRecord(csvRow, recordTypeConfig);
 
-      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow);
+      expect(recordTypeUtils.transformRecord).toHaveBeenCalledWith(csvRow, ENERGY_ACT_CODE);
       expect(recordTypeUtils.findExistingRecord).toHaveBeenCalledWith({ transformed: true });
       expect(recordTypeUtils.updateRecord).toHaveBeenCalledWith({ transformed: true }, { _id: 123 });
       expect(dataSource.status.itemsProcessed).toEqual(1);

--- a/api/src/integrations/bcogc/inspections-utils.test.js
+++ b/api/src/integrations/bcogc/inspections-utils.test.js
@@ -14,7 +14,7 @@ describe('transformRecord', () => {
   });
 
   it('returns basic fields if empty csvRow parameter provided', () => {
-    const result = inspections.transformRecord({});
+    const result = inspections.transformRecord({}, actName);
 
     expect(result).toEqual({
       _schemaName: 'Inspection',
@@ -50,7 +50,7 @@ describe('transformRecord', () => {
       description: 'description123',
       'activities inspected': 'activitiesInspection123',
       status: 'statusCancelled'
-    });
+    }, actName);
 
     expect(result).toEqual({
       _schemaName: 'Inspection',
@@ -65,7 +65,7 @@ describe('transformRecord', () => {
       recordName: 'Inspection Number 123456',
       legislation: [
         {
-          act: 'Energy Resource Activities Act',
+          act: actName,
           section: '57',
           subSection: '4',
           legislationDescription: 'Inspection to verify compliance with regulatory requirement'

--- a/api/src/integrations/bcogc/orders-utils.test.js
+++ b/api/src/integrations/bcogc/orders-utils.test.js
@@ -17,7 +17,7 @@ describe('orders-utils testing', () => {
     });
 
     it('returns basic fields if empty csvRow parameter provided', () => {
-      const result = orders.transformRecord({});
+      const result = orders.transformRecord({}, actName);
 
       expect(result).toEqual({
         _schemaName: 'Order',
@@ -51,7 +51,7 @@ describe('orders-utils testing', () => {
         Proponent: 'Test Proponent',
         Filename: 'sample-order.pdf',
         'File URL': 'https://www.example.com/sample-order.pdf'
-      });
+      }, actName);
 
       expect(result).toEqual({
         _schemaName: 'Order',
@@ -69,7 +69,7 @@ describe('orders-utils testing', () => {
         recordName: 'General Order 123',
         legislation: [
           {
-            act: 'Energy Resource Activities Act',
+            act: actName,
             section: 49,
             legislationDescription: 'General Order'
           }


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added a missing parameter to transformRecord() calls in BCOGC integration utility tests
- tests now pass
- Also improved handling in BCOGC  datasource.js. If a call to get the actName fails, the actCode will now be passed in. This is perfectly acceptable behaviour as many records are already being created with just the actCode instead of the associated actName.
