### PR TITLE
[FIX][NRPTI-1239] Amp record redaction fix (temporary workaround)

### DIFF
--- a/api/src/controllers/agencies.js
+++ b/api/src/controllers/agencies.js
@@ -93,7 +93,16 @@ exports.protectedPut = async function(args, res, next) {
   next();
 };
 
-exports.getAgencyCodeFromName = function(agencyName){
+/** 
+ * gets the intermediate code (agencyCode) for the given agencyName
+ * A synchronous version of getAgencyCodeFromName. Instead of using the db to lookup values,
+ * this function uses some hardcoded constants.
+ * This function was implemented as a temporary fix because the async version proved difficult to implement.
+ * This should be replaced
+ * @param {*} agencyName 
+ * @returns {string} agencyCode
+ */
+exports.getAgencyCodeFromNameBandaid = function(agencyName){
   const AGENCY_NAME_CODE_MAP = [
     {
       agencyCode: 'AGENCY_ALC',
@@ -159,5 +168,5 @@ exports.getAgencyCodeFromName = function(agencyName){
     }
   }
 
-  throw new Error("Error in getAgencyCodeFromName : No code found for ", agencyName);
+  return agencyName; // if no matching code is found, just return the passed-in name
 };

--- a/api/src/controllers/agencies.js
+++ b/api/src/controllers/agencies.js
@@ -93,7 +93,7 @@ exports.protectedPut = async function(args, res, next) {
   next();
 };
 
-exports.getAgencyNameFromCode = function(agencyName){
+exports.getAgencyCodeFromName = function(agencyName){
   const AGENCY_NAME_CODE_MAP = [
     {
       agencyCode: 'AGENCY_ALC',
@@ -154,8 +154,8 @@ exports.getAgencyNameFromCode = function(agencyName){
   ];
 
   for(const agency of AGENCY_NAME_CODE_MAP){
-    if(agency.agencyCode === agencyName){
-      return agency.agencyName;
+    if(agency.agencyName === agencyName){
+      return agency.agencyCode;
     }
   }
 

--- a/api/src/controllers/agencies.js
+++ b/api/src/controllers/agencies.js
@@ -92,3 +92,72 @@ exports.protectedPut = async function(args, res, next) {
   queryActions.sendResponse(res, 200, result);
   next();
 };
+
+exports.getAgencyNameFromCode = function(agencyName){
+  const AGENCY_NAME_CODE_MAP = [
+    {
+      agencyCode: 'AGENCY_ALC',
+      agencyName: 'Agricultural Land Commission'
+    },
+    {
+      agencyCode: 'AGENCY_WF',
+      agencyName: 'BC Wildfire Service'
+    },
+    {
+      agencyCode: 'AGENCY_ENV_COS',
+      agencyName: 'Conservation Officer Service'
+    },
+    {
+      agencyCode: 'AGENCY_EAO',
+      agencyName: 'Environmental Assessment Office'
+    },
+    {
+      agencyCode: 'AGENCY_EMLI',
+      agencyName: 'Ministry of Energy Mines and Low Carbon Innovation'
+    },
+    {
+      agencyCode: 'AGENCY_ENV',
+      agencyName: 'Ministry of Environment and Climate Change Strategy'
+    },
+    {
+      agencyCode: 'AGENCY_ENV_BCPARKS',
+      agencyName: 'BC Parks'
+    },
+    {
+      agencyCode: 'AGENCY_OGC',
+      agencyName: 'BC Energy Regulator'
+    },
+    {
+      agencyCode: 'AGENCY_LNG',
+      agencyName: 'LNG Secretariat'
+    },
+    {
+      agencyCode: 'AGENCY_AGRI',
+      agencyName: 'Ministry of Agriculture and Food'
+    },
+    {
+      agencyCode: 'AGENCY_FLNRO',
+      agencyName: 'Ministry of Forests'
+    },
+    {
+      agencyCode: 'AGENCY_FLNR_NRO',
+      agencyName: 'Natural Resource Officers'
+    },
+    {
+      agencyCode: 'AGENCY_WLRS',
+      agencyName: 'Ministry of Water, Land and Resource Stewardship'
+    },
+    {
+      agencyCode: 'AGENCY_CAS',
+      agencyName: 'Climate Action Secretariat'
+    }
+  ];
+
+  for(const agency of AGENCY_NAME_CODE_MAP){
+    if(agency.agencyCode === agencyName){
+      return agency.agencyName;
+    }
+  }
+
+  throw new Error("Error in getAgencyCodeFromName : No code found for ", agencyName);
+};

--- a/api/src/controllers/agencies.js
+++ b/api/src/controllers/agencies.js
@@ -162,11 +162,7 @@ exports.getAgencyCodeFromNameBandaid = function(agencyName){
     }
   ];
 
-  for(const agency of AGENCY_NAME_CODE_MAP){
-    if(agency.agencyName === agencyName){
-      return agency.agencyCode;
-    }
-  }
+  const agency = AGENCY_NAME_CODE_MAP.find(agency => agency.agencyName === agencyName);
 
-  return null; // if no matching code is found, return null
+  return agency ? agency.agencyCode : null; // if no matching code is found, return null
 };

--- a/api/src/controllers/agencies.js
+++ b/api/src/controllers/agencies.js
@@ -100,7 +100,7 @@ exports.protectedPut = async function(args, res, next) {
  * This function was implemented as a temporary fix because the async version proved difficult to implement.
  * This should be replaced
  * @param {*} agencyName 
- * @returns {string} agencyCode
+ * @returns {string} agencyCode if matching code is found, else null
  */
 exports.getAgencyCodeFromNameBandaid = function(agencyName){
   const AGENCY_NAME_CODE_MAP = [
@@ -168,5 +168,5 @@ exports.getAgencyCodeFromNameBandaid = function(agencyName){
     }
   }
 
-  return agencyName; // if no matching code is found, just return the passed-in name
+  return null; // if no matching code is found, return null
 };

--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -126,7 +126,7 @@ function isIssuedToConsideredAnonymous(issuedTo, issuingAgency) {
 
   // check if the issuingAgency has legislative authority to publish names
   if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency) 
-                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyCodeFromName(issuingAgency))) {
+                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyCodeFromNameBandaid(issuingAgency))) {
     // name is anonymous, issuing agency cannot publish names
     return true;
   }

--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -124,9 +124,11 @@ function isIssuedToConsideredAnonymous(issuedTo, issuingAgency) {
     return false;
   }
 
+  const agencyCode = agenciesController.getAgencyCodeFromNameBandaid(issuingAgency);
+  
   // check if the issuingAgency has legislative authority to publish names
-  if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency) 
-                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyCodeFromNameBandaid(issuingAgency))) {
+  if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency)
+                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agencyCode)) {
     // name is anonymous, issuing agency cannot publish names
     return true;
   }

