### PR TITLE
[BUG][NRPTI-1242] Add support for creating & updating permits from multiple permit codes

### DIFF
--- a/api/src/integrations/core/datasource.js
+++ b/api/src/integrations/core/datasource.js
@@ -270,17 +270,14 @@ class CoreDataSource {
     return permits.filter(p => this.isValidPermit(p,nrptiRecord));
   }
 
-  isValidPermit(permit,nrptiRecord){
+  isValidPermit(permit,nrptiRecord) {
     //Mine must not be historical which is indicated by an authorized year of '9999' on the latest amendment.
-    if((permit.permit_amendments.length && !permit.permit_amendments[0].authorization_end_date) 
-      || permit.permit_status_code === 'O'){
+    if ((permit.permit_amendments.length && !permit.permit_amendments[0].authorization_end_date) 
+      || permit.permit_status_code === 'O') {
 
       // Do not use 'G-4-352' for Lumby
       // https://bcmines.atlassian.net/browse/NRPT-684
-      if (nrptiRecord.name === 'Lumby Mine' && permit.permit_no === 'G-4-352') {
-        return false;
-      }
-      return true;
+      return !nrptiRecord.name === 'Lumby Mine' && permit.permit_no === 'G-4-352';
     }
     return false;
   }
@@ -298,7 +295,7 @@ class CoreDataSource {
   getValidPermit(permits) {
     // First, any mines with 'X' as their second character are considered exploratory. Remove them unless they are the only valid permits
     let nonExploratoryPermits = permits.filter(permit => permit.permit_no[1].toLowerCase() !== 'x');
-    if(nonExploratoryPermits.length === 0){
+    if (nonExploratoryPermits.length === 0) {
       nonExploratoryPermits = permits;
     }
 

--- a/api/src/integrations/core/datasource.test.js
+++ b/api/src/integrations/core/datasource.test.js
@@ -147,14 +147,14 @@ describe('Core DataSource', () => {
     });
   });
 
-  describe('getMinePermit', () => {
+  describe('getMinePermits', () => {
     
-    it('throws an error when no permit is found in getMinePermit method', async () => {
+    it('throws an error when no permit is found in getMinePermits method', async () => {
       const nrptiRecord = null;
       
       const dataSource = new DataSource(null);
       
-      await expect(dataSource.getMinePermit(nrptiRecord)).rejects.toThrow('getMinePermit - required nrptiRecord is null.');
+      await expect(dataSource.getMinePermits(nrptiRecord)).rejects.toThrow('getMinePermits - required nrptiRecord is null.');
     });
   });
 

--- a/api/src/integrations/core/permit-utils.js
+++ b/api/src/integrations/core/permit-utils.js
@@ -103,7 +103,7 @@ class Permits extends BaseRecordUtils {
     return await super.updateRecord(newPermit, existingPermit);
   }
 
-  async getMinePermits(mineId) {
+  async getCurrentMinePermits(mineId) {
     const Permit = mongoose.model('Permit');
     const permits = await Permit.find({ _schemaName: 'Permit', mineGuid: mineId });
 

--- a/api/src/integrations/core/permit-utils.test.js
+++ b/api/src/integrations/core/permit-utils.test.js
@@ -231,13 +231,13 @@ describe('Permits class', () => {
     });
   });
 
-  describe('getMinePermits method', () => {
+  describe('getCurrentMinePermits method', () => {
     it('returns null if no existing record found', async () => {
       mongoose.model = jest.fn(() => ({
         find: jest.fn(() => null),
       }));
 
-      const result = await permitsInstance.getMinePermits('123');
+      const result = await permitsInstance.getCurrentMinePermits('123');
       expect(result).toBeNull();
     });
 
@@ -247,7 +247,7 @@ describe('Permits class', () => {
         find: jest.fn(() => existingRecord),
       }));
 
-      const result = await permitsInstance.getMinePermits('123');
+      const result = await permitsInstance.getCurrentMinePermits('123');
       expect(result).toEqual(existingRecord);
     });
   });


### PR DESCRIPTION
## Pull Request Standards

# Description
Previously only the most recent valid permit was selected for a mine and records processed for the permit. However requirements changed and now both M and MX records need to be publicly available. A hotfix [hotfix](https://github.com/bcgov/NRPTI/pull/1162) was deployed but did not address the underlying problem leading to syncing issues. This PR attempts to properly implement a solution.

This PR includes the following proposed change(s):
Replaces getMinePermit() with getMinePermits() and separates the logic out into multiple methods so that createMinePermit() and updateMinePermit() can process multiple mine permits instead of only the currently selected valid Mine Permit. This allows both MX and M permits and collections for a single mine to be processed during the cron run.
