### PR TITLE
[FIX][NRPTI-1233] updated bcmi collection migration to properly find all relevant permits

### DIFF
--- a/api/migrations/20240619192233-updateBCMICollectionTypeField.js
+++ b/api/migrations/20240619192233-updateBCMICollectionTypeField.js
@@ -23,7 +23,7 @@ exports.up = async function(db) {
     const nrpti = await mClient.collection('nrpti');
 
     const collections = await nrpti.find({ _schemaName: 'CollectionBCMI' }).toArray();
-    const permits = await nrpti.find({ _schemaName: 'PermitBCMI' }).toArray();
+    const permits = await nrpti.find({ _schemaName: { $in: ['Permit', 'PermitBCMI'] } }).toArray();
 
     let count = 0;
 


### PR DESCRIPTION
The original migration was only looking for permits with _schemaName == PermitBCMI. It turns out that many of the mine permits actually have _schemaName == Permit. The migration has been updated to capture both these sets of permits when updating the document collection.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Fixed BCMICollection update migration by including missing permits from the available records to check.