--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -126,7 +126,7 @@ function isIssuedToConsideredAnonymous(issuedTo, issuingAgency) {
 
   // check if the issuingAgency has legislative authority to publish names
   if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency) 
-                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyNameFromCode(issuingAgency))) {
+                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyCodeFromName(issuingAgency))) {
     // name is anonymous, issuing agency cannot publish names
     return true;
   }

--- a/api/src/utils/business-logic-manager.js
+++ b/api/src/utils/business-logic-manager.js
@@ -2,6 +2,7 @@ const QueryActions = require('./query-actions');
 const DocumentController = require('../controllers/document-controller');
 const moment = require('moment');
 const constants = require('./constants/misc');
+const agenciesController = require('../controllers/agencies');
 
 /**
  * Apply business logic changes to a record. Updates the provided updateObj, and returns it.
@@ -124,7 +125,8 @@ function isIssuedToConsideredAnonymous(issuedTo, issuingAgency) {
   }
 
   // check if the issuingAgency has legislative authority to publish names
-  if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency)) {
+  if (issuingAgency && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(issuingAgency) 
+                    && !constants.AUTHORIZED_PUBLISH_AGENCIES.includes(agenciesController.getAgencyNameFromCode(issuingAgency))) {
     // name is anonymous, issuing agency cannot publish names
     return true;
   }


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[NRPTI-###]`
- [x] Documentation is updated to reflect change

# Description
When deciding if a record needs redaction, one of the checks is of the issuing agency and making sure that it has authority to publish records. BUT due to the change to using an intermediate code for representing agencies, this check was often comparing the actual agency name to the agency code and authorized agencies were not getting through. The first version of the fix included an async function that required many other upstream functions to be converted to async. Ultimately, this task was not able to be successfully completed in a timely manner. A bandaid function was created using hardcoded values. These will eventually be out of date and the bug behaviour will start appearing again. #1258 was created to address this tech debt.

This PR includes the following proposed change(s):

- updated the check to see if the issuing agency has authority to publish by translating the agencyName to the associated agencyCode
