### PR TITLE
[FEATURE][NRPTI-1125] Automated publishing of redacted mines act inspection reports

### DIFF
--- a/api/src/integrations/integration-utils.js
+++ b/api/src/integrations/integration-utils.js
@@ -84,7 +84,11 @@ exports.getRecords = async function(url, options = undefined) {
       }
     };
 
+    try{
     const res = await axios.post(CORE_TOKEN_ENDPOINT, QS.stringify(requestBody), config);
+    } catch (excception ){
+      console.log(excception);
+    }
 
     const payload = res.data ? res.data : null;
 

--- a/api/src/integrations/integration-utils.js
+++ b/api/src/integrations/integration-utils.js
@@ -84,11 +84,7 @@ exports.getRecords = async function(url, options = undefined) {
       }
     };
 
-    try{
     const res = await axios.post(CORE_TOKEN_ENDPOINT, QS.stringify(requestBody), config);
-    } catch (excception ){
-      console.log(excception);
-    }
 
     const payload = res.data ? res.data : null;
 

--- a/api/src/integrations/nris-emli/datasource.js
+++ b/api/src/integrations/nris-emli/datasource.js
@@ -20,6 +20,7 @@ const NRIS_EMLI_API_ENDPOINT =
   process.env.NRIS_EMLI_API_ENDPOINT || 'https://api.nrs.gov.bc.ca/nrisws-api/v1/emprInspections';
 const NRIS_username = process.env.NRIS_username || null;
 const NRIS_password = process.env.NRIS_password || null;
+const NRIS_ATTACHMENT_DATE = process.env.NRIS_ATTACHMENT_DATE || '2024-06-01';
 const RETRY_LIMIT = 10;
 
 class NrisDataSource {
@@ -163,7 +164,7 @@ class NrisDataSource {
           const existingRecord = await this.findExistingRecord(newRecord);
 
           if (existingRecord) {
-             if (newRecord.documents.length === 0) {    //TODO is this wrong?? Should be existingRecord
+             if (newRecord.documents.length === 0) {
               // create attachment if no existing document was found, if no "Final Report" is attached no document will be created
               if (NRIS_EMLI_DOCUMENT_BINARIES_ENABLED === 'true') {
                 await this.createRecordAttachments(records[i], newRecord);
@@ -311,13 +312,13 @@ class NrisDataSource {
 
   isAttachmentAllowed(attachment){
     //Allow final reports
-    if(attachment.fileType === 'Final Report'){
+    if (attachment.fileType === 'Final Report') {
       return true;
     }
-    //Allow inspection reports if they were created after June 1st
-    if(attachment.fileType === 'Report'){
+    //Allow inspection reports if they were created after a specific date (June 1st)
+    if (attachment.fileType === 'Report') {
       return attachment.attachmentComment.toLowerCase() === "inspection report" 
-      && attachment.attachmentDate != null && moment(attachment.attachmentDate).isAfter("2024-06-01");
+      && attachment.attachmentDate != null && moment(attachment.attachmentDate).isAfter(NRIS_ATTACHMENT_DATE);
     } 
     return false;
   }

--- a/api/src/integrations/nris-emli/datasource.test.js
+++ b/api/src/integrations/nris-emli/datasource.test.js
@@ -472,16 +472,19 @@ describe('NrisDataSource', () => {
         attachment: [
           { attachmentId: 'attachmentId1', fileType: 'Other' },
           { attachmentId: 'attachmentId2', fileType: 'Final Report' },
+          { attachmentId: 'attachmentId3', fileType: 'Report', attachmentComment: 'Inspection Report'},
+          { attachmentId: 'attachmentId4', fileType: 'Report', attachmentComment: 'Inspection Report', attachmentDate: "2024-06-06" },
         ],
       };
   
       const newRecord = {};
       await dataSource.createRecordAttachments(record, newRecord);
   
-      expect(dataSource.getFileFromNRIS).toHaveBeenCalledTimes(1);
+      expect(dataSource.getFileFromNRIS).toHaveBeenCalledTimes(2);
       expect(dataSource.getFileFromNRIS).toHaveBeenCalledWith('sampleAssessmentId', 'attachmentId2');
+      expect(dataSource.getFileFromNRIS).toHaveBeenCalledWith('sampleAssessmentId', 'attachmentId4');
   
-      expect(dataSource.putFileS3).toHaveBeenCalledTimes(1);
+      expect(dataSource.putFileS3).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/api/src/integrations/nris-emli/datasource.test.js
+++ b/api/src/integrations/nris-emli/datasource.test.js
@@ -473,6 +473,7 @@ describe('NrisDataSource', () => {
           { attachmentId: 'attachmentId1', fileType: 'Other' },
           { attachmentId: 'attachmentId2', fileType: 'Final Report' },
           { attachmentId: 'attachmentId3', fileType: 'Report', attachmentComment: 'Inspection Report'},
+          { attachmentId: 'attachmentId3', fileType: 'Report', attachmentComment: 'Inspection Report', attachmentDate: "2020-01-10 11:50"},
           { attachmentId: 'attachmentId4', fileType: 'Report', attachmentComment: 'Inspection Report', attachmentDate: "2024-06-06" },
         ],
       };

--- a/api/test/setEnvVars.js
+++ b/api/test/setEnvVars.js
@@ -1,3 +1,4 @@
 process.env.NRIS_EMLI_DOCUMENT_BINARIES_ENABLED = 'true';
 process.env.NRIS_username = 'test';
 process.env.NRIS_password = 'test';
+process.env.NRIS_ATTACHMENT_DATE = '2024-06-01';


### PR DESCRIPTION
# Description
Add support for redacted inspection reports to automatically be published in the EMLI integration. Previously only Final reports were published but we can now automatically publish reports created after June 1st as they have been redacted and not contain any personal information.

This PR includes the following proposed change(s):
* Added logic to publish attachments with a fileType of 'Report', attachment comment of 'Inspection Report' and a date after the environment variable NRIS_ATTACHMENT_DATE which defaults to June 1st.
* Expanded test case to cover new attachment logic
