### PR TITLE
[FEATURE][NRPTI] Move token refresh logic to core-utils, cleanup search logging

### DIFF
--- a/api/src/controllers/collection-controller.js
+++ b/api/src/controllers/collection-controller.js
@@ -532,6 +532,7 @@ const createCollection = async function (collectionObj, user) {
   collectionObj.type && (collection.type = collectionObj.type);
   collectionObj.agency && (collection.agency = collectionObj.agency);
   collectionObj.records && collectionObj.records.length && (collection.records = collectionObj.records);
+  collectionObj.permitNumber && (collection.permitNumber = collectionObj.permitNumber)
 
   // If incoming object has addRole: 'public' then read will look like ['sysadmin', 'public']
   if (collectionObj.addRole && collectionObj.addRole === 'public') {

--- a/api/src/integrations/core-util.js
+++ b/api/src/integrations/core-util.js
@@ -1,0 +1,33 @@
+const integrationUtils = require('./integration-utils');
+const {getCoreAccessToken, getAuthHeader } = require('./integration-utils');
+
+const CORE_CLIENT_ID = process.env.CORE_CLIENT_ID || null;
+const CORE_CLIENT_SECRET = process.env.CORE_CLIENT_SECRET || null;
+const CORE_GRANT_TYPE = process.env.CORE_GRANT_TYPE || null;
+const TIME_BUFFER = 30000;
+const SECONDS_TO_MILLISECONDS_MULTIPLIER = 1000;
+
+
+class CoreUtil {
+
+    async getToken(){
+        console.log('Updating CORE Token...');
+        const apiAccess = await getCoreAccessToken(CORE_CLIENT_ID, CORE_CLIENT_SECRET, CORE_GRANT_TYPE);
+        this.apiAccessExpiry = this.getExpiryTime(apiAccess.expires_in);
+        this.client_token = apiAccess.access_token;
+        console.log('CORE Token updated.');
+    }
+
+    getExpiryTime(tokenDuration) {
+        return Date.now() + ( tokenDuration * SECONDS_TO_MILLISECONDS_MULTIPLIER ) - TIME_BUFFER;
+    }
+
+    async getRecords(url, additionalOptions = {}) {
+        if (this.client_token == null || Date.now() >= this.apiAccessExpiry) {
+            await this.getToken();
+        }
+        return await integrationUtils.getRecords(url, getAuthHeader(this.client_token, additionalOptions));
+    }
+}
+
+module.exports = CoreUtil;

--- a/api/src/integrations/core-util.js
+++ b/api/src/integrations/core-util.js
@@ -10,6 +10,10 @@ const SECONDS_TO_MILLISECONDS_MULTIPLIER = 1000;
 
 class CoreUtil {
 
+    /**
+     * Sets the CORE API token and marks when the token will expire
+     *
+     */
     async getToken(){
         console.log('Updating CORE Token...');
         const apiAccess = await getCoreAccessToken(CORE_CLIENT_ID, CORE_CLIENT_SECRET, CORE_GRANT_TYPE);
@@ -18,10 +22,21 @@ class CoreUtil {
         console.log('CORE Token updated.');
     }
 
+    /**
+     * Gives a time for when the given duration will pass with a buffer
+     *
+     * @param {int} tokenDuration the number of seconds that the token is valid for.
+     * @returns {int} the epoch time when the token is expected to expire ( - the buffer ) = current time + token duration - buffer
+     *
+     */
     getExpiryTime(tokenDuration) {
         return Date.now() + ( tokenDuration * SECONDS_TO_MILLISECONDS_MULTIPLIER ) - TIME_BUFFER;
     }
 
+    /**
+     * Wrapper for integration-utils.getRecords with additional logic to check if the token is expired
+     * 
+     */
     async getRecords(url, additionalOptions = {}) {
         if (this.client_token == null || Date.now() >= this.apiAccessExpiry) {
             await this.getToken();

--- a/api/src/models/bcmi/collection-bcmi.js
+++ b/api/src/models/bcmi/collection-bcmi.js
@@ -43,7 +43,8 @@ module.exports = require('../../utils/model-schema-generator')(
     updatedBy: { type: String, default: '' },
     datePublished: { type: Date, default: null },
     sourceSystemRef: { type: String, default: 'nrpti' },
-    publishedBy: { type: String, default: '' }
+    publishedBy: { type: String, default: '' },
+    permitNumber: {type: String, default: ''}
   },
   'nrpti'
 );


### PR DESCRIPTION
This PR includes the following proposed change(s):

- Move all core token refresh logic to a seperate Core Utils class used by both the core-documents integration and core integration.
- Cleanup search logging by changing logs to 'debug' level and setting the console output level to 'info'
- Add permitNumber to BCMICollections to store the correct permit number to be used later for displaying in BCMI.
- Fix bug where admin users couldn't see public records due to missing the 'public' role.
