### PR TITLE
[BUG][NRPTI-1235] Check legislation act codes during CSV export

### DIFF
--- a/angular/projects/admin-nrpti/src/app/records/records-resolver.ts
+++ b/angular/projects/admin-nrpti/src/app/records/records-resolver.ts
@@ -7,10 +7,7 @@ import { EpicProjectIds, SchemaLists } from '../../../../common/src/app/utils/re
 
 @Injectable()
 export class RecordsResolver implements Resolve<Observable<object>> {
-  constructor(
-    private factoryService: FactoryService,
-    private tableTemplateUtils: TableTemplateUtils
-  ) {}
+  constructor(private factoryService: FactoryService, private tableTemplateUtils: TableTemplateUtils) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<object> {
     const params = { ...route.params };

--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
@@ -11,6 +11,7 @@ import { CourtConvictionDetailComponent } from '../court-convictions/court-convi
 import { Penalty } from '../../../../../common/src/app/models/master/common-models/penalty';
 import { AgencyDataService } from '../../../../../global/src/lib/utils/agency-data-service-nrced';
 import { FactoryService } from '../../services/factory.service';
+import { ActDataServiceNRCED } from '../../../../../global/src/lib/utils/act-data-service-nrced';
 export class RecordUtils {
   /**
    * Given a record type, return the matching detail component type, or null if no matching component found.
@@ -127,6 +128,7 @@ export class RecordUtils {
     output = `${csvHeaders.join(',')}\n`;
 
     const agencyDataService = new AgencyDataService(factoryService);
+    const dataService = new ActDataServiceNRCED(factoryService);
 
     for (const row of data) {
       let line = [];
@@ -150,7 +152,14 @@ export class RecordUtils {
       const legislation = Array.isArray(row['legislation']) ? row['legislation'][0] : row['legislation'];
 
       if (legislation) {
-        line.push(escapeCsvString(legislation['act']));
+        if(legislation['act'] && legislation['act'].startsWith("ACT_")){
+          const actTitle = dataService.displayActTitleFull(legislation['act']);
+          if(actTitle){
+            line.push(escapeCsvString(actTitle));
+          }
+        } else {
+          line.push(escapeCsvString(legislation['act']));
+        }
         line.push(escapeCsvString(legislation['regulation']));
         line.push(escapeCsvString(legislation['section']));
         line.push(escapeCsvString(legislation['subSection']));

--- a/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
+++ b/angular/projects/public-nrpti/src/app/records/utils/record-utils.ts
@@ -152,9 +152,9 @@ export class RecordUtils {
       const legislation = Array.isArray(row['legislation']) ? row['legislation'][0] : row['legislation'];
 
       if (legislation) {
-        if(legislation['act'] && legislation['act'].startsWith("ACT_")){
+        if (legislation['act'] && legislation['act'].startsWith('ACT_')) {
           const actTitle = dataService.displayActTitleFull(legislation['act']);
-          if(actTitle){
+          if (actTitle) {
             line.push(escapeCsvString(actTitle));
           }
         } else {
@@ -197,7 +197,6 @@ export class RecordUtils {
 
     download(`nrced-export-${moment().format('YYYY-MM-DD')}.csv`, output);
   }
-
 }
 
 /**


### PR DESCRIPTION
This PR includes the following proposed change(s):

* Add logic to lookup legislation act codes during CSV export, fixing a bug where the end user would be shown the act code instead of the friendly title.
