### PR TITLE
[BUG][NRPTI-1250] Fix acts update function call

### DIFF
--- a/api/src/controllers/acts-regulations-controller.js
+++ b/api/src/controllers/acts-regulations-controller.js
@@ -70,7 +70,7 @@ exports.updateActTitles = async function(args, res, next){
   let actTitle = '';
   for (const [actCode, {actAPI}] of Object.entries(LEGISLATION_CODES)){
     const response = await axios.get(actAPI);
-    actTitle = this.parseTitleFromXML(response.data);
+    actTitle = exports.parseTitleFromXML(response.data);
     actMap[actCode] = actTitle;
   }
   updateTitlesInDB(actMap);


### PR DESCRIPTION
This PR includes the following proposed change(s):

- Replaces call to this.parseTitleFromXML with exports.parseTitleFromXML as using 'this' is not valid outside of a class.
- This bug was preventing the cronjobs in the test environment from completing successfully
